### PR TITLE
fix: update code for rand 0.9 and hickory-resolver 0.25 API changes

### DIFF
--- a/crates/proxy/src/logging.rs
+++ b/crates/proxy/src/logging.rs
@@ -633,8 +633,8 @@ impl LogManager {
                     // Sample based on sample_rate (0.0-1.0)
                     // Generate random number and check if it's less than sample_rate
                     use rand::Rng;
-                    let mut rng = rand::thread_rng();
-                    rng.gen::<f64>() < config.sample_rate
+                    let mut rng = rand::rng();
+                    rng.random::<f64>() < config.sample_rate
                 };
 
                 if !should_log {

--- a/crates/proxy/src/shadow.rs
+++ b/crates/proxy/src/shadow.rs
@@ -94,8 +94,8 @@ impl ShadowManager {
 
         // Sample based on percentage
         if self.config.percentage < 100.0 {
-            let mut rng = rand::thread_rng();
-            let roll: f64 = rng.gen_range(0.0..100.0);
+            let mut rng = rand::rng();
+            let roll: f64 = rng.random_range(0.0..100.0);
             if roll > self.config.percentage {
                 trace!(
                     roll = roll,

--- a/crates/proxy/src/upstream/adaptive.rs
+++ b/crates/proxy/src/upstream/adaptive.rs
@@ -447,9 +447,9 @@ impl AdaptiveBalancer {
         }
 
         // Weighted random selection
-        use rand::prelude::*;
-        let mut rng = thread_rng();
-        let threshold = rng.gen::<f64>() * total_score;
+        use rand::Rng;
+        let mut rng = rand::rng();
+        let threshold = rng.random::<f64>() * total_score;
 
         trace!(
             total_score = total_score,

--- a/crates/proxy/src/upstream/consistent_hash.rs
+++ b/crates/proxy/src/upstream/consistent_hash.rs
@@ -497,8 +497,8 @@ impl LoadBalancer for ConsistentHashBalancer {
             .unwrap_or_else(|| {
                 // Generate random key for requests without proper hash key
                 use rand::Rng;
-                let mut rng = rand::thread_rng();
-                let key = format!("random-{}", rng.gen::<u64>());
+                let mut rng = rand::rng();
+                let key = format!("random-{}", rng.random::<u64>());
                 trace!(random_key = %key, "Generated random hash key (no context key)");
                 (key, true)
             });

--- a/crates/proxy/src/upstream/locality.rs
+++ b/crates/proxy/src/upstream/locality.rs
@@ -5,6 +5,7 @@
 //! multi-region deployments to minimize latency and cross-zone traffic costs.
 
 use async_trait::async_trait;
+use rand::seq::IndexedRandom;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -240,7 +241,7 @@ impl LocalityAwareBalancer {
             return None;
         }
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         targets.choose(&mut rng).copied()
     }
 }

--- a/crates/proxy/src/upstream/mod.rs
+++ b/crates/proxy/src/upstream/mod.rs
@@ -5,6 +5,7 @@
 
 use async_trait::async_trait;
 use pingora::upstreams::peer::HttpPeer;
+use rand::seq::IndexedRandom;
 use std::collections::HashMap;
 use std::net::ToSocketAddrs;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
@@ -448,7 +449,7 @@ impl LoadBalancer for RandomBalancer {
             return Err(SentinelError::NoHealthyUpstream);
         }
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let target = healthy_targets
             .choose(&mut rng)
             .ok_or(SentinelError::NoHealthyUpstream)?;

--- a/crates/proxy/src/upstream/p2c.rs
+++ b/crates/proxy/src/upstream/p2c.rs
@@ -202,7 +202,7 @@ impl P2cBalancer {
             targets,
             health_status: Arc::new(RwLock::new(HashMap::new())),
             metrics,
-            rng: Arc::new(RwLock::new(StdRng::from_entropy())),
+            rng: Arc::new(RwLock::new(StdRng::from_rng(&mut rand::rng()))),
             cumulative_weights,
         }
     }
@@ -242,7 +242,7 @@ impl P2cBalancer {
             // Weighted random selection
             let total_weight = self.cumulative_weights.last().copied().unwrap_or(0);
             if total_weight > 0 {
-                let threshold = rng.gen_range(0..total_weight);
+                let threshold = rng.random_range(0..total_weight);
                 for &idx in &healthy_indices {
                     if self.cumulative_weights[idx] > threshold {
                         trace!(
@@ -257,7 +257,7 @@ impl P2cBalancer {
         }
 
         // Fallback to uniform random
-        let selected = healthy_indices[rng.gen_range(0..healthy_indices.len())];
+        let selected = healthy_indices[rng.random_range(0..healthy_indices.len())];
         trace!(
             target_index = selected,
             "Selected target via uniform random"

--- a/crates/proxy/src/upstream/sticky_session.rs
+++ b/crates/proxy/src/upstream/sticky_session.rs
@@ -43,7 +43,7 @@ impl StickySessionRuntimeConfig {
 
         // Generate random HMAC key
         let mut hmac_key = [0u8; 32];
-        rand::thread_rng().fill_bytes(&mut hmac_key);
+        rand::rng().fill_bytes(&mut hmac_key);
 
         Self {
             cookie_name: config.cookie_name.clone(),

--- a/crates/proxy/src/upstream/subset.rs
+++ b/crates/proxy/src/upstream/subset.rs
@@ -14,6 +14,7 @@
 //! Reference: https://sre.google/sre-book/load-balancing-datacenter/
 
 use async_trait::async_trait;
+use rand::seq::IndexedRandom;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -222,7 +223,7 @@ impl SubsetBalancer {
             }
             SubsetInnerAlgorithm::Random => {
                 use rand::seq::SliceRandom;
-                let mut rng = rand::thread_rng();
+                let mut rng = rand::rng();
                 healthy.choose(&mut rng).copied()
             }
             SubsetInnerAlgorithm::LeastConnections => {


### PR DESCRIPTION
## Summary
Fixes compilation errors after dependabot dependency updates:

**rand 0.9 changes:**
- `thread_rng()` → `rng()`
- `gen()` → `random()`
- `gen_range()` → `random_range()`
- Add `IndexedRandom` import for slice `.choose()` method
- `StdRng::from_entropy()` → `StdRng::from_rng(&mut rand::rng())`

**hickory-resolver 0.25 changes:**
- Use builder pattern for `TokioResolver` construction
- Update error handling (removed `NoRecordsFound` variant from public API)

## Test plan
- [x] `cargo check` passes