### PR TITLE
chore: bump version to 0.6.7 for release 26.04_4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ for details.
 
 | CalVer | Crate Version | Date | Highlights |
 |--------|---------------|------|------------|
+| [26.04_4](#26044---2026-04-19) | 0.6.7 | 2026-04-19 | Cloudflare DNS-01, custom ACME servers, EAB, SAN renewal fix |
 | [26.04_3](#26043---2026-04-16) | 0.6.6 | 2026-04-16 | Security: rand unsoundness fix, dependency updates |
 | [26.04_2](#26042---2026-04-10) | 0.6.5 | 2026-04-10 | Security: wasmtime 43.0.1 (critical sandbox escape fix) |
 | [26.04_1](#26041---2026-04-09) | 0.6.4 | 2026-04-09 | Numeric route priorities, host extraction fix, Docker glibc fix, conformance CI restored |
@@ -36,6 +37,23 @@ for details.
 | [26.01_0](#26010---2026-01-01) | 0.2.0 | 2026-01-01 | First CalVer release |
 | [25.12](#2512) | 0.1.x | 2025-12 | Initial public releases |
 | [24.12](#2412) | 0.1.0 | 2024-12 | Initial development |
+
+---
+
+## [26.04_4] - 2026-04-19
+
+**Crate version:** 0.6.7
+
+### Added
+- **Cloudflare DNS-01 provider** for ACME challenges, enabling wildcard certificate issuance via Cloudflare DNS API v4. Includes zone ID caching and full test coverage. (#197)
+- **Custom ACME directory URLs** via `server-url` config option, supporting non-Let's Encrypt CAs like ZeroSSL and Step-ca. (#197)
+- **External Account Binding (EAB)** support for ACME account creation, required by providers like ZeroSSL. Configured via `eab { kid "..." hmac-key "..." }` block. (#197)
+
+### Fixed
+- **SAN certificate renewal loop** where the renewal scheduler iterated all domains in a multi-domain certificate, triggering redundant renewals. Now only checks the primary domain. (#197)
+
+### Security
+- **Bump `github.com/moby/spdystream`** 0.5.0 to 0.5.1 in conformance tests, fixing a high-severity DOS on CRI vulnerability. (#196)
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8378,7 +8378,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8418,7 +8418,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8440,7 +8440,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8519,7 +8519,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8550,7 +8550,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8641,7 +8641,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8658,7 +8658,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.6"
+version = "0.6.7"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump crate version 0.6.6 to 0.6.7
- Update CHANGELOG with 26.04_4 release notes

## Changes in this release

### Added
- Cloudflare DNS-01 provider (#197)
- Custom ACME directory URLs and EAB support (#197)

### Fixed
- SAN certificate renewal loop (#197)

### Security
- Bump spdystream 0.5.0 to 0.5.1 (#196)