### PR TITLE
chore: bump version to 0.6.6 for release 26.04_3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ for details.
 
 | CalVer | Crate Version | Date | Highlights |
 |--------|---------------|------|------------|
+| [26.04_3](#26043---2026-04-16) | 0.6.6 | 2026-04-16 | Security: rand unsoundness fix, dependency updates |
 | [26.04_2](#26042---2026-04-10) | 0.6.5 | 2026-04-10 | Security: wasmtime 43.0.1 (critical sandbox escape fix) |
 | [26.04_1](#26041---2026-04-09) | 0.6.4 | 2026-04-09 | Numeric route priorities, host extraction fix, Docker glibc fix, conformance CI restored |
 | [26.03_4](#26034---2026-03-18) | 0.6.2 | 2026-03-18 | Configurable Cache-Status header name |
@@ -35,6 +36,23 @@ for details.
 | [26.01_0](#26010---2026-01-01) | 0.2.0 | 2026-01-01 | First CalVer release |
 | [25.12](#2512) | 0.1.x | 2025-12 | Initial public releases |
 | [24.12](#2412) | 0.1.0 | 2024-12 | Initial development |
+
+---
+
+## [26.04_3] - 2026-04-16
+
+**Crate version:** 0.6.6
+
+### Security
+- **Bump rand to fix unsoundness advisory** — Updates pingora fork to bump `rand` 0.8→0.9 across all pingora crates, and bumps direct `rand` 0.10.0→0.10.1 and transitive `rand` 0.9.2→0.9.4. Resolves Dependabot alerts #43, #44, #45 (RUSTSEC unsoundness with custom loggers). (#192)
+- **Bump aes 0.8→0.9** — Migrates to cipher 0.5 (`BlockEncrypt`→`BlockCipherEncrypt`). (#193)
+
+### Dependencies
+- Bump `jsonschema` 0.45→0.46 (#193)
+- Bump `tiktoken-rs` 0.9→0.11 (#193)
+- Bump `actions/github-script` 8→9 (#186)
+- Bump `softprops/action-gh-release` 2→3 (#185)
+- Bump Rust toolchain to 1.94.1, MSRV to 1.94.1
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8378,7 +8378,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8418,7 +8418,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8440,7 +8440,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8519,7 +8519,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8550,7 +8550,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8641,7 +8641,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8658,7 +8658,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump crate version 0.6.5 → 0.6.6
- Update CHANGELOG with 26.04_3 release notes

## Changes in this release

### Security
- Bump rand to fix RUSTSEC unsoundness advisory (#192)
- Bump aes 0.8→0.9 (#193)

### Dependencies
- jsonschema 0.45→0.46, tiktoken-rs 0.9→0.11 (#193)
- actions/github-script 8→9 (#186), softprops/action-gh-release 2→3 (#185)
- Rust toolchain 1.94.1, MSRV 1.94.1