### PR TITLE
chore: bump version to 0.5.1 for release 26.02_7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/agent-protocol/Cargo.toml
+++ b/crates/agent-protocol/Cargo.toml
@@ -20,7 +20,7 @@ mmap-buffers = ["memmap2", "dep:tempfile"]
 
 [dependencies]
 # Local crates
-zentinel-common = { path = "../common", version = "0.5.0" }
+zentinel-common = { path = "../common", version = "0.5.1" }
 
 # Protocol and serialization
 prost = { workspace = true }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["config", "network-programming"]
 
 [dependencies]
 # Local crates
-zentinel-common = { path = "../common", version = "0.5.0", default-features = false }
+zentinel-common = { path = "../common", version = "0.5.1", default-features = false }
 
 # Configuration formats
 kdl = { workspace = true }

--- a/crates/playground-wasm/Cargo.toml
+++ b/crates/playground-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-playground-wasm"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 # Local crates
-zentinel-sim = { path = "../sim", version = "0.5.0" }
+zentinel-sim = { path = "../sim", version = "0.5.1" }
 
 # WASM bindings
 wasm-bindgen = "0.2"

--- a/crates/proxy/Cargo.toml
+++ b/crates/proxy/Cargo.toml
@@ -33,9 +33,9 @@ pingora-cache = { workspace = true }
 pingora-memory-cache = { workspace = true }
 
 # Local crates
-zentinel-config = { path = "../config", version = "0.5.0", features = ["validation"] }
-zentinel-common = { path = "../common", version = "0.5.0" }
-zentinel-agent-protocol = { path = "../agent-protocol", version = "0.5.0" }
+zentinel-config = { path = "../config", version = "0.5.1", features = ["validation"] }
+zentinel-common = { path = "../common", version = "0.5.1" }
+zentinel-agent-protocol = { path = "../agent-protocol", version = "0.5.1" }
 
 # Async runtime
 tokio = { workspace = true }

--- a/crates/sim/Cargo.toml
+++ b/crates/sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-sim"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"
@@ -13,8 +13,8 @@ categories = ["simulation", "wasm", "network-programming"]
 
 [dependencies]
 # Local crates (WASM-compatible - disable runtime features)
-zentinel-config = { path = "../config", version = "0.5.0", default-features = false }
-zentinel-common = { path = "../common", version = "0.5.0", default-features = false }
+zentinel-config = { path = "../config", version = "0.5.1", default-features = false }
+zentinel-common = { path = "../common", version = "0.5.1", default-features = false }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/wasm-runtime/Cargo.toml
+++ b/crates/wasm-runtime/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["wasm", "network-programming"]
 
 [dependencies]
 # Local crates
-zentinel-agent-protocol = { path = "../agent-protocol", version = "0.5.0" }
+zentinel-agent-protocol = { path = "../agent-protocol", version = "0.5.1" }
 
 # Wasmtime runtime with component model
 wasmtime = { version = "41", features = ["component-model", "async", "cranelift"] }


### PR DESCRIPTION
Automated version bump after release 26.02_7. Direct push to main was blocked by branch protection, and the GHA fallback couldn't create this PR due to missing permissions.

Changes: increments workspace and crate versions from 0.5.0 → 0.5.1.