### PR TITLE
chore: bump version to 0.4.12 for release 26.02_5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.11"
+version = "0.4.12"
 edition = "2021"
 authors = ["Sentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Automated version bump after release 26.02_5. Direct push to main was blocked by branch protection.