### PR TITLE
feat(acme): add cloudflare dns and custom acme server support with EAB

### DIFF
--- a/config/examples/README.md
+++ b/config/examples/README.md
@@ -14,6 +14,9 @@ Example configurations demonstrating Zentinel features and patterns.
 | Example | Description |
 |---------|-------------|
 | [api-schema-validation.kdl](api-schema-validation.kdl) | JSON Schema and OpenAPI validation for API routes |
+| [acme-cloudflare.kdl](acme-cloudflare.kdl) | Automatic TLS via Cloudflare DNS-01 challenges |
+| [acme-zerossl.kdl](acme-zerossl.kdl) | ACME with custom URL and EAB (e.g., ZeroSSL) |
+| [acme-san.kdl](acme-san.kdl) | Multi-domain (SAN) certificate management |
 
 ## AI/Inference
 

--- a/config/examples/acme-cloudflare.kdl
+++ b/config/examples/acme-cloudflare.kdl
@@ -1,0 +1,53 @@
+// ACME Cloudflare DNS-01 Challenge Example
+//
+// This example demonstrates how to configure automatic TLS certificates
+// using Cloudflare DNS-01 challenges, which supports wildcard certificates.
+
+listeners {
+    listener "https" address="0.0.0.0:443" {
+        tls {
+            acme {
+                email "admin@example.com"
+
+                // Wildcard and apex domain
+                domains "example.com" "*.example.com"
+
+                // DNS-01 is required for wildcard certificates
+                challenge-type "dns-01"
+
+                dns-provider {
+                    type "cloudflare"
+
+                    // Path to a file containing your Cloudflare API Token
+                    // The token needs "Zone.DNS:Edit" and "Zone.Zone:Read" permissions
+                    credentials-file "/etc/zentinel/secrets/cloudflare-token.txt"
+
+                    api-timeout-secs 30
+
+                    propagation {
+                        initial-delay-secs 20
+                        check-interval-secs 10
+                        timeout-secs 300
+                        nameservers "1.1.1.1" "8.8.8.8"
+                    }
+                }
+
+                // Optional: custom storage path
+                storage "/var/lib/zentinel/acme"
+            }
+        }
+    }
+}
+
+upstreams {
+    upstream "backend" {
+        server address="127.0.0.1:8080"
+    }
+}
+
+routes {
+    route "default" {
+        match path="/"
+        back-to upstream="backend"
+    }
+}

--- a/config/examples/acme-san.kdl
+++ b/config/examples/acme-san.kdl
@@ -1,0 +1,46 @@
+// ACME SAN (Subject Alternative Name) Certificate Example
+//
+// This example demonstrates a single certificate covering multiple domains.
+// Zentinel's scheduler handles this by only checking the primary domain
+// to avoid redundant renewal loops.
+
+listeners {
+    listener "https" address="0.0.0.0:443" {
+        tls {
+            acme {
+                email "admin@example.com"
+
+                // Multiple domains in a single certificate
+                // The first domain is treated as the primary domain
+                domains "example.com" "api.example.com" "static.example.com"
+
+                challenge-type "http-01"
+                staging true
+            }
+        }
+    }
+}
+
+upstreams {
+    upstream "api" {
+        server address="127.0.0.1:8081"
+    }
+    upstream "static" {
+        server address="127.0.0.1:8082"
+    }
+}
+
+routes {
+    route "api" {
+        match host="api.example.com"
+        back-to upstream="api"
+    }
+    route "static" {
+        match host="static.example.com"
+        back-to upstream="static"
+    }
+    route "home" {
+        match host="example.com"
+        back-to upstream="api"
+    }
+}

--- a/config/examples/acme-zerossl.kdl
+++ b/config/examples/acme-zerossl.kdl
@@ -1,0 +1,41 @@
+// ACME ZeroSSL with EAB Example
+//
+// This example demonstrates how to configure ACME with a custom directory
+// URL and External Account Binding (EAB), required by providers like ZeroSSL.
+
+listeners {
+    listener "https" address="0.0.0.0:443" {
+        tls {
+            acme {
+                email "admin@example.com"
+                domains "example.com" "www.example.com"
+
+                // Custom ACME directory URL for ZeroSSL
+                server-url "https://acme.zerossl.com/v2/DV90"
+
+                // External Account Binding (EAB)
+                // Obtain these from your ZeroSSL dashboard
+                eab {
+                    kid "your-eab-kid"
+                    hmac-key "your-base64url-encoded-hmac-key"
+                }
+
+                storage "/var/lib/zentinel/acme-zerossl"
+                renew-before-days 30
+            }
+        }
+    }
+}
+
+upstreams {
+    upstream "backend" {
+        server address="127.0.0.1:8080"
+    }
+}
+
+routes {
+    route "default" {
+        match path="/"
+        back-to upstream="backend"
+    }
+}

--- a/crates/config/src/kdl/server.rs
+++ b/crates/config/src/kdl/server.rs
@@ -10,8 +10,8 @@ use crate::server::{
     default_acme_storage, default_graceful_shutdown_timeout, default_keepalive_timeout,
     default_max_concurrent_streams, default_max_connections, default_renewal_days,
     default_request_timeout, default_worker_threads, AcmeChallengeType, AcmeConfig,
-    DnsProviderConfig, DnsProviderType, ListenerConfig, ListenerProtocol, PropagationCheckConfig,
-    ServerConfig, SniCertificate, TlsConfig,
+    DnsProviderConfig, DnsProviderType, ExternalAccountBinding, ListenerConfig, ListenerProtocol,
+    PropagationCheckConfig, ServerConfig, SniCertificate, TlsConfig,
 };
 
 use super::helpers::{get_bool_entry, get_first_arg_string, get_int_entry, get_string_entry};
@@ -324,7 +324,25 @@ fn parse_acme_config(node: &kdl::KdlNode, listener_id: &str) -> Result<AcmeConfi
     }
 
     // Optional with defaults
+    let server_url = get_string_entry(node, "server-url");
     let staging = get_bool_entry(node, "staging").unwrap_or(false);
+    // Parse EAB if present
+    let eab = if let Some(children) = node.children() {
+        children
+            .nodes()
+            .iter()
+            .find(|n| n.name().value() == "eab")
+            .map(|eab_node| -> Result<ExternalAccountBinding> {
+                let kid = get_string_entry(eab_node, "kid")
+                    .ok_or_else(|| anyhow::anyhow!("ACME EAB configuration requires 'kid'"))?;
+                let hmac_key = get_string_entry(eab_node, "hmac-key")
+                    .ok_or_else(|| anyhow::anyhow!("ACME EAB configuration requires 'hmac-key'"))?;
+                Ok(ExternalAccountBinding { kid, hmac_key })
+            })
+            .transpose()?
+    } else {
+        None
+    };
     let storage = get_string_entry(node, "storage")
         .map(PathBuf::from)
         .unwrap_or_else(default_acme_storage);
@@ -382,7 +400,9 @@ fn parse_acme_config(node: &kdl::KdlNode, listener_id: &str) -> Result<AcmeConfi
     Ok(AcmeConfig {
         email,
         domains,
+        server_url,
         staging,
+        eab,
         storage,
         renew_before_days,
         challenge_type,
@@ -483,6 +503,7 @@ fn parse_dns_provider_type(
 ) -> Result<DnsProviderType> {
     match type_str.to_lowercase().as_str() {
         "hetzner" => Ok(DnsProviderType::Hetzner),
+        "cloudflare" => Ok(DnsProviderType::Cloudflare),
         "webhook" => {
             let url = get_string_entry(node, "url").ok_or_else(|| {
                 anyhow::anyhow!(

--- a/crates/config/src/server.rs
+++ b/crates/config/src/server.rs
@@ -198,23 +198,29 @@ pub struct TlsConfig {
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, Validate)]
 pub struct AcmeConfig {
-    /// Contact email for Let's Encrypt account
-    /// Required for account registration and recovery
+    /// Contact email for account registration and recovery
     #[validate(email)]
     pub email: String,
 
     /// Domain names to obtain certificates for
-    /// At least one domain is required
     #[validate(length(min = 1, message = "at least one domain is required"))]
     pub domains: Vec<String>,
 
+    /// Optional custom ACME directory URL (e.g., ZeroSSL)
+    /// If not provided, defaults to Let's Encrypt
+    #[validate(url)]
+    pub server_url: Option<String>,
+
     /// Use Let's Encrypt staging environment
-    /// Set to true for testing to avoid rate limits
+    /// Only used if server_url is not provided
     #[serde(default)]
     pub staging: bool,
 
+    /// External Account Binding (EAB) credentials
+    /// Required by some providers like ZeroSSL
+    pub eab: Option<ExternalAccountBinding>,
+
     /// Directory for storing certificates and account keys
-    /// Defaults to /var/lib/zentinel/acme
     #[serde(default = "default_acme_storage")]
     pub storage: PathBuf,
 
@@ -231,6 +237,15 @@ pub struct AcmeConfig {
 
     /// DNS provider configuration (required for DNS-01 challenges)
     pub dns_provider: Option<DnsProviderConfig>,
+}
+
+/// External Account Binding (EAB) credentials for ACME
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalAccountBinding {
+    /// Key ID (KID) provided by the ACME CA
+    pub kid: String,
+    /// HMAC Key (base64url-encoded) provided by the ACME CA
+    pub hmac_key: String,
 }
 
 /// ACME challenge type
@@ -288,6 +303,9 @@ pub struct DnsProviderConfig {
 pub enum DnsProviderType {
     /// Hetzner DNS API
     Hetzner,
+
+    /// Cloudflare DNS API
+    Cloudflare,
 
     /// Generic webhook provider
     Webhook {

--- a/crates/proxy/docs/acme.md
+++ b/crates/proxy/docs/acme.md
@@ -101,15 +101,48 @@ pub trait DnsProvider: Send + Sync + Debug {
     async fn supports_domain(&self, domain: &str) -> DnsResult<bool>;
 }
 ```
-
 #### Supported DNS Providers
 
 | Provider | Description |
 |----------|-------------|
 | `hetzner` | Hetzner DNS API |
+| `cloudflare` | Cloudflare DNS API v4 |
 | `webhook` | Generic webhook for custom DNS integrations |
 
 #### DNS-01 Challenge Flow
+...
+### Custom ACME Directory and EAB
+
+Zentinel supports custom ACME directory URLs and External Account Binding (EAB), which is required by providers like ZeroSSL.
+
+```kdl
+acme {
+    email "admin@example.com"
+    domains "example.com"
+
+    // Custom ACME directory URL
+    server-url "https://acme.zerossl.com/v2/DV90"
+
+    // External Account Binding (EAB) credentials
+    eab {
+        kid "your-eab-kid"
+        hmac-key "your-base64url-encoded-hmac-key"
+    }
+}
+```
+
+### SAN (Subject Alternative Name) Certificates
+
+Zentinel supports single certificates covering multiple domains. The renewal scheduler automatically handles this by only checking the primary domain (the first one in the list) to avoid redundant renewal requests and infinite loops.
+
+```kdl
+acme {
+    email "admin@example.com"
+    domains "example.com" "api.example.com" "www.example.com"
+}
+```
+
+### `acme/client.rs`
 
 1. **Create Order** - Request certificate with DNS-01 challenges
 2. **Create TXT Records** - Provider creates `_acme-challenge.{domain}` records

--- a/crates/proxy/src/acme/client.rs
+++ b/crates/proxy/src/acme/client.rs
@@ -9,6 +9,8 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
 use chrono::{DateTime, Utc};
 use instant_acme::{
     Account, AuthorizationStatus, ChallengeType, Identifier, LetsEncrypt, NewAccount, NewOrder,
@@ -71,9 +73,11 @@ impl AcmeClient {
         &self.storage
     }
 
-    /// Get the ACME directory URL based on staging configuration
+    /// Get the ACME directory URL based on configuration
     fn directory_url(&self) -> &str {
-        if self.config.staging {
+        if let Some(ref url) = self.config.server_url {
+            url
+        } else if self.config.staging {
             LETSENCRYPT_STAGING
         } else {
             LETSENCRYPT_PRODUCTION
@@ -114,14 +118,20 @@ impl AcmeClient {
         // Create new account
         info!(
             email = %self.config.email,
-            staging = self.config.staging,
+            server_url = %self.directory_url(),
             "Creating new ACME account"
         );
 
-        let directory = if self.config.staging {
-            LetsEncrypt::Staging
+        let eab = if let Some(ref eab_config) = self.config.eab {
+            let hmac_key = URL_SAFE_NO_PAD.decode(&eab_config.hmac_key).map_err(|e| {
+                AcmeError::AccountCreation(format!("Invalid EAB HMAC key (base64url): {}", e))
+            })?;
+            Some(instant_acme::ExternalAccountKey::new(
+                eab_config.kid.clone(),
+                &hmac_key,
+            ))
         } else {
-            LetsEncrypt::Production
+            None
         };
 
         let (account, credentials) = Account::builder()
@@ -132,8 +142,8 @@ impl AcmeClient {
                     terms_of_service_agreed: true,
                     only_return_existing: false,
                 },
-                directory.url().to_owned(),
-                None,
+                self.directory_url().to_owned(),
+                eab.as_ref(),
             )
             .await
             .map_err(|e| AcmeError::AccountCreation(e.to_string()))?;

--- a/crates/proxy/src/acme/dns/mod.rs
+++ b/crates/proxy/src/acme/dns/mod.rs
@@ -47,4 +47,4 @@ pub use challenge::{create_challenge_info, Dns01ChallengeInfo, Dns01ChallengeMan
 pub use credentials::CredentialLoader;
 pub use propagation::{PropagationChecker, PropagationConfig};
 pub use provider::{DnsProvider, DnsProviderError, DnsResult};
-pub use providers::{create_provider, HetznerProvider, WebhookProvider};
+pub use providers::{create_provider, CloudflareProvider, HetznerProvider, WebhookProvider};

--- a/crates/proxy/src/acme/dns/providers/cloudflare.rs
+++ b/crates/proxy/src/acme/dns/providers/cloudflare.rs
@@ -1,0 +1,257 @@
+//! Cloudflare DNS provider implementation
+//!
+//! Uses the Cloudflare API v4 to manage TXT records for DNS-01 challenges.
+//! API documentation: <https://developers.cloudflare.com/api/operations/dns-records-for-a-zone-create-dns-record>
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use parking_lot::RwLock;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, trace};
+
+use crate::acme::dns::provider::{
+    challenge_record_fqdn, normalize_domain, DnsProvider, DnsProviderError, DnsResult,
+    CHALLENGE_TTL,
+};
+
+/// Cloudflare API base URL
+const CLOUDFLARE_API_BASE: &str = "https://api.cloudflare.com/client/v4";
+
+/// Cloudflare DNS provider
+#[derive(Debug)]
+pub struct CloudflareProvider {
+    client: Client,
+    token: String,
+    base_url: String,
+    /// Cache of domain -> zone_id mappings
+    zone_cache: Arc<RwLock<HashMap<String, String>>>,
+}
+
+impl CloudflareProvider {
+    /// Create a new Cloudflare DNS provider
+    ///
+    /// # Arguments
+    ///
+    /// * `token` - Cloudflare API Token (Bearer auth)
+    /// * `timeout` - Request timeout
+    pub fn new(token: &str, timeout: Duration) -> DnsResult<Self> {
+        let client = Client::builder().timeout(timeout).build().map_err(|e| {
+            DnsProviderError::Configuration(format!("Failed to create HTTP client: {}", e))
+        })?;
+
+        Ok(Self {
+            client,
+            token: token.to_string(),
+            base_url: CLOUDFLARE_API_BASE.to_string(),
+            zone_cache: Arc::new(RwLock::new(HashMap::new())),
+        })
+    }
+
+    /// Create a new Cloudflare DNS provider with a custom base URL (for testing)
+    #[doc(hidden)]
+    pub fn new_test(token: &str, base_url: String, timeout: Duration) -> DnsResult<Self> {
+        let mut provider = Self::new(token, timeout)?;
+        provider.base_url = base_url;
+        Ok(provider)
+    }
+
+    /// Get the zone ID for a domain
+    async fn get_zone_id(&self, domain: &str) -> DnsResult<String> {
+        let normalized = normalize_domain(domain);
+
+        // Check cache first
+        {
+            let cache = self.zone_cache.read();
+            if let Some(zone_id) = cache.get(normalized) {
+                trace!(domain = %domain, zone_id = %zone_id, "Zone ID found in cache");
+                return Ok(zone_id.clone());
+            }
+        }
+
+        // Fetch zones from API
+        // We filter by name to get the specific zone
+        let response = self
+            .client
+            .get(format!("{}/zones", self.base_url))
+            .header("Authorization", format!("Bearer {}", self.token))
+            .query(&[("name", normalized)])
+            .send()
+            .await
+            .map_err(|e| DnsProviderError::ApiRequest(format!("Failed to list zones: {}", e)))?;
+
+        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+            return Err(DnsProviderError::Authentication(
+                "Invalid Cloudflare API token".to_string(),
+            ));
+        }
+
+        let zones_resp: CloudflareResponse<Vec<Zone>> = response.json().await.map_err(|e| {
+            DnsProviderError::ApiRequest(format!("Failed to parse zone response: {}", e))
+        })?;
+
+        if !zones_resp.success {
+            return Err(DnsProviderError::ApiRequest(format!(
+                "Cloudflare API error: {:?}",
+                zones_resp.errors
+            )));
+        }
+
+        // Find the matching zone
+        let zone = zones_resp
+            .result
+            .and_then(|zones| zones.into_iter().next())
+            .ok_or_else(|| DnsProviderError::ZoneNotFound {
+                domain: normalized.to_string(),
+            })?;
+
+        // Cache the result
+        {
+            let mut cache = self.zone_cache.write();
+            cache.insert(normalized.to_string(), zone.id.clone());
+        }
+
+        debug!(domain = %domain, zone_id = %zone.id, "Found zone for domain");
+        Ok(zone.id)
+    }
+}
+
+#[async_trait]
+impl DnsProvider for CloudflareProvider {
+    fn name(&self) -> &'static str {
+        "cloudflare"
+    }
+
+    async fn create_txt_record(
+        &self,
+        domain: &str,
+        record_name: &str,
+        record_value: &str,
+    ) -> DnsResult<String> {
+        let zone_id = self.get_zone_id(domain).await?;
+        let full_name = format!("{}.{}", record_name, normalize_domain(domain));
+
+        let payload = CreateRecordRequest {
+            type_name: "TXT".to_string(),
+            name: full_name.clone(),
+            content: record_value.to_string(),
+            ttl: CHALLENGE_TTL,
+        };
+
+        let response = self
+            .client
+            .post(format!("{}/zones/{}/dns_records", self.base_url, zone_id))
+            .header("Authorization", format!("Bearer {}", self.token))
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| {
+                DnsProviderError::ApiRequest(format!("Failed to create TXT record: {}", e))
+            })?;
+
+        let record_resp: CloudflareResponse<Record> = response.json().await.map_err(|e| {
+            DnsProviderError::ApiRequest(format!("Failed to parse record response: {}", e))
+        })?;
+
+        if !record_resp.success {
+            return Err(DnsProviderError::RecordCreation {
+                record_name: full_name,
+                message: format!("{:?}", record_resp.errors),
+            });
+        }
+
+        let record = record_resp
+            .result
+            .ok_or_else(|| DnsProviderError::RecordCreation {
+                record_name: full_name,
+                message: "Cloudflare API returned success but missing record in result".to_string(),
+            })?;
+
+        debug!(
+            domain = %domain,
+            record_id = %record.id,
+            "Created TXT record"
+        );
+        Ok(record.id)
+    }
+
+    async fn delete_txt_record(&self, domain: &str, record_id: &str) -> DnsResult<()> {
+        let zone_id = self.get_zone_id(domain).await?;
+
+        let response = self
+            .client
+            .delete(format!(
+                "{}/zones/{}/dns_records/{}",
+                self.base_url, zone_id, record_id
+            ))
+            .header("Authorization", format!("Bearer {}", self.token))
+            .send()
+            .await
+            .map_err(|e| {
+                DnsProviderError::ApiRequest(format!("Failed to delete TXT record: {}", e))
+            })?;
+
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(()); // Already deleted
+        }
+
+        let delete_resp: CloudflareResponse<serde_json::Value> =
+            response.json().await.map_err(|e| {
+                DnsProviderError::ApiRequest(format!("Failed to parse delete response: {}", e))
+            })?;
+
+        if !delete_resp.success {
+            return Err(DnsProviderError::RecordDeletion {
+                record_id: record_id.to_string(),
+                message: format!("{:?}", delete_resp.errors),
+            });
+        }
+
+        debug!(domain = %domain, record_id = %record_id, "Deleted TXT record");
+        Ok(())
+    }
+
+    async fn supports_domain(&self, domain: &str) -> DnsResult<bool> {
+        match self.get_zone_id(domain).await {
+            Ok(_) => Ok(true),
+            Err(DnsProviderError::ZoneNotFound { .. }) => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// Generic Cloudflare API response
+#[derive(Debug, Deserialize)]
+struct CloudflareResponse<T> {
+    success: bool,
+    errors: Vec<CloudflareError>,
+    result: Option<T>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CloudflareError {
+    code: i32,
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Zone {
+    id: String,
+}
+
+#[derive(Debug, Serialize)]
+struct CreateRecordRequest {
+    #[serde(rename = "type")]
+    type_name: String,
+    name: String,
+    content: String,
+    ttl: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct Record {
+    id: String,
+}

--- a/crates/proxy/src/acme/dns/providers/mod.rs
+++ b/crates/proxy/src/acme/dns/providers/mod.rs
@@ -2,11 +2,14 @@
 //!
 //! Available providers:
 //! - [`HetznerProvider`] - Hetzner DNS API
+//! - [`CloudflareProvider`] - Cloudflare DNS API
 //! - [`WebhookProvider`] - Generic webhook for custom providers
 
+mod cloudflare;
 mod hetzner;
 mod webhook;
 
+pub use cloudflare::CloudflareProvider;
 pub use hetzner::HetznerProvider;
 pub use webhook::WebhookProvider;
 
@@ -33,6 +36,15 @@ pub fn create_provider(config: &DnsProviderConfig) -> DnsResult<Arc<dyn DnsProvi
                 )
             })?;
             let provider = HetznerProvider::new(token, timeout)?;
+            Ok(Arc::new(provider))
+        }
+        DnsProviderType::Cloudflare => {
+            let token = credentials.token().ok_or_else(|| {
+                DnsProviderError::Credentials(
+                    "Cloudflare provider requires a token credential".to_string(),
+                )
+            })?;
+            let provider = CloudflareProvider::new(token, timeout)?;
             Ok(Arc::new(provider))
         }
         DnsProviderType::Webhook { url, auth_header } => {

--- a/crates/proxy/src/acme/scheduler.rs
+++ b/crates/proxy/src/acme/scheduler.rs
@@ -121,56 +121,54 @@ impl RenewalScheduler {
     async fn check_renewals(&self) -> Result<(), AcmeError> {
         let domains = self.client.config().domains.clone();
 
-        info!(
-            domain_count = domains.len(),
-            "Checking certificates for renewal"
-        );
+        if domains.is_empty() {
+            return Ok(());
+        }
 
-        for domain in &domains {
-            match self.client.needs_renewal(domain) {
-                Ok(true) => {
-                    info!(domain = %domain, "Certificate needs renewal");
+        // We only check the primary domain for renewal as all domains in this
+        // config block are part of the same certificate and stored under the primary domain.
+        let domain = &domains[0];
 
-                    match self.renew_certificate().await {
-                        Ok(()) => {
-                            info!(domain = %domain, "Certificate renewed successfully");
+        match self.client.needs_renewal(domain) {
+            Ok(true) => {
+                info!(domain = %domain, "Certificate needs renewal");
 
-                            // Trigger TLS hot-reload
-                            if let Some(ref resolver) = self.sni_resolver {
-                                if let Err(e) = resolver.reload() {
-                                    error!(
-                                        domain = %domain,
-                                        error = %e,
-                                        "Failed to reload TLS configuration"
-                                    );
-                                } else {
-                                    info!("TLS configuration reloaded with new certificate");
-                                }
+                match self.renew_certificate().await {
+                    Ok(()) => {
+                        info!(domain = %domain, "Certificate renewed successfully");
+
+                        // Trigger TLS hot-reload
+                        if let Some(ref resolver) = self.sni_resolver {
+                            if let Err(e) = resolver.reload() {
+                                error!(
+                                    domain = %domain,
+                                    error = %e,
+                                    "Failed to reload TLS configuration"
+                                );
+                            } else {
+                                info!("TLS configuration reloaded with new certificate");
                             }
                         }
-                        Err(e) => {
-                            error!(
-                                domain = %domain,
-                                error = %e,
-                                "Certificate renewal failed"
-                            );
-                            // Continue with other domains
-                        }
                     }
-
-                    // Only renew once per check - all domains are in the same cert
-                    break;
+                    Err(e) => {
+                        error!(
+                            domain = %domain,
+                            error = %e,
+                            "Certificate renewal failed"
+                        );
+                        return Err(e);
+                    }
                 }
-                Ok(false) => {
-                    debug!(domain = %domain, "Certificate is still valid");
-                }
-                Err(e) => {
-                    warn!(
-                        domain = %domain,
-                        error = %e,
-                        "Failed to check certificate renewal status"
-                    );
-                }
+            }
+            Ok(false) => {
+                debug!(domain = %domain, "Certificate is still valid");
+            }
+            Err(e) => {
+                warn!(
+                    domain = %domain,
+                    error = %e,
+                    "Failed to check certificate renewal status"
+                );
             }
         }
 

--- a/crates/proxy/tests/acme_dns01_test.rs
+++ b/crates/proxy/tests/acme_dns01_test.rs
@@ -479,3 +479,169 @@ mod provider_errors {
         assert!(msg.contains("not supported"));
     }
 }
+
+// ============================================================================
+// Cloudflare Provider Tests
+// ============================================================================
+
+mod cloudflare_provider {
+    use super::*;
+    use zentinel_proxy::acme::dns::CloudflareProvider;
+
+    #[tokio::test]
+    async fn test_create_record_success() {
+        let mock_server = MockServer::start().await;
+        let token = "test-token";
+        let zone_id = "zone-123";
+        let record_id = "record-456";
+
+        // Mock zone lookup
+        Mock::given(method("GET"))
+            .and(path("/zones"))
+            .and(wiremock::matchers::query_param("name", "example.com"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+                "errors": [],
+                "result": [{ "id": zone_id, "name": "example.com" }]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // Mock record creation
+        Mock::given(method("POST"))
+            .and(path(format!("/zones/{}/dns_records", zone_id)))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+                "errors": [],
+                "result": { "id": record_id }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let provider =
+            CloudflareProvider::new_test(token, mock_server.uri(), Duration::from_secs(30))
+                .unwrap();
+
+        let id = provider
+            .create_txt_record("example.com", "_acme-challenge", "value")
+            .await
+            .unwrap();
+
+        assert_eq!(id, record_id);
+    }
+
+    #[tokio::test]
+    async fn test_zone_caching() {
+        let mock_server = MockServer::start().await;
+        let zone_id = "zone-123";
+
+        // Mock zone lookup - only allow ONE call
+        Mock::given(method("GET"))
+            .and(path("/zones"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+                "errors": [],
+                "result": [{ "id": zone_id, "name": "example.com" }]
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let provider =
+            CloudflareProvider::new_test("token", mock_server.uri(), Duration::from_secs(30))
+                .unwrap();
+
+        // First call triggers API
+        let id1 = provider.supports_domain("example.com").await.unwrap();
+        assert!(id1);
+
+        // Second call should use cache (no API call, otherwise expect(1) fails)
+        let id2 = provider.supports_domain("example.com").await.unwrap();
+        assert!(id2);
+    }
+
+    #[tokio::test]
+    async fn test_authentication_failure() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/zones"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&mock_server)
+            .await;
+
+        let provider =
+            CloudflareProvider::new_test("bad-token", mock_server.uri(), Duration::from_secs(30))
+                .unwrap();
+
+        let result = provider.create_txt_record("example.com", "re", "val").await;
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            DnsProviderError::Authentication(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_delete_record_success() {
+        let mock_server = MockServer::start().await;
+        let zone_id = "zone-123";
+        let record_id = "record-456";
+
+        // Mock zone lookup (cached from previous if we were careful, but here new provider)
+        Mock::given(method("GET"))
+            .and(path("/zones"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+                "errors": [],
+                "result": [{ "id": zone_id, "name": "example.com" }]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // Mock record deletion
+        Mock::given(method("DELETE"))
+            .and(path(format!(
+                "/zones/{}/dns_records/{}",
+                zone_id, record_id
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+                "errors": [],
+                "result": {}
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let provider =
+            CloudflareProvider::new_test("token", mock_server.uri(), Duration::from_secs(30))
+                .unwrap();
+
+        let result = provider.delete_txt_record("example.com", record_id).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_zone_not_found() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/zones"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+                "errors": [],
+                "result": []
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let provider =
+            CloudflareProvider::new_test("token", mock_server.uri(), Duration::from_secs(30))
+                .unwrap();
+
+        let result = provider.supports_domain("unknown.com").await.unwrap();
+        assert!(!result);
+    }
+}

--- a/crates/proxy/tests/acme_startup_test.rs
+++ b/crates/proxy/tests/acme_startup_test.rs
@@ -27,7 +27,9 @@ fn acme_config(storage: PathBuf) -> AcmeConfig {
     AcmeConfig {
         email: "test@example.com".to_string(),
         domains: vec!["example.com".to_string()],
+        server_url: None,
         staging: true,
+        eab: None,
         storage,
         renew_before_days: 30,
         challenge_type: AcmeChallengeType::Http01,
@@ -350,5 +352,74 @@ mod validate_acme_config {
             }
             e => panic!("Expected ConfigBuild error, got {:?}", e),
         }
+    }
+}
+
+// ============================================================================
+// ACME Client & Configuration Logic
+// ============================================================================
+
+mod acme_client_logic {
+    use super::*;
+    use zentinel_proxy::acme::AcmeClient;
+
+    #[test]
+    fn test_acme_client_uses_custom_url() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut config = acme_config(temp_dir.path().to_path_buf());
+        let custom_url = "https://acme.custom.com/directory";
+        config.server_url = Some(custom_url.to_string());
+
+        let _client = AcmeClient::new(
+            config,
+            Arc::new(CertificateStorage::new(temp_dir.path()).unwrap()),
+        );
+
+        // Custom URL is used internally.
+    }
+
+    #[test]
+    fn test_acme_config_parsing_eab() {
+        use zentinel_config::Config;
+
+        let kdl_text = r#"
+            version "0.6.0"
+            system {
+                worker-threads 4
+            }
+            listeners {
+                listener "test" {
+                    address "127.0.0.1:443"
+                    tls {
+                        acme {
+                            email "test@example.com"
+                            domains "example.com"
+                            server-url "https://acme.zerossl.com/v2/DV90"
+                            eab {
+                                kid "my-kid"
+                                hmac-key "my-hmac-key"
+                            }
+                        }
+                    }
+                }
+            }
+        "#;
+
+        let config = Config::from_kdl(kdl_text).expect("Should parse ACME EAB config");
+        let listener = config
+            .listeners
+            .iter()
+            .find(|l| l.id == "test")
+            .expect("Listener should exist");
+        let tls = listener.tls.as_ref().expect("TLS should exist");
+        let acme = tls.acme.as_ref().expect("ACME should exist");
+
+        assert_eq!(
+            acme.server_url.as_ref().unwrap(),
+            "https://acme.zerossl.com/v2/DV90"
+        );
+        let eab = acme.eab.as_ref().expect("EAB should exist");
+        assert_eq!(eab.kid, "my-kid");
+        assert_eq!(eab.hmac_key, "my-hmac-key");
     }
 }


### PR DESCRIPTION
- Implement Cloudflare DNS-01 provider for ACME challenges
- Add support for custom ACME directory URLs (e.g., ZeroSSL, Step-ca)
- Implement External Account Binding (EAB) support for ACME account creation
- Fix a bug in the renewal scheduler that caused infinite renewal loops when using multiple domains (SAN) in a single ACME configuration
- Update KDL parser to support the new 'server-url' and 'eab' configuration blocks

## Summary

<!-- Brief description of what this PR does -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Manifesto Alignment

<!-- All changes must align with the [Manifesto](MANIFESTO.md) -->

- [x] **Bounded** — Has clear limits (memory, queue depth, timeouts)
- [x] **Observable** — Emits appropriate metrics/logs
- [x] **Fails safely** — Explicit failure modes, no ambiguity
- [x] **No implicit behavior** — All behavior visible in config

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have read the [design rationale documents](doc/design/) and my changes align with existing architectural decisions
- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally
- [x] I have updated documentation (if applicable)
  - [x] Crate `docs/` updated
  - [ ] [Docs site](https://github.com/zentinelproxy/zentinelproxy.io-docs) PR opened (if user-visible)

## Testing

<!-- How was this tested? -->

```bash
# Commands used to test
cargo test -p <crate> <test_name>
```

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->
