### PR TITLE
chore: bump version to 0.6.5 for release 26.04_2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ for details.
 
 | CalVer | Crate Version | Date | Highlights |
 |--------|---------------|------|------------|
+| [26.04_2](#26042---2026-04-10) | 0.6.5 | 2026-04-10 | Security: wasmtime 43.0.1 (critical sandbox escape fix) |
 | [26.04_1](#26041---2026-04-09) | 0.6.4 | 2026-04-09 | Numeric route priorities, host extraction fix, Docker glibc fix, conformance CI restored |
 | [26.03_4](#26034---2026-03-18) | 0.6.2 | 2026-03-18 | Configurable Cache-Status header name |
 | [26.02_18](#260218---2026-02-26) | 0.5.10 | 2026-02-26 | Remove v1 agent protocol |
@@ -34,6 +35,15 @@ for details.
 | [26.01_0](#26010---2026-01-01) | 0.2.0 | 2026-01-01 | First CalVer release |
 | [25.12](#2512) | 0.1.x | 2025-12 | Initial public releases |
 | [24.12](#2412) | 0.1.0 | 2024-12 | Initial development |
+
+---
+
+## [26.04_2] - 2026-04-10
+
+**Crate version:** 0.6.5
+
+### Security
+- **Bump wasmtime 43.0.0 → 43.0.1** — Resolves 10 Dependabot advisories including CVE-2026-34971 (critical: sandbox escape on aarch64 via miscompiled guest heap access in Cranelift), 6 medium-severity issues (OOB memory access, host panics/crashes), and 3 low-severity issues (data leakage, use-after-free). (#183)
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8295,7 +8295,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.3"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8335,7 +8335,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.3"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8357,7 +8357,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.3"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8436,7 +8436,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.3"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8467,7 +8467,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.3"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8558,7 +8558,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.3"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8575,7 +8575,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.3"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.3"
+version = "0.6.5"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump workspace crate version `0.6.3` → `0.6.5` (`0.6.4` was used by `26.04_1` but never merged to `main`)
- Add `26.04_2` changelog entry covering the wasmtime security bump (#183)

## Context

This release is a security patch: wasmtime `43.0.0` → `43.0.1` resolving 10 advisories including a critical aarch64 sandbox escape (CVE-2026-34971).

## Test plan

- [x] `cargo check --workspace` passes
- [ ] CI passes