### PR TITLE
fix(ci): add pingora version for crates.io publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,15 +28,15 @@ rust-version = "1.85"
 
 [workspace.dependencies]
 # Core dependencies (using our fork with security fixes)
-pingora = { git = "https://github.com/raskell-io/pingora.git", rev = "5847d5e", features = ["proxy", "lb", "rustls"] }
-pingora-core = { git = "https://github.com/raskell-io/pingora.git", rev = "5847d5e", features = ["rustls"] }
-pingora-http = { git = "https://github.com/raskell-io/pingora.git", rev = "5847d5e" }
-pingora-proxy = { git = "https://github.com/raskell-io/pingora.git", rev = "5847d5e" }
-pingora-load-balancing = { git = "https://github.com/raskell-io/pingora.git", rev = "5847d5e" }
-pingora-timeout = { git = "https://github.com/raskell-io/pingora.git", rev = "5847d5e" }
-pingora-limits = { git = "https://github.com/raskell-io/pingora.git", rev = "5847d5e" }
-pingora-cache = { git = "https://github.com/raskell-io/pingora.git", rev = "5847d5e" }
-pingora-memory-cache = { git = "https://github.com/raskell-io/pingora.git", rev = "5847d5e" }
+pingora = { version = "0.7.0", git = "https://github.com/raskell-io/pingora.git", rev = "5847d5e", features = ["proxy", "lb", "rustls"] }
+pingora-core = { version = "0.7.0", git = "https://github.com/raskell-io/pingora.git", rev = "5847d5e", features = ["rustls"] }
+pingora-http = { version = "0.7.0", git = "https://github.com/raskell-io/pingora.git", rev = "5847d5e" }
+pingora-proxy = { version = "0.7.0", git = "https://github.com/raskell-io/pingora.git", rev = "5847d5e" }
+pingora-load-balancing = { version = "0.7.0", git = "https://github.com/raskell-io/pingora.git", rev = "5847d5e" }
+pingora-timeout = { version = "0.7.0", git = "https://github.com/raskell-io/pingora.git", rev = "5847d5e" }
+pingora-limits = { version = "0.7.0", git = "https://github.com/raskell-io/pingora.git", rev = "5847d5e" }
+pingora-cache = { version = "0.7.0", git = "https://github.com/raskell-io/pingora.git", rev = "5847d5e" }
+pingora-memory-cache = { version = "0.7.0", git = "https://github.com/raskell-io/pingora.git", rev = "5847d5e" }
 
 # Async runtime
 # Minimal feature set for proxy workloads (trimmed from "full" for smaller binary)

--- a/crates/proxy/src/acme/challenge_server.rs
+++ b/crates/proxy/src/acme/challenge_server.rs
@@ -131,9 +131,10 @@ async fn handle_connection(
         _ => http_404(),
     };
 
-    stream.write_all(response.as_bytes()).await.map_err(|e| {
-        AcmeError::Protocol(format!("Failed to write challenge response: {}", e))
-    })?;
+    stream
+        .write_all(response.as_bytes())
+        .await
+        .map_err(|e| AcmeError::Protocol(format!("Failed to write challenge response: {}", e)))?;
 
     Ok(())
 }
@@ -162,16 +163,18 @@ mod tests {
 
         let addr_str = addr.to_string();
         let cm_clone = Arc::clone(&cm);
-        let server_handle = tokio::spawn(async move {
-            run_challenge_server(&addr_str, cm_clone, shutdown_rx).await
-        });
+        let server_handle =
+            tokio::spawn(
+                async move { run_challenge_server(&addr_str, cm_clone, shutdown_rx).await },
+            );
 
         // Give server time to start
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         // Send a challenge request
         let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let request = "GET /.well-known/acme-challenge/test-token-123 HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        let request =
+            "GET /.well-known/acme-challenge/test-token-123 HTTP/1.1\r\nHost: localhost\r\n\r\n";
         stream.write_all(request.as_bytes()).await.unwrap();
 
         let mut response = vec![0u8; 4096];
@@ -198,14 +201,16 @@ mod tests {
 
         let addr_str = addr.to_string();
         let cm_clone = Arc::clone(&cm);
-        let server_handle = tokio::spawn(async move {
-            run_challenge_server(&addr_str, cm_clone, shutdown_rx).await
-        });
+        let server_handle =
+            tokio::spawn(
+                async move { run_challenge_server(&addr_str, cm_clone, shutdown_rx).await },
+            );
 
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let request = "GET /.well-known/acme-challenge/unknown-token HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        let request =
+            "GET /.well-known/acme-challenge/unknown-token HTTP/1.1\r\nHost: localhost\r\n\r\n";
         stream.write_all(request.as_bytes()).await.unwrap();
 
         let mut response = vec![0u8; 4096];
@@ -230,9 +235,10 @@ mod tests {
 
         let addr_str = addr.to_string();
         let cm_clone = Arc::clone(&cm);
-        let server_handle = tokio::spawn(async move {
-            run_challenge_server(&addr_str, cm_clone, shutdown_rx).await
-        });
+        let server_handle =
+            tokio::spawn(
+                async move { run_challenge_server(&addr_str, cm_clone, shutdown_rx).await },
+            );
 
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 

--- a/crates/proxy/tests/acme_startup_test.rs
+++ b/crates/proxy/tests/acme_startup_test.rs
@@ -176,10 +176,7 @@ mod challenge_server {
 
         // Register multiple tokens
         for i in 0..10 {
-            cm.add_challenge(
-                &format!("token-{}", i),
-                &format!("auth-value-{}", i),
-            );
+            cm.add_challenge(&format!("token-{}", i), &format!("auth-value-{}", i));
         }
 
         let (addr, shutdown_tx, server_handle) = start_server(Arc::clone(&cm)).await;
@@ -236,10 +233,7 @@ mod challenge_server {
 
         // Server should exit cleanly within a reasonable time
         let result = tokio::time::timeout(Duration::from_secs(2), server_handle).await;
-        assert!(
-            result.is_ok(),
-            "Server should shut down within 2 seconds"
-        );
+        assert!(result.is_ok(), "Server should shut down within 2 seconds");
 
         // The JoinHandle result should be Ok (no panic)
         let inner = result.unwrap();
@@ -282,7 +276,8 @@ mod challenge_server {
         // Unknown token
         {
             let mut stream = tokio::net::TcpStream::connect(&addr).await.unwrap();
-            let request = "GET /.well-known/acme-challenge/unknown HTTP/1.1\r\nHost: localhost\r\n\r\n";
+            let request =
+                "GET /.well-known/acme-challenge/unknown HTTP/1.1\r\nHost: localhost\r\n\r\n";
             stream.write_all(request.as_bytes()).await.unwrap();
 
             let mut response = vec![0u8; 4096];

--- a/crates/proxy/tests/tls_sni_test.rs
+++ b/crates/proxy/tests/tls_sni_test.rs
@@ -506,10 +506,7 @@ mod acme_resolver {
 
         let config = acme_tls_config(temp_dir.path().to_path_buf());
         let result = SniResolver::from_config(&config);
-        assert!(
-            result.is_err(),
-            "Missing ACME cert files should fail"
-        );
+        assert!(result.is_err(), "Missing ACME cert files should fail");
         match result.unwrap_err() {
             TlsError::CertificateLoad(_) => {}
             e => panic!("Expected CertificateLoad error, got {:?}", e),


### PR DESCRIPTION
## Summary
- Adds `version = "0.7.0"` to all pingora workspace dependencies so `cargo publish` can resolve them from crates.io (git-only deps without a version are rejected)
- Runs `cargo fmt` to fix formatting issues in recent test files

## Context
Release `26.02_5` fails at the `Publish crates` step because `sentinel-proxy` depends on pingora via a git source without a version:
```
dependency `pingora` does not specify a version
```
Failed run: https://github.com/raskell-io/sentinel/actions/runs/22042847503

## Test plan
- [ ] CI passes (formatting + clippy + tests)
- [ ] Merge, delete and re-tag `26.02_5`, verify `cargo publish` succeeds