### PR TITLE
deps: bump rcgen to 0.14.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2755,7 +2755,7 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-rustls",
  "hyper-util",
- "rcgen 0.14.7",
+ "rcgen",
  "rustls",
  "rustls-pki-types",
  "serde",
@@ -4910,19 +4910,6 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rcgen"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
-dependencies = [
- "pem",
- "ring",
- "rustls-pki-types",
- "time",
- "yasna",
 ]
 
 [[package]]
@@ -8351,7 +8338,7 @@ dependencies = [
  "kube",
  "parking_lot",
  "prometheus 0.14.0",
- "rcgen 0.13.2",
+ "rcgen",
  "rustls",
  "schemars 1.2.1",
  "serde",
@@ -8419,7 +8406,7 @@ dependencies = [
  "prometheus 0.14.0",
  "proptest",
  "rand 0.10.0",
- "rcgen 0.14.7",
+ "rcgen",
  "redis",
  "regex",
  "reqwest 0.13.2",

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -45,7 +45,7 @@ http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["tokio", "server-auto", "http1"] }
 
 # TLS bootstrap cert generation
-rcgen = "0.13"
+rcgen = "0.14"
 
 # Memory allocator
 tikv-jemallocator.workspace = true

--- a/crates/gateway/src/config_writer.rs
+++ b/crates/gateway/src/config_writer.rs
@@ -489,7 +489,7 @@ fn write_fallback_self_signed_cert(
         rcgen::generate_simple_self_signed(subject_alt_names).map_err(std::io::Error::other)?;
 
     std::fs::write(cert_path, cert.cert.pem())?;
-    std::fs::write(key_path, cert.key_pair.serialize_pem())?;
+    std::fs::write(key_path, cert.signing_key.serialize_pem())?;
 
     #[cfg(unix)]
     {


### PR DESCRIPTION
## Summary

- Bump rcgen from 0.13.2 to 0.14.7 in `crates/gateway/Cargo.toml` (proxy was already on 0.14)
- Fix `CertifiedKey` API change: field renamed from `key_pair` to `signing_key` in `config_writer.rs`
- Unifies the workspace on a single rcgen version, eliminating duplicate builds

## Test plan

- [x] `cargo check -p zentinel-gateway -p zentinel-proxy` passes
- [x] `cargo clippy -p zentinel-gateway -p zentinel-proxy --all-targets -- -D warnings` passes
- [ ] CI green