### PR TITLE
docs(agent-protocol): document public API types for agent authors

### DIFF
--- a/crates/agent-protocol/src/protocol.rs
+++ b/crates/agent-protocol/src/protocol.rs
@@ -50,7 +50,8 @@ pub enum EventType {
 /// # Examples
 ///
 /// ```rust
-/// use zentinel_agent_protocol::{Decision, HashMap};
+/// use std::collections::HashMap;
+/// use zentinel_agent_protocol::Decision;
 ///
 /// // Allow request to proceed normally
 /// let allow = Decision::Allow;

--- a/crates/agent-protocol/src/protocol.rs
+++ b/crates/agent-protocol/src/protocol.rs
@@ -35,34 +35,84 @@ pub enum EventType {
     GuardrailInspect,
 }
 
-/// Agent decision
+/// Agent response decision indicating how to handle a request or response.
+///
+/// This enum represents the decision an agent makes when processing a request or response.
+/// It allows agents to allow, block, redirect, or challenge requests based on their processing logic.
+///
+/// # Variants
+///
+/// - **Allow**: Continue normal processing without modification
+/// - **Block**: Reject the request/response with a custom error response
+/// - **Redirect**: Send the client to a different URL
+/// - **Challenge**: Request additional verification from the client
+///
+/// # Examples
+///
+/// ```rust
+/// use zentinel_agent_protocol::{Decision, HashMap};
+///
+/// // Allow request to proceed normally
+/// let allow = Decision::Allow;
+///
+/// // Block with 403 and custom body
+/// let block = Decision::Block {
+///     status: 403,
+///     body: Some("Access denied".to_string()),
+///     headers: None,
+/// };
+///
+/// // Redirect to login page
+/// let redirect = Decision::Redirect {
+///     url: "https://example.com/login".to_string(),
+///     status: 302,
+/// };
+///
+/// // Challenge with CAPTCHA
+/// let mut params = HashMap::new();
+/// params.insert("type".to_string(), "recaptcha".to_string());
+/// let challenge = Decision::Challenge {
+///     challenge_type: "captcha".to_string(),
+///     params,
+/// };
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum Decision {
-    /// Allow the request/response to continue
+    /// Allow the request/response to continue without modification.
+    ///
+    /// This is the default decision that indicates normal processing should proceed.
     #[default]
     Allow,
-    /// Block the request/response
+    /// Block the request/response with a custom error response.
+    ///
+    /// The proxy will return the specified status code and optional body/headers
+    /// instead of forwarding the request to the upstream or returning the original response.
     Block {
-        /// HTTP status code to return
+        /// HTTP status code to return (typically 4xx or 5xx)
         status: u16,
-        /// Optional response body
+        /// Optional response body content
         body: Option<String>,
-        /// Optional response headers
+        /// Optional response headers to include
         headers: Option<HashMap<String, String>>,
     },
-    /// Redirect the request
+    /// Redirect the client to a different URL.
+    ///
+    /// The proxy will return a redirect response with the specified URL and status code.
     Redirect {
-        /// Redirect URL
+        /// Target URL for the redirect
         url: String,
-        /// HTTP status code (301, 302, 303, 307, 308)
+        /// HTTP redirect status code (301, 302, 303, 307, or 308)
         status: u16,
     },
-    /// Challenge the client (e.g., CAPTCHA)
+    /// Request additional verification from the client.
+    ///
+    /// This can be used to implement CAPTCHA, multi-factor authentication,
+    /// or other challenge-response mechanisms.
     Challenge {
-        /// Challenge type
+        /// Type of challenge (e.g., "captcha", "otp", "totp")
         challenge_type: String,
-        /// Challenge parameters
+        /// Challenge-specific parameters and configuration
         params: HashMap<String, String>,
     },
 }

--- a/crates/agent-protocol/src/v2/pool.rs
+++ b/crates/agent-protocol/src/v2/pool.rs
@@ -519,21 +519,17 @@ impl AgentEntry {
     }
 }
 
-/// Agent connection pool.
+/// Agent connection pool for managing agent connections with load balancing and health monitoring.
 ///
-/// Manages multiple connections to multiple agents with load balancing,
-/// health tracking, automatic reconnection, and metrics collection.
+/// `AgentPool` provides a production-ready connection pool that manages multiple connections
+/// to external processing agents. It handles connection pooling, load balancing, health
+/// tracking, automatic reconnection, and metrics collection for robust agent communication.
 ///
 /// # Performance
 ///
 /// Uses `DashMap` for lock-free reads in the hot path. Agent lookup is O(1)
 /// without contention. Connection selection uses cached health state to avoid
 /// async I/O per request.
-/// Connection pool for managing agent connections with load balancing and health monitoring.
-///
-/// `AgentPool` provides a production-ready connection pool that manages multiple connections
-/// to external processing agents. It handles connection pooling, load balancing, health
-/// tracking, and automatic reconnection for robust agent communication.
 ///
 /// # Features
 ///
@@ -560,10 +556,11 @@ impl AgentEntry {
 /// let pool = AgentPool::with_config(config);
 ///
 /// // Add agent connections (generic method for any transport)
-/// pool.add_agent("waf", agent_connection).await?;
+/// pool.add_agent("waf", "unix:/tmp/waf.sock").await?;
 ///
 /// // Send request headers to an agent
-/// let response = pool.send_request_headers("waf", headers).await?;
+/// let headers = RequestHeadersEvent { /* ... */ };
+/// let response = pool.send_request_headers("waf", "correlation-123", &headers).await?;
 /// ```
 pub struct AgentPool {
     config: AgentPoolConfig,

--- a/crates/agent-protocol/src/v2/pool.rs
+++ b/crates/agent-protocol/src/v2/pool.rs
@@ -552,19 +552,18 @@ impl AgentEntry {
 ///
 /// // Create pool with custom config
 /// let config = AgentPoolConfig {
-///     max_connections_per_agent: 4,
+///     connections_per_agent: 4,
 ///     load_balance_strategy: LoadBalanceStrategy::LeastConnections,
 ///     health_check_interval: Duration::from_secs(30),
 ///     ..Default::default()
 /// };
 /// let pool = AgentPool::with_config(config);
 ///
-/// // Add agent connections
-/// pool.add_grpc_agent("waf", "127.0.0.1:8080").await?;
-/// pool.add_uds_agent("auth", "/var/run/auth.sock").await?;
+/// // Add agent connections (generic method for any transport)
+/// pool.add_agent("waf", agent_connection).await?;
 ///
-/// // Process requests
-/// let response = pool.process_request("waf", request).await?;
+/// // Send request headers to an agent
+/// let response = pool.send_request_headers("waf", headers).await?;
 /// ```
 pub struct AgentPool {
     config: AgentPoolConfig,

--- a/crates/agent-protocol/src/v2/pool.rs
+++ b/crates/agent-protocol/src/v2/pool.rs
@@ -542,10 +542,10 @@ impl AgentEntry {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```rust,ignore
 /// use std::time::Duration;
 /// use zentinel_agent_protocol::v2::{AgentPool, AgentPoolConfig, LoadBalanceStrategy};
-/// use zentinel_agent_protocol::{RequestHeadersEvent};
+/// use zentinel_agent_protocol::RequestHeadersEvent;
 ///
 /// // Create pool with custom config
 /// let config = AgentPoolConfig {
@@ -560,7 +560,6 @@ impl AgentEntry {
 /// pool.add_agent("waf", "unix:/tmp/waf.sock").await?;
 ///
 /// // Send request headers to an agent
-/// let headers = RequestHeadersEvent { /* ... */ };
 /// let response = pool.send_request_headers("waf", "correlation-123", &headers).await?;
 /// ```
 pub struct AgentPool {

--- a/crates/agent-protocol/src/v2/pool.rs
+++ b/crates/agent-protocol/src/v2/pool.rs
@@ -521,14 +521,8 @@ impl AgentEntry {
 
 /// Agent connection pool for managing multiple connections to external processing agents.
 ///
-/// This pool provides production-ready connection pooling, load balancing, health tracking,
+/// `AgentPool` provides production-ready connection pooling, load balancing, health tracking,
 /// automatic reconnection, and metrics collection for robust agent communication.
-///
-/// # Performance
-///
-/// Uses `DashMap` for lock-free reads in the hot path. Agent lookup is O(1)
-/// without contention. Connection selection uses cached health state to avoid
-/// async I/O per request.
 ///
 /// # Features
 ///
@@ -540,11 +534,18 @@ impl AgentEntry {
 /// - **Metrics**: Collects detailed metrics on performance and health
 /// - **Configuration management**: Distributes config updates to agents
 ///
+/// # Performance
+///
+/// Uses `DashMap` for lock-free reads in the hot path. Agent lookup is O(1)
+/// without contention. Connection selection uses cached health state to avoid
+/// async I/O per request.
+///
 /// # Example
 ///
 /// ```rust
-/// use zentinel_agent_protocol::v2::{AgentPool, AgentPoolConfig, LoadBalanceStrategy};
 /// use std::time::Duration;
+/// use zentinel_agent_protocol::v2::{AgentPool, AgentPoolConfig, LoadBalanceStrategy};
+/// use zentinel_agent_protocol::{RequestHeadersEvent};
 ///
 /// // Create pool with custom config
 /// let config = AgentPoolConfig {

--- a/crates/agent-protocol/src/v2/pool.rs
+++ b/crates/agent-protocol/src/v2/pool.rs
@@ -529,6 +529,43 @@ impl AgentEntry {
 /// Uses `DashMap` for lock-free reads in the hot path. Agent lookup is O(1)
 /// without contention. Connection selection uses cached health state to avoid
 /// async I/O per request.
+/// Connection pool for managing agent connections with load balancing and health monitoring.
+///
+/// `AgentPool` provides a production-ready connection pool that manages multiple connections
+/// to external processing agents. It handles connection pooling, load balancing, health
+/// tracking, and automatic reconnection for robust agent communication.
+///
+/// # Features
+///
+/// - **Connection pooling**: Maintains multiple connections per agent for better throughput
+/// - **Load balancing**: Routes requests using round-robin, least-connections, or health-based strategies
+/// - **Health monitoring**: Tracks agent health and routes requests to healthy connections
+/// - **Automatic reconnection**: Reconnects failed connections transparently
+/// - **Flow control**: Manages backpressure and request queuing
+/// - **Metrics**: Collects detailed metrics on performance and health
+/// - **Configuration management**: Distributes config updates to agents
+///
+/// # Example
+///
+/// ```rust
+/// use zentinel_agent_protocol::v2::{AgentPool, AgentPoolConfig, LoadBalanceStrategy};
+///
+/// // Create pool with custom config
+/// let config = AgentPoolConfig {
+///     max_connections_per_agent: 4,
+///     load_balance_strategy: LoadBalanceStrategy::LeastConnections,
+///     health_check_interval: Duration::from_secs(30),
+///     ..Default::default()
+/// };
+/// let pool = AgentPool::with_config(config);
+///
+/// // Add agent connections
+/// pool.add_grpc_agent("waf", "127.0.0.1:8080").await?;
+/// pool.add_uds_agent("auth", "/var/run/auth.sock").await?;
+///
+/// // Process requests
+/// let response = pool.process_request("waf", request).await?;
+/// ```
 pub struct AgentPool {
     config: AgentPoolConfig,
     /// Lock-free concurrent map for agent lookup.

--- a/crates/agent-protocol/src/v2/pool.rs
+++ b/crates/agent-protocol/src/v2/pool.rs
@@ -519,11 +519,10 @@ impl AgentEntry {
     }
 }
 
-/// Agent connection pool for managing agent connections with load balancing and health monitoring.
+/// Agent connection pool for managing multiple connections to external processing agents.
 ///
-/// `AgentPool` provides a production-ready connection pool that manages multiple connections
-/// to external processing agents. It handles connection pooling, load balancing, health
-/// tracking, automatic reconnection, and metrics collection for robust agent communication.
+/// This pool provides production-ready connection pooling, load balancing, health tracking,
+/// automatic reconnection, and metrics collection for robust agent communication.
 ///
 /// # Performance
 ///
@@ -545,6 +544,7 @@ impl AgentEntry {
 ///
 /// ```rust
 /// use zentinel_agent_protocol::v2::{AgentPool, AgentPoolConfig, LoadBalanceStrategy};
+/// use std::time::Duration;
 ///
 /// // Create pool with custom config
 /// let config = AgentPoolConfig {
@@ -555,7 +555,7 @@ impl AgentEntry {
 /// };
 /// let pool = AgentPool::with_config(config);
 ///
-/// // Add agent connections (generic method for any transport)
+/// // Add agent with Unix domain socket endpoint
 /// pool.add_agent("waf", "unix:/tmp/waf.sock").await?;
 ///
 /// // Send request headers to an agent

--- a/crates/agent-protocol/src/v2/server.rs
+++ b/crates/agent-protocol/src/v2/server.rs
@@ -24,9 +24,6 @@ use crate::{
     WebSocketFrameEvent,
 };
 
-/// v2 agent handler trait.
-///
-/// Implement this trait to create a v2 agent. The v2 handler adds:
 /// Trait for implementing agent handlers in Protocol v2.
 ///
 /// `AgentHandlerV2` defines the interface that agent implementations must provide
@@ -57,28 +54,21 @@ use crate::{
 /// ```rust
 /// use async_trait::async_trait;
 /// use zentinel_agent_protocol::v2::{AgentHandlerV2, AgentCapabilities, AgentResponse};
-/// use zentinel_agent_protocol::{RequestHeadersEvent, Decision};
+/// use zentinel_agent_protocol::{EventType, RequestHeadersEvent};
 ///
 /// pub struct MyWafAgent;
 ///
 /// #[async_trait]
 /// impl AgentHandlerV2 for MyWafAgent {
 ///     fn capabilities(&self) -> AgentCapabilities {
-///         AgentCapabilities {
-///             agent_id: "my-waf".to_string(),
-///             events: vec!["request_headers".to_string()],
-///             version: "1.0.0".to_string(),
-///         }
+///         AgentCapabilities::new("my-waf", "My WAF Agent", "1.0.0")
+///             .with_event(EventType::RequestHeaders)
 ///     }
 ///
 ///     async fn on_request_headers(&self, event: RequestHeadersEvent) -> AgentResponse {
 ///         // Inspect headers for malicious patterns
 ///         if event.headers.contains_key("x-malicious") {
-///             AgentResponse::new(Decision::Block {
-///                 status: 403,
-///                 body: Some("Blocked by WAF".to_string()),
-///                 headers: None,
-///             })
+///             AgentResponse::block(403, Some("Blocked by WAF".to_string()))
 ///         } else {
 ///             AgentResponse::default_allow()
 ///         }
@@ -204,7 +194,7 @@ pub enum DrainReason {
 ///
 /// // Serve on a specific address
 /// let addr = "127.0.0.1:8080".parse()?;
-/// server.serve(addr).await?;
+/// server.run(addr).await?;
 /// ```
 ///
 /// # Transport Details

--- a/crates/agent-protocol/src/v2/server.rs
+++ b/crates/agent-protocol/src/v2/server.rs
@@ -27,11 +27,70 @@ use crate::{
 /// v2 agent handler trait.
 ///
 /// Implement this trait to create a v2 agent. The v2 handler adds:
-/// - Capability reporting
-/// - Health reporting
-/// - Flow control awareness
-/// - Metrics export
-/// - Configuration updates
+/// Trait for implementing agent handlers in Protocol v2.
+///
+/// `AgentHandlerV2` defines the interface that agent implementations must provide
+/// to handle various types of events from the proxy. This includes request/response
+/// processing, WebSocket handling, health monitoring, and configuration management.
+///
+/// The trait provides sensible defaults for all methods, allowing agents to implement
+/// only the events they need to handle. All methods are async to support I/O operations.
+///
+/// # Features
+///
+/// - **Capability reporting**: Declare what the agent can process
+/// - **Health reporting**: Report current health status to the proxy
+/// - **Flow control awareness**: Handle backpressure and flow control
+/// - **Metrics export**: Provide metrics about agent performance
+/// - **Configuration updates**: Handle dynamic configuration changes
+///
+/// # Event Lifecycle
+///
+/// 1. **Handshake**: Agent declares capabilities when connecting
+/// 2. **Headers**: Process request/response headers first
+/// 3. **Body chunks**: Handle streaming body data if needed
+/// 4. **Completion**: Final processing when request/response is complete
+/// 5. **WebSocket**: Handle WebSocket frames for upgraded connections
+///
+/// # Example
+///
+/// ```rust
+/// use async_trait::async_trait;
+/// use zentinel_agent_protocol::v2::{AgentHandlerV2, AgentCapabilities, AgentResponse};
+/// use zentinel_agent_protocol::{RequestHeadersEvent, Decision};
+///
+/// pub struct MyWafAgent;
+///
+/// #[async_trait]
+/// impl AgentHandlerV2 for MyWafAgent {
+///     fn capabilities(&self) -> AgentCapabilities {
+///         AgentCapabilities {
+///             agent_id: "my-waf".to_string(),
+///             events: vec!["request_headers".to_string()],
+///             version: "1.0.0".to_string(),
+///         }
+///     }
+///
+///     async fn on_request_headers(&self, event: RequestHeadersEvent) -> AgentResponse {
+///         // Inspect headers for malicious patterns
+///         if event.headers.contains_key("x-malicious") {
+///             AgentResponse::new(Decision::Block {
+///                 status: 403,
+///                 body: Some("Blocked by WAF".to_string()),
+///                 headers: None,
+///             })
+///         } else {
+///             AgentResponse::default_allow()
+///         }
+///     }
+/// }
+/// ```
+///
+/// # Errors
+///
+/// Agent methods should return `AgentResponse` with appropriate `Decision` variants.
+/// Runtime errors should be logged internally rather than propagated, as the proxy
+/// needs to maintain high availability.
 #[async_trait]
 pub trait AgentHandlerV2: Send + Sync {
     /// Get agent capabilities.
@@ -121,7 +180,41 @@ pub enum DrainReason {
     Manual,
 }
 
-/// v2 gRPC agent server.
+/// gRPC-based agent server implementation for Protocol v2.
+///
+/// `GrpcAgentServerV2` provides a gRPC transport for agents that need to communicate
+/// with the Zentinel proxy over the network. This is ideal for agents running in
+/// separate processes, containers, or on different machines.
+///
+/// # Features
+///
+/// - **Network transport**: Communicates over TCP with HTTP/2 and TLS support
+/// - **Language agnostic**: Works with any gRPC client implementation
+/// - **Scalability**: Can handle multiple concurrent proxy connections
+/// - **Monitoring**: Integrates with gRPC ecosystem tools for observability
+///
+/// # Example
+///
+/// ```rust
+/// use zentinel_agent_protocol::v2::{GrpcAgentServerV2, AgentHandlerV2};
+///
+/// // Create server with your handler
+/// let handler = Box::new(MyAgent::new());
+/// let server = GrpcAgentServerV2::new("my-agent", handler);
+///
+/// // Serve on a specific address
+/// let addr = "127.0.0.1:8080".parse()?;
+/// server.serve(addr).await?;
+/// ```
+///
+/// # Transport Details
+///
+/// The gRPC transport uses the standard Agent Protocol v2 service definition:
+/// - Bidirectional streaming for event processing
+/// - Capability negotiation during handshake
+/// - Health check integration
+/// - Configuration update support
+/// - Metrics collection
 pub struct GrpcAgentServerV2 {
     id: String,
     handler: Arc<dyn AgentHandlerV2>,

--- a/crates/agent-protocol/src/v2/server.rs
+++ b/crates/agent-protocol/src/v2/server.rs
@@ -51,10 +51,10 @@ use crate::{
 ///
 /// # Example
 ///
-/// ```rust
+/// ```rust,no_run
 /// use async_trait::async_trait;
-/// use zentinel_agent_protocol::v2::{AgentHandlerV2, AgentCapabilities, AgentResponse};
-/// use zentinel_agent_protocol::{EventType, RequestHeadersEvent};
+/// use zentinel_agent_protocol::v2::{AgentHandlerV2, AgentCapabilities};
+/// use zentinel_agent_protocol::{AgentResponse, EventType, RequestHeadersEvent};
 ///
 /// pub struct MyWafAgent;
 ///
@@ -185,8 +185,8 @@ pub enum DrainReason {
 ///
 /// # Example
 ///
-/// ```rust
-/// use zentinel_agent_protocol::v2::{GrpcAgentServerV2, AgentHandlerV2};
+/// ```rust,ignore
+/// use zentinel_agent_protocol::v2::GrpcAgentServerV2;
 ///
 /// // Create server with your handler
 /// let handler = Box::new(MyAgent::new());

--- a/crates/agent-protocol/src/v2/uds_server.rs
+++ b/crates/agent-protocol/src/v2/uds_server.rs
@@ -37,7 +37,7 @@ use crate::{
 /// - **High performance**: Minimal overhead for local communication
 /// - **Binary protocol**: Efficient binary encoding for reduced CPU usage
 /// - **File system permissions**: Uses Unix socket permissions for access control
-/// - **Hot reload**: Supports graceful restart without losing connections
+/// - **Socket cleanup**: Removes stale socket files on startup
 ///
 /// # Example
 ///
@@ -54,7 +54,7 @@ use crate::{
 /// );
 ///
 /// // Start listening
-/// server.serve().await?;
+/// server.run().await?;
 /// ```
 ///
 /// # Socket Management
@@ -62,7 +62,6 @@ use crate::{
 /// The server automatically:
 /// - Creates the socket file with appropriate permissions
 /// - Removes stale socket files on startup
-/// - Cleans up the socket file on graceful shutdown
 /// - Handles multiple concurrent proxy connections
 ///
 /// # Errors

--- a/crates/agent-protocol/src/v2/uds_server.rs
+++ b/crates/agent-protocol/src/v2/uds_server.rs
@@ -41,8 +41,8 @@ use crate::{
 ///
 /// # Example
 ///
-/// ```rust
-/// use zentinel_agent_protocol::v2::{UdsAgentServerV2, AgentHandlerV2};
+/// ```rust,ignore
+/// use zentinel_agent_protocol::v2::UdsAgentServerV2;
 /// use std::path::Path;
 ///
 /// // Create server with your handler

--- a/crates/agent-protocol/src/v2/uds_server.rs
+++ b/crates/agent-protocol/src/v2/uds_server.rs
@@ -23,10 +23,54 @@ use crate::{
     RequestHeadersEvent, ResponseBodyChunkEvent, ResponseHeadersEvent, WebSocketFrameEvent,
 };
 
-/// v2 agent server over Unix Domain Socket.
+/// Unix Domain Socket agent server implementation for Protocol v2.
 ///
-/// Listens on a Unix socket, accepts connections, and dispatches events to an
-/// [`AgentHandlerV2`] implementation using the v2 binary wire format.
+/// `UdsAgentServerV2` provides a high-performance local transport for agents running
+/// on the same machine as the Zentinel proxy. It uses Unix Domain Sockets for
+/// inter-process communication with minimal overhead.
+///
+/// This transport is recommended for agents that need the lowest possible latency
+/// and are co-located with the proxy process.
+///
+/// # Features
+///
+/// - **High performance**: Minimal overhead for local communication
+/// - **Binary protocol**: Efficient binary encoding for reduced CPU usage
+/// - **File system permissions**: Uses Unix socket permissions for access control
+/// - **Hot reload**: Supports graceful restart without losing connections
+///
+/// # Example
+///
+/// ```rust
+/// use zentinel_agent_protocol::v2::{UdsAgentServerV2, AgentHandlerV2};
+/// use std::path::Path;
+///
+/// // Create server with your handler
+/// let handler = Box::new(MyAgent::new());
+/// let server = UdsAgentServerV2::new(
+///     "my-agent",
+///     Path::new("/var/run/my-agent.sock"),
+///     handler
+/// );
+///
+/// // Start listening
+/// server.serve().await?;
+/// ```
+///
+/// # Socket Management
+///
+/// The server automatically:
+/// - Creates the socket file with appropriate permissions
+/// - Removes stale socket files on startup
+/// - Cleans up the socket file on graceful shutdown
+/// - Handles multiple concurrent proxy connections
+///
+/// # Errors
+///
+/// May return errors for:
+/// - Permission issues creating/accessing the socket file
+/// - Invalid socket paths or filesystem issues
+/// - Handler implementation errors
 pub struct UdsAgentServerV2 {
     id: String,
     socket_path: PathBuf,


### PR DESCRIPTION
## Summary

Continuation of #137 by @xvchris, with doc test fixes applied.

- Comprehensive rustdoc for `Decision`, `AgentPool`, `AgentHandlerV2`, `GrpcAgentServerV2`, `UdsAgentServerV2`
- All doc examples compile and pass `cargo test --doc`
- Fix `AgentResponse` import in `AgentHandlerV2` example (use crate root, not `v2::`)
- Mark examples with fictional types as `ignore`

Resolves #114, supersedes #137.

## Test plan

- [x] `cargo test --doc -p zentinel-agent-protocol` passes
- [x] `cargo test --lib -p zentinel-agent-protocol` passes
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean