### PR TITLE
fix(ci): add pull-requests: write to publish-crates job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,6 +189,7 @@ jobs:
     environment: release  # Optional: use GitHub environment for additional protection
     permissions:
       contents: write
+      pull-requests: write
     outputs:
       commit-sha: ${{ steps.commit.outputs.sha }}
     steps:


### PR DESCRIPTION
## Summary
- Adds `pull-requests: write` permission to the `publish-crates` job in the release workflow
- The version bump push to `main` is blocked by branch protection, and the fallback step that creates a PR was failing with `Resource not accessible by integration (createPullRequest)` because the `GITHUB_TOKEN` lacked this permission

## Context
Failed run: https://github.com/raskell-io/sentinel/actions/runs/22042322077

## Test plan
- [ ] Merge this PR, then re-run the failed release workflow (or push a new tag) and confirm the version bump PR gets created successfully