### PR TITLE
feat(upstream): backend drain lifecycle events (#124)

### DIFF
--- a/crates/proxy/src/proxy/http_trait.rs
+++ b/crates/proxy/src/proxy/http_trait.rs
@@ -640,6 +640,8 @@ impl ProxyHttp for ZentinelProxy {
             match pool.select_peer_with_metadata(None).await {
                 Ok((mut peer, metadata)) => {
                     let selection_duration = selection_start.elapsed();
+                    // Track active request for drain lifecycle
+                    pool.increment_active();
                     // Store selected peer address for feedback reporting in logging()
                     let peer_addr = peer.address().to_string();
                     ctx.selected_upstream_address = Some(peer_addr.clone());
@@ -3346,6 +3348,7 @@ impl ProxyHttp for ZentinelProxy {
             if let Some(pool) = self.upstream_pools.get(upstream_id).await {
                 pool.report_result_with_latency(peer_addr, success, Some(duration))
                     .await;
+                pool.decrement_active();
                 trace!(
                     correlation_id = %ctx.trace_id,
                     upstream = %upstream_id,

--- a/crates/proxy/src/proxy/mod.rs
+++ b/crates/proxy/src/proxy/mod.rs
@@ -429,21 +429,15 @@ impl ZentinelProxy {
                         scoped_upstream_pools.len().await
                     );
 
-                    // Shutdown old pools after delay
+                    // Track drain lifecycle for old pools instead of blind sleep
                     tokio::spawn(async move {
-                        tokio::time::sleep(Duration::from_secs(60)).await;
+                        let tracker = crate::upstream::drain::DrainTracker::default();
 
-                        // Shutdown old global pools
-                        for (name, pool) in old_pools {
-                            info!("Shutting down old global pool: {}", name);
-                            pool.shutdown().await;
-                        }
+                        // Track global pools
+                        tracker.track_pools(old_pools).await;
 
-                        // Shutdown old scoped pools
-                        for (name, pool) in old_scoped_pools {
-                            info!("Shutting down old scoped pool: {}", name);
-                            pool.shutdown().await;
-                        }
+                        // Track scoped pools
+                        tracker.track_pools(old_scoped_pools).await;
                     });
                 }
             }

--- a/crates/proxy/src/upstream/drain.rs
+++ b/crates/proxy/src/upstream/drain.rs
@@ -1,0 +1,172 @@
+//! Backend drain lifecycle tracking.
+//!
+//! Monitors old upstream pools after a config reload, tracking active
+//! connections and emitting structured events when backends are fully drained.
+//!
+//! Lifecycle states:
+//! - `Active`: backend is receiving new connections
+//! - `Draining`: backend removed from config, existing connections finishing
+//! - `Drained`: all connections completed, safe to terminate backend
+//!
+//! This replaces the previous blind 60-second sleep with active monitoring.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tracing::{debug, info, warn};
+
+use super::UpstreamPool;
+
+/// Backend drain lifecycle state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendState {
+    /// Backend is active and receiving new connections.
+    Active,
+    /// Backend has been removed from config. No new connections are being
+    /// sent, but existing connections are still in flight.
+    Draining,
+    /// All connections have completed. Safe to shut down the backend.
+    Drained,
+}
+
+impl std::fmt::Display for BackendState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BackendState::Active => write!(f, "active"),
+            BackendState::Draining => write!(f, "draining"),
+            BackendState::Drained => write!(f, "drained"),
+        }
+    }
+}
+
+/// Tracks the drain lifecycle of old upstream pools after a config reload.
+///
+/// When pools are replaced during a reload, the old pools are handed to
+/// the `DrainTracker` which monitors their active request count and
+/// emits structured log events when they transition through the lifecycle.
+pub struct DrainTracker {
+    /// Maximum time to wait for drain before force-shutting down.
+    max_drain_time: Duration,
+    /// Poll interval for checking connection counts.
+    poll_interval: Duration,
+}
+
+impl DrainTracker {
+    pub fn new(max_drain_time: Duration, poll_interval: Duration) -> Self {
+        Self {
+            max_drain_time,
+            poll_interval,
+        }
+    }
+
+    /// Monitor old pools and emit drain lifecycle events.
+    ///
+    /// This runs as a spawned task. It polls each pool's active request count
+    /// and emits structured events as they transition from Draining to Drained.
+    pub async fn track_pools(
+        &self,
+        pools: HashMap<String, Arc<UpstreamPool>>,
+    ) {
+        if pools.is_empty() {
+            return;
+        }
+
+        let pool_count = pools.len();
+        info!(
+            pool_count = pool_count,
+            "Starting drain tracking for removed upstream pools"
+        );
+
+        // Emit Draining events
+        for (name, pool) in &pools {
+            let active = pool.active_request_count();
+            info!(
+                upstream_id = %name,
+                active_requests = active,
+                state = %BackendState::Draining,
+                "Backend entering drain state"
+            );
+        }
+
+        let start = Instant::now();
+        let mut pending: HashMap<String, Arc<UpstreamPool>> = pools;
+
+        while !pending.is_empty() && start.elapsed() < self.max_drain_time {
+            tokio::time::sleep(self.poll_interval).await;
+
+            let mut newly_drained = Vec::new();
+
+            for (name, pool) in &pending {
+                let active = pool.active_request_count();
+
+                if active == 0 {
+                    let drain_duration = start.elapsed();
+                    info!(
+                        upstream_id = %name,
+                        drain_duration_ms = drain_duration.as_millis(),
+                        drain_duration_secs = drain_duration.as_secs_f64(),
+                        state = %BackendState::Drained,
+                        "Backend fully drained, safe to terminate"
+                    );
+                    newly_drained.push(name.clone());
+                } else {
+                    debug!(
+                        upstream_id = %name,
+                        active_requests = active,
+                        elapsed_ms = start.elapsed().as_millis(),
+                        state = %BackendState::Draining,
+                        "Backend still draining"
+                    );
+                }
+            }
+
+            for name in newly_drained {
+                if let Some(pool) = pending.remove(&name) {
+                    pool.shutdown().await;
+                }
+            }
+        }
+
+        // Force shutdown any remaining pools that didn't drain in time
+        for (name, pool) in &pending {
+            let active = pool.active_request_count();
+            warn!(
+                upstream_id = %name,
+                active_requests = active,
+                max_drain_time_secs = self.max_drain_time.as_secs(),
+                state = "drain_timeout",
+                "Backend drain timeout exceeded, force shutting down"
+            );
+            pool.shutdown().await;
+        }
+
+        if pool_count > 0 {
+            info!(
+                pool_count = pool_count,
+                total_duration_ms = start.elapsed().as_millis(),
+                "Drain tracking complete for all removed pools"
+            );
+        }
+    }
+}
+
+impl Default for DrainTracker {
+    fn default() -> Self {
+        Self {
+            max_drain_time: Duration::from_secs(60),
+            poll_interval: Duration::from_secs(1),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backend_state_display() {
+        assert_eq!(BackendState::Active.to_string(), "active");
+        assert_eq!(BackendState::Draining.to_string(), "draining");
+        assert_eq!(BackendState::Drained.to_string(), "drained");
+    }
+}

--- a/crates/proxy/src/upstream/mod.rs
+++ b/crates/proxy/src/upstream/mod.rs
@@ -86,6 +86,7 @@ impl UpstreamTarget {
 // Load balancing algorithm implementations
 pub mod adaptive;
 pub mod consistent_hash;
+pub mod drain;
 pub mod health;
 pub mod inference_health;
 pub mod least_tokens;
@@ -271,6 +272,8 @@ pub struct PoolStats {
     pub retries: AtomicU64,
     /// Circuit breaker trips
     pub circuit_breaker_trips: AtomicU64,
+    /// Currently active requests (in-flight)
+    pub active_requests: AtomicU64,
 }
 
 /// Target information for shadow traffic
@@ -1575,6 +1578,26 @@ impl UpstreamPool {
     /// Check if TLS is enabled for this upstream
     pub fn is_tls_enabled(&self) -> bool {
         self.tls_enabled
+    }
+
+    /// Get the number of currently active (in-flight) requests for this pool.
+    ///
+    /// Used by the drain tracker to determine when a pool has been fully
+    /// drained after removal from config.
+    pub fn active_request_count(&self) -> u64 {
+        self.stats.active_requests.load(Ordering::Relaxed)
+    }
+
+    /// Increment the active request counter. Called when a request is assigned
+    /// to this pool.
+    pub fn increment_active(&self) {
+        self.stats.active_requests.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Decrement the active request counter. Called when a request completes
+    /// (success or failure).
+    pub fn decrement_active(&self) {
+        self.stats.active_requests.fetch_sub(1, Ordering::Relaxed);
     }
 
     /// Shutdown the pool


### PR DESCRIPTION
## Summary

Adds active monitoring of backend drain state during config reloads, replacing the blind 60-second sleep with structured lifecycle tracking. Closes #124.

## Changes

**New: `DrainTracker` (`crates/proxy/src/upstream/drain.rs`)**
- Polls active request counts on old pools after config reload
- Emits structured tracing events for each state transition
- Configurable max drain time (60s) and poll interval (1s)
- Force-shuts down pools that exceed the drain timeout

**`UpstreamPool` changes:**
- New `active_requests` counter in `PoolStats` (AtomicU64)
- `increment_active()` / `decrement_active()` / `active_request_count()` methods

**Request lifecycle hooks:**
- `increment_active()` called after peer selection in `upstream_peer()`
- `decrement_active()` called after `report_result_with_latency()` in `logging()`

**Structured events emitted:**
| Event | Fields | When |
|-------|--------|------|
| Backend entering drain state | upstream_id, active_requests, state=draining | Pool removed from config |
| Backend still draining | upstream_id, active_requests, elapsed_ms | Each poll interval |
| Backend fully drained | upstream_id, drain_duration_ms, state=drained | Active requests reach 0 |
| Backend drain timeout | upstream_id, active_requests, max_drain_time_secs | Timeout exceeded |

## Test plan
- [x] `cargo clippy -p zentinel-proxy -- -D warnings` clean
- [x] `cargo test -p zentinel-proxy backend_state` passes
- [x] Workspace compiles cleanly