### PR TITLE
fix(ci): make release publish idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,7 +239,7 @@ jobs:
         run: |
           BRANCH="chore/bump-${{ needs.validate.outputs.new-semver }}"
           git checkout -b "$BRANCH"
-          git push origin "$BRANCH"
+          git push --force origin "$BRANCH"
           gh pr create \
             --title "chore: bump version to ${{ needs.validate.outputs.new-semver }} for release ${{ needs.validate.outputs.calver }}" \
             --body "Automated version bump after release ${{ needs.validate.outputs.calver }}. Direct push to main was blocked by branch protection." \
@@ -260,8 +260,16 @@ jobs:
             "sentinel-proxy"
           )
 
+          NEW_SEMVER="${{ needs.validate.outputs.new-semver }}"
+
           for crate in "${CRATES[@]}"; do
             echo "Publishing $crate..."
+
+            # Check if this version is already published (from a partial prior run)
+            if cargo search "$crate" --limit 1 2>/dev/null | grep -q "\"$NEW_SEMVER\""; then
+              echo "$crate@$NEW_SEMVER already published, skipping"
+              continue
+            fi
 
             # Retry up to 3 times (crates.io index propagation)
             for i in 1 2 3; do

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.11"
+version = "0.4.12"
 edition = "2021"
 authors = ["Sentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- **Bump workspace version to 0.4.12** — three crates (`sentinel-common`, `sentinel-config`, `sentinel-agent-protocol`) were already published at 0.4.12 from a partial prior run, so the workspace version needs to match
- **Skip already-published crates** — uses `cargo search` to detect if a version already exists on crates.io before attempting `cargo publish`, making partial re-runs safe
- **Force-push version bump branch** — prevents `non-fast-forward` rejections when the `chore/bump-*` branch lingers from a previous failed attempt

## Context
Release `26.02_5` has been failing in a loop:
1. First run: `pull-requests: write` missing (fixed in #73)
2. Second run: `pingora` git dep missing version (fixed in #75)
3. Third run: `sentinel-common@0.4.12 already exists on crates.io` — 3 of 4 crates got published before the prior failure

## Test plan
- [ ] CI passes
- [ ] After merge, re-tag `26.02_5` and verify the full release pipeline completes