### PR TITLE
chore: bump version to 0.6.8 for release 26.04_5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ for details.
 
 | CalVer | Crate Version | Date | Highlights |
 |--------|---------------|------|------------|
+| [26.04_5](#26045---2026-04-20) | 0.6.8 | 2026-04-20 | Configurable ACME certificate key type (ECDSA P-256/P-384) |
 | [26.04_4](#26044---2026-04-19) | 0.6.7 | 2026-04-19 | Cloudflare DNS-01, custom ACME servers, EAB, SAN renewal fix |
 | [26.04_3](#26043---2026-04-16) | 0.6.6 | 2026-04-16 | Security: rand unsoundness fix, dependency updates |
 | [26.04_2](#26042---2026-04-10) | 0.6.5 | 2026-04-10 | Security: wasmtime 43.0.1 (critical sandbox escape fix) |
@@ -37,6 +38,15 @@ for details.
 | [26.01_0](#26010---2026-01-01) | 0.2.0 | 2026-01-01 | First CalVer release |
 | [25.12](#2512) | 0.1.x | 2025-12 | Initial public releases |
 | [24.12](#2412) | 0.1.0 | 2024-12 | Initial development |
+
+---
+
+## [26.04_5] - 2026-04-20
+
+**Crate version:** 0.6.8
+
+### Added
+- **Configurable ACME certificate key type** via `key-type` config option. Supports `ecdsa-p256` (default) and `ecdsa-p384` for higher security strength. Invalid values produce a clear config parse error. (#199)
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8378,7 +8378,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8418,7 +8418,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8440,7 +8440,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8519,7 +8519,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8550,7 +8550,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8641,7 +8641,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8658,7 +8658,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.7"
+version = "0.6.8"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump crate version 0.6.7 to 0.6.8
- Update CHANGELOG with 26.04_5 release notes

## Changes in this release

### Added
- Configurable ACME certificate key type (ECDSA P-256/P-384) (#199)