### PR TITLE
fix(deps): resolve 3 Dependabot security alerts in Go conformance module

### DIFF
--- a/conformance/go.mod
+++ b/conformance/go.mod
@@ -1,6 +1,6 @@
 module github.com/zentinelproxy/zentinel/conformance
 
-go 1.22.0
+go 1.25.0
 
 require sigs.k8s.io/gateway-api v1.2.1
 
@@ -35,15 +35,15 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	golang.org/x/mod v0.20.0 // indirect
-	golang.org/x/net v0.28.0 // indirect
-	golang.org/x/oauth2 v0.21.0 // indirect
-	golang.org/x/sync v0.8.0 // indirect
-	golang.org/x/sys v0.24.0 // indirect
-	golang.org/x/term v0.23.0 // indirect
-	golang.org/x/text v0.17.0 // indirect
+	golang.org/x/mod v0.33.0 // indirect
+	golang.org/x/net v0.52.0 // indirect
+	golang.org/x/oauth2 v0.36.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/term v0.41.0 // indirect
+	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
-	golang.org/x/tools v0.24.0 // indirect
+	golang.org/x/tools v0.42.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240701130421-f6361c86f094 // indirect
 	google.golang.org/grpc v1.66.2 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect


### PR DESCRIPTION
## Summary
- Upgrades `golang.org/x/net` v0.28.0 → v0.52.0 — fixes XSS vulnerability and HTTP proxy bypass via IPv6 Zone IDs
- Upgrades `golang.org/x/oauth2` v0.21.0 → v0.36.0 — fixes improper input validation
- Resolves Dependabot alerts #24, #25, #26

## Test plan
- [ ] `go mod tidy` passes cleanly in `conformance/`
- [ ] Conformance test suite still passes
- [ ] Dependabot alerts auto-close after merge