### PR TITLE
feat: Support for ACME-managed SNI Certificates (Multi-tenant TLS)

### DIFF
--- a/crates/config/src/kdl/server.rs
+++ b/crates/config/src/kdl/server.rs
@@ -643,44 +643,67 @@ fn parse_sni_certificate(node: &kdl::KdlNode, listener_id: &str) -> Result<SniCe
         ));
     }
 
-    let cert_file = get_string_entry(node, "cert-file")
-        .map(PathBuf::from)
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "SNI certificate for listener '{}' requires 'cert-file'",
-                listener_id
-            )
-        })?;
+    // Parse acme configuration if present
+    let acme = if let Some(children) = children {
+        children
+            .nodes()
+            .iter()
+            .find(|n| n.name().value() == "acme")
+            .map(|n| parse_acme_config(n, listener_id))
+            .transpose()?
+    } else {
+        None
+    };
 
-    let key_file = get_string_entry(node, "key-file")
-        .map(PathBuf::from)
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "SNI certificate for listener '{}' requires 'key-file'",
-                listener_id
-            )
-        })?;
+    let cert_file = get_string_entry(node, "cert-file").map(PathBuf::from);
+    let key_file = get_string_entry(node, "key-file").map(PathBuf::from);
 
-    if !priority_hostnames.is_empty() {
+    // Validate mutual exclusion and completeness
+    match (&acme, &cert_file, &key_file) {
+        (Some(_), Some(_), _) | (Some(_), _, Some(_)) => {
+            return Err(anyhow::anyhow!(
+                "SNI certificate for listener '{}' cannot specify both manual files and an 'acme' block",
+                listener_id
+            ));
+        }
+        (None, None, _) | (None, _, None) => {
+            return Err(anyhow::anyhow!(
+                "SNI certificate for listener '{}' requires either both 'cert-file' and 'key-file', or an 'acme' block",
+                listener_id
+            ));
+        }
+        _ => {} // Valid: either acme OR (cert_file AND key_file)
+    }
+
+    if let Some(ref acme_config) = acme {
         debug!(
             listener_id = %listener_id,
-            priority_hostnames = ?priority_hostnames,
-            cert_file = %cert_file.display(),
-            "Parsed SNI certificate (SAN auto-extraction with priority tie-breaking)"
-        );
-    } else if hostnames.is_empty() {
-        debug!(
-            listener_id = %listener_id,
-            cert_file = %cert_file.display(),
-            "Parsed SNI certificate (hostnames will be auto-extracted from CN/SAN)"
+            acme_domains = ?acme_config.domains,
+            "Parsed SNI certificate with ACME"
         );
     } else {
-        debug!(
-            listener_id = %listener_id,
-            hostnames = ?hostnames,
-            cert_file = %cert_file.display(),
-            "Parsed SNI certificate"
-        );
+        let cert_path = cert_file.as_ref().unwrap().display();
+        if !priority_hostnames.is_empty() {
+            debug!(
+                listener_id = %listener_id,
+                priority_hostnames = ?priority_hostnames,
+                cert_file = %cert_path,
+                "Parsed SNI certificate (SAN auto-extraction with priority tie-breaking)"
+            );
+        } else if hostnames.is_empty() {
+            debug!(
+                listener_id = %listener_id,
+                cert_file = %cert_path,
+                "Parsed SNI certificate (hostnames will be auto-extracted from CN/SAN)"
+            );
+        } else {
+            debug!(
+                listener_id = %listener_id,
+                hostnames = ?hostnames,
+                cert_file = %cert_path,
+                "Parsed SNI certificate"
+            );
+        }
     }
 
     Ok(SniCertificate {
@@ -688,6 +711,7 @@ fn parse_sni_certificate(node: &kdl::KdlNode, listener_id: &str) -> Result<SniCe
         priority_hostnames,
         cert_file,
         key_file,
+        acme,
     })
 }
 

--- a/crates/config/src/server.rs
+++ b/crates/config/src/server.rs
@@ -395,11 +395,14 @@ pub struct SniCertificate {
     /// another cert also claims them. Mutually exclusive with `hostnames`.
     pub priority_hostnames: Vec<String>,
 
-    /// Certificate file path
-    pub cert_file: PathBuf,
+    /// Certificate file path (optional if acme is configured)
+    pub cert_file: Option<PathBuf>,
 
-    /// Private key file path
-    pub key_file: PathBuf,
+    /// Private key file path (optional if acme is configured)
+    pub key_file: Option<PathBuf>,
+
+    /// ACME configuration for this certificate
+    pub acme: Option<AcmeConfig>,
 }
 
 // ============================================================================

--- a/crates/config/src/validation.rs
+++ b/crates/config/src/validation.rs
@@ -383,6 +383,10 @@ pub fn validate_config_semantics(config: &Config) -> Result<(), validator::Valid
     trace!("Validating listeners");
     validate_listeners(config, &route_ids, &mut errors);
 
+    // Validate ACME domains (global uniqueness)
+    trace!("Validating ACME domains");
+    validate_acme_domains(config, &mut errors);
+
     // Validate filters
     trace!("Validating filters");
     validate_filters(config, &agent_ids, &mut errors);
@@ -573,6 +577,49 @@ fn validate_listeners(config: &Config, route_ids: &HashSet<&str>, errors: &mut V
                     default_route,
                     format_available(route_ids)
                 ));
+            }
+        }
+    }
+}
+
+/// Validate ACME domains across all configurations (global uniqueness)
+fn validate_acme_domains(config: &Config, errors: &mut Vec<String>) {
+    let mut domain_source: HashMap<String, String> = HashMap::new();
+
+    for listener in &config.listeners {
+        // 1. Root-level ACME for listener
+        if let Some(ref tls) = listener.tls {
+            if let Some(ref acme) = tls.acme {
+                for domain in &acme.domains {
+                    let domain_lower = domain.to_lowercase();
+                    let source = format!("listener '{}' (root acme)", listener.id);
+                    if let Some(prev_source) = domain_source.insert(domain_lower, source.clone()) {
+                        errors.push(format!(
+                            "Domain '{}' is configured in multiple ACME blocks: {} and {}.\n\
+                             Each domain must be managed by exactly one ACME block to avoid conflicts.",
+                            domain, prev_source, source
+                        ));
+                    }
+                }
+            }
+
+            // 2. SNI-level ACME certificates
+            for (i, sni) in tls.additional_certs.iter().enumerate() {
+                if let Some(ref acme) = sni.acme {
+                    for domain in &acme.domains {
+                        let domain_lower = domain.to_lowercase();
+                        let source = format!("listener '{}' (sni cert #{})", listener.id, i);
+                        if let Some(prev_source) =
+                            domain_source.insert(domain_lower, source.clone())
+                        {
+                            errors.push(format!(
+                                "Domain '{}' is configured in multiple ACME blocks: {} and {}.\n\
+                                 Each domain must be managed by exactly one ACME block to avoid conflicts.",
+                                domain, prev_source, source
+                            ));
+                        }
+                    }
+                }
             }
         }
     }

--- a/crates/gateway/src/translator.rs
+++ b/crates/gateway/src/translator.rs
@@ -442,8 +442,9 @@ impl ConfigTranslator {
                     additional_certs.push(SniCertificate {
                         hostnames: cert.hostnames.clone(),
                         priority_hostnames: vec![],
-                        cert_file: cert.cert_path,
-                        key_file: cert.key_path,
+                        cert_file: Some(cert.cert_path),
+                        key_file: Some(cert.key_path),
+                        acme: None,
                     });
                 }
                 Err(e) => {

--- a/crates/proxy/docs/acme.md
+++ b/crates/proxy/docs/acme.md
@@ -279,14 +279,62 @@ pub struct ZentinelProxy {
     /// ACME challenge manager for HTTP-01 validation
     pub acme_challenges: Option<Arc<ChallengeManager>>,
 
-    /// ACME client for certificate operations
-    pub acme_client: Option<Arc<AcmeClient>>,
+    /// ACME clients for certificate operations (one per config block)
+    pub acme_clients: Vec<Arc<AcmeClient>>,
 }
 ```
 
+## Multi-tenant ACME (SNI Support)
+
+Zentinel supports independent ACME certificate management for SNI blocks. This is ideal for multi-tenant environments where each tenant has its own domain and requires a separate certificate with potentially different account details or challenge types.
+
+### Independent Renewal Schedulers
+
+When multiple ACME blocks are configured (root level or within SNI blocks), Zentinel spawns independent background schedulers for each. This ensures that a failure or delay in one tenant's certificate issuance (e.g., waiting for DNS propagation) does not block or impact the renewal process of other tenants.
+
+### Implicit Hostname Derivation
+
+For better usability, SNI blocks with ACME can automatically derive their routing hostnames from the ACME domain list if explicit `hostnames` are not provided.
+
+```kdl
+listeners {
+    listener "https" {
+        tls {
+            // Root certificate (fallback)
+            acme {
+                email "admin@example.com"
+                domains "example.com"
+            }
+
+            // Tenant A - using HTTP-01
+            sni {
+                acme {
+                    email "tenant-a@example.com"
+                    domains "tenant-a.com"
+                }
+            }
+
+            // Tenant B - using DNS-01 for wildcard
+            sni {
+                acme {
+                    email "tenant-b@example.com"
+                    domains "*.tenant-b.com" "tenant-b.com"
+                    challenge-type "dns-01"
+                    dns-provider { ... }
+                }
+            }
+        }
+    }
+}
+```
+
+### Global Domain Validation
+
+To prevent storage path collisions and race conditions, Zentinel enforces global uniqueness for ACME-managed domains. A domain cannot appear in more than one ACME block across the entire configuration.
+
 ## Configuration
 
-ACME is configured within the `tls {}` block of a listener.
+ACME is configured within the `tls {}` block of a listener or an `sni {}` block.
 
 ### HTTP-01 Challenge (Default)
 

--- a/crates/proxy/src/acme/scheduler.rs
+++ b/crates/proxy/src/acme/scheduler.rs
@@ -64,6 +64,11 @@ impl RenewalScheduler {
         }
     }
 
+    /// Get the ACME client
+    pub fn client(&self) -> &Arc<AcmeClient> {
+        &self.client
+    }
+
     /// Set the DNS-01 challenge manager
     ///
     /// Required when using DNS-01 challenge type.

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -77,6 +77,7 @@ pub mod scoped_routing;
 pub mod shadow;
 pub mod static_files;
 pub mod tls;
+pub mod tls_metrics;
 pub mod trace_id;
 pub mod upstream;
 pub mod validation;

--- a/crates/proxy/src/main.rs
+++ b/crates/proxy/src/main.rs
@@ -20,7 +20,7 @@ use pingora::prelude::*;
 use std::sync::Arc;
 use tracing::{error, info, warn};
 
-use zentinel_config::server::AcmeChallengeType;
+use zentinel_config::server::{AcmeChallengeType, AcmeConfig};
 use zentinel_config::Config;
 use zentinel_proxy::acme::{
     AcmeClient, AcmeError, CertificateStorage, ChallengeManager, RenewalScheduler,
@@ -359,19 +359,17 @@ fn lint_config(config_path: Option<&str>) -> Result<()> {
 struct AcmeState {
     /// Challenge manager for HTTP-01 challenge handling
     challenge_manager: Arc<ChallengeManager>,
-    /// ACME client for certificate operations
-    acme_client: Arc<AcmeClient>,
-    /// Renewal scheduler (consumed by spawning its `run()` loop)
-    scheduler: RenewalScheduler,
+    /// Renewal schedulers (one per ACME configuration block)
+    schedulers: Vec<RenewalScheduler>,
 }
 
-/// Initialize ACME for all listeners that have ACME configured
+/// Initialize ACME for all listeners and SNI certificates that have ACME configured
 ///
 /// This function:
-/// 1. Creates storage, client, and challenge manager for each ACME listener
+/// 1. Creates storage, client, and challenge manager for each ACME configuration
 /// 2. Initializes (or loads) the ACME account with Let's Encrypt
 /// 3. Obtains initial certificates if they don't exist yet
-/// 4. Returns the ACME state for wiring into the proxy and background scheduler
+/// 4. Returns the ACME state for wiring into the proxy and background schedulers
 ///
 /// For HTTP-01 challenges during initial issuance, a temporary HTTP server is
 /// spawned to serve challenge responses (since Pingora isn't running yet).
@@ -379,146 +377,159 @@ async fn initialize_acme(
     config: &Config,
     sni_resolver: Option<Arc<HotReloadableSniResolver>>,
 ) -> Result<Option<AcmeState>, AcmeError> {
-    // Find the first HTTPS listener with ACME configured
-    let acme_listener = config.listeners.iter().find(|l| {
-        l.protocol == zentinel_config::ListenerProtocol::Https
-            && l.tls.as_ref().is_some_and(|t| t.acme.is_some())
-    });
+    // Collect all ACME configurations from listeners and SNI blocks
+    let mut acme_configs: Vec<(String, AcmeConfig)> = Vec::new();
 
-    let acme_listener = match acme_listener {
-        Some(l) => l,
-        None => return Ok(None),
-    };
+    for listener in &config.listeners {
+        if listener.protocol == zentinel_config::ListenerProtocol::Https {
+            if let Some(ref tls) = listener.tls {
+                // Root-level ACME
+                if let Some(ref acme) = tls.acme {
+                    acme_configs.push((format!("listener '{}' (root)", listener.id), acme.clone()));
+                }
 
-    let tls_config = acme_listener.tls.as_ref().unwrap();
-    let acme_config = tls_config.acme.as_ref().unwrap();
-
-    info!(
-        listener_id = %acme_listener.id,
-        domains = ?acme_config.domains,
-        staging = acme_config.staging,
-        challenge_type = ?acme_config.challenge_type,
-        "Initializing ACME certificate management"
-    );
-
-    // Create storage
-    let storage = Arc::new(CertificateStorage::new(&acme_config.storage)?);
-
-    // Create client and initialize account
-    let acme_client = Arc::new(AcmeClient::new(acme_config.clone(), Arc::clone(&storage)));
-    acme_client.init_account().await?;
-
-    // Create challenge manager
-    let challenge_manager = Arc::new(ChallengeManager::new());
-
-    // Create renewal scheduler
-    let mut scheduler = RenewalScheduler::new(
-        Arc::clone(&acme_client),
-        Arc::clone(&challenge_manager),
-        sni_resolver,
-    );
-
-    // If DNS-01, set up DNS challenge manager
-    if acme_config.challenge_type == AcmeChallengeType::Dns01 {
-        if let Some(ref dns_config) = acme_config.dns_provider {
-            let provider = zentinel_proxy::acme::dns::create_provider(dns_config)?;
-
-            let nameservers: Vec<std::net::IpAddr> = dns_config
-                .propagation
-                .nameservers
-                .iter()
-                .filter_map(|s| s.parse().ok())
-                .collect();
-
-            let propagation_config = zentinel_proxy::acme::dns::PropagationConfig {
-                initial_delay: std::time::Duration::from_secs(
-                    dns_config.propagation.initial_delay_secs,
-                ),
-                check_interval: std::time::Duration::from_secs(
-                    dns_config.propagation.check_interval_secs,
-                ),
-                timeout: std::time::Duration::from_secs(dns_config.propagation.timeout_secs),
-                nameservers,
-            };
-
-            let dns_manager = Arc::new(zentinel_proxy::acme::dns::Dns01ChallengeManager::new(
-                provider,
-                propagation_config,
-            )?);
-            scheduler = scheduler.with_dns_manager(dns_manager);
+                // SNI-level ACME
+                for (i, sni) in tls.additional_certs.iter().enumerate() {
+                    if let Some(ref acme) = sni.acme {
+                        acme_configs.push((
+                            format!("listener '{}' (sni cert #{})", listener.id, i),
+                            acme.clone(),
+                        ));
+                    }
+                }
+            }
         }
     }
 
-    // Check if initial certificate issuance is needed
-    let primary_domain = acme_config
-        .domains
-        .first()
-        .ok_or_else(|| AcmeError::OrderCreation("No domains configured for ACME".to_string()))?;
+    if acme_configs.is_empty() {
+        return Ok(None);
+    }
 
-    if acme_client.needs_renewal(primary_domain)? {
+    info!(
+        config_count = acme_configs.len(),
+        "Initializing ACME certificate management for multiple configurations"
+    );
+
+    // Shared challenge manager for all HTTP-01 challenges on this proxy instance
+    let challenge_manager = Arc::new(ChallengeManager::new());
+    let mut schedulers = Vec::new();
+
+    for (description, acme_config) in acme_configs {
         info!(
-            domain = %primary_domain,
-            "Initial certificate issuance required"
+            source = %description,
+            domains = ?acme_config.domains,
+            staging = acme_config.staging,
+            challenge_type = ?acme_config.challenge_type,
+            "Initializing ACME for {}", description
         );
 
-        match acme_config.challenge_type {
-            AcmeChallengeType::Http01 => {
-                // Find an HTTP listener address for the temporary challenge server
-                let http_addr = config
-                    .listeners
+        // Create storage
+        let storage = Arc::new(CertificateStorage::new(&acme_config.storage)?);
+
+        // Create client and initialize account
+        let acme_client = Arc::new(AcmeClient::new(acme_config.clone(), Arc::clone(&storage)));
+        acme_client.init_account().await?;
+
+        // Create renewal scheduler
+        let mut scheduler = RenewalScheduler::new(
+            Arc::clone(&acme_client),
+            Arc::clone(&challenge_manager),
+            sni_resolver.clone(),
+        );
+
+        // If DNS-01, set up DNS challenge manager
+        if acme_config.challenge_type == AcmeChallengeType::Dns01 {
+            if let Some(ref dns_config) = acme_config.dns_provider {
+                let provider = zentinel_proxy::acme::dns::create_provider(dns_config)?;
+
+                let nameservers: Vec<std::net::IpAddr> = dns_config
+                    .propagation
+                    .nameservers
                     .iter()
-                    .find(|l| l.protocol == zentinel_config::ListenerProtocol::Http)
-                    .map(|l| l.address.clone())
-                    .unwrap_or_else(|| "0.0.0.0:80".to_string());
+                    .filter_map(|s| s.parse().ok())
+                    .collect();
 
-                info!(
-                    address = %http_addr,
-                    "Starting temporary HTTP challenge server for initial certificate acquisition"
-                );
+                let propagation_config = zentinel_proxy::acme::dns::PropagationConfig {
+                    initial_delay: std::time::Duration::from_secs(
+                        dns_config.propagation.initial_delay_secs,
+                    ),
+                    check_interval: std::time::Duration::from_secs(
+                        dns_config.propagation.check_interval_secs,
+                    ),
+                    timeout: std::time::Duration::from_secs(dns_config.propagation.timeout_secs),
+                    nameservers,
+                };
 
-                // Start temporary challenge server
-                let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
-                let cm_clone = Arc::clone(&challenge_manager);
-                let server_handle = tokio::spawn(async move {
-                    zentinel_proxy::acme::challenge_server::run_challenge_server(
-                        &http_addr,
-                        cm_clone,
-                        shutdown_rx,
-                    )
-                    .await
-                });
-
-                // Give the server a moment to bind
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-
-                // Obtain certificates
-                let result = scheduler.ensure_certificates().await;
-
-                // Shut down temporary server
-                let _ = shutdown_tx.send(true);
-                let _ =
-                    tokio::time::timeout(std::time::Duration::from_secs(5), server_handle).await;
-
-                result?;
-            }
-            AcmeChallengeType::Dns01 => {
-                // DNS-01 doesn't need an HTTP server
-                scheduler.ensure_certificates().await?;
+                let dns_manager = Arc::new(zentinel_proxy::acme::dns::Dns01ChallengeManager::new(
+                    provider,
+                    propagation_config,
+                )?);
+                scheduler = scheduler.with_dns_manager(dns_manager);
             }
         }
 
-        info!("Initial ACME certificate acquisition completed");
-    } else {
-        info!(
-            domain = %primary_domain,
-            "ACME certificates already exist and are valid"
-        );
+        // Check if initial certificate issuance is needed
+        let primary_domain = acme_config.domains.first().ok_or_else(|| {
+            AcmeError::OrderCreation(format!("No domains configured for ACME in {}", description))
+        })?;
+
+        if acme_client.needs_renewal(primary_domain)? {
+            info!(
+                source = %description,
+                domain = %primary_domain,
+                "Initial certificate issuance required"
+            );
+
+            match acme_config.challenge_type {
+                AcmeChallengeType::Http01 => {
+                    // Find an HTTP listener address for the temporary challenge server
+                    let http_addr = config
+                        .listeners
+                        .iter()
+                        .find(|l| l.protocol == zentinel_config::ListenerProtocol::Http)
+                        .map(|l| l.address.clone())
+                        .unwrap_or_else(|| "0.0.0.0:80".to_string());
+
+                    info!(
+                        address = %http_addr,
+                        "Starting temporary HTTP challenge server for initial certificate acquisition"
+                    );
+
+                    // Start temporary challenge server
+                    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+                    let cm_clone = Arc::clone(&challenge_manager);
+                    let _server_handle = tokio::spawn(async move {
+                        zentinel_proxy::acme::challenge_server::run_challenge_server(
+                            &http_addr,
+                            cm_clone,
+                            shutdown_rx,
+                        )
+                        .await
+                    });
+
+                    // Give the server a moment to bind
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+                    // Obtain certificates
+                    let result = scheduler.ensure_certificates().await;
+
+                    // Shut down temporary server
+                    let _ = shutdown_tx.send(true);
+                    result?;
+                }
+                AcmeChallengeType::Dns01 => {
+                    // DNS-01 doesn't need a temporary server
+                    scheduler.ensure_certificates().await?;
+                }
+            }
+        }
+
+        schedulers.push(scheduler);
     }
 
     Ok(Some(AcmeState {
         challenge_manager,
-        acme_client,
-        scheduler,
+        schedulers,
     }))
 }
 
@@ -603,7 +614,11 @@ fn run_server(
     // Wire ACME components into the proxy
     if let Some(ref state) = acme_state {
         proxy.acme_challenges = Some(Arc::clone(&state.challenge_manager));
-        proxy.acme_client = Some(Arc::clone(&state.acme_client));
+        proxy.acme_clients = state
+            .schedulers
+            .iter()
+            .map(|s| Arc::clone(s.client()))
+            .collect();
     }
 
     // Initialize OpenTelemetry tracer if configured
@@ -839,12 +854,18 @@ fn run_server(
         warn!("Auto-reload requires a config file path");
     }
 
-    // Spawn ACME renewal scheduler as a background task
+    // Spawn ACME renewal schedulers as background tasks
     if let Some(state) = acme_state {
-        runtime.spawn(async move {
-            state.scheduler.run().await;
-        });
-        info!("ACME certificate renewal scheduler started");
+        let scheduler_count = state.schedulers.len();
+        for scheduler in state.schedulers {
+            runtime.spawn(async move {
+                scheduler.run().await;
+            });
+        }
+        info!(
+            count = scheduler_count,
+            "ACME certificate renewal schedulers started"
+        );
     }
 
     // Spawn signal handler task in the runtime

--- a/crates/proxy/src/proxy/mod.rs
+++ b/crates/proxy/src/proxy/mod.rs
@@ -114,9 +114,9 @@ pub struct ZentinelProxy {
     /// ACME challenge manager for HTTP-01 challenge handling
     /// Present only when ACME is configured for at least one listener
     pub acme_challenges: Option<Arc<crate::acme::ChallengeManager>>,
-    /// ACME client for certificate management
+    /// ACME clients for certificate management
     /// Present only when ACME is configured
-    pub acme_client: Option<Arc<crate::acme::AcmeClient>>,
+    pub acme_clients: Vec<Arc<crate::acme::AcmeClient>>,
 }
 
 impl ZentinelProxy {
@@ -332,6 +332,11 @@ impl ZentinelProxy {
             warn!("Failed to initialize model routing metrics: {}", e);
         }
 
+        // Initialize TLS metrics (best-effort, log warning if fails)
+        if let Err(e) = crate::tls_metrics::init_tls_metrics() {
+            warn!("Failed to initialize TLS metrics: {}", e);
+        }
+
         Ok(Self {
             config_manager,
             route_matcher,
@@ -359,7 +364,7 @@ impl ZentinelProxy {
             guardrail_processor,
             // ACME challenge manager - initialized later if ACME is configured
             acme_challenges: None,
-            acme_client: None,
+            acme_clients: Vec::new(),
         })
     }
 

--- a/crates/proxy/src/tls.rs
+++ b/crates/proxy/src/tls.rs
@@ -129,7 +129,9 @@ pub struct SniResolver {
 
 impl SniResolver {
     /// Create a new SNI resolver from TLS configuration
-    pub fn from_config(config: &TlsConfig) -> Result<Self, TlsError> {
+    pub fn from_config(config: &TlsConfig, listener_id: Option<&str>) -> Result<Self, TlsError> {
+        let listener_id_str = listener_id.unwrap_or("unknown");
+
         // Get cert_file and key_file - manual certs or ACME-managed paths
         let (cert_path_buf, key_path_buf);
         let (cert_file, key_file) = match (&config.cert_file, &config.key_file) {
@@ -156,6 +158,7 @@ impl SniResolver {
         let default_cert = load_certified_key(cert_file, key_file)?;
 
         info!(
+            listener_id = %listener_id_str,
             cert_file = %cert_file.display(),
             "Loaded default TLS certificate"
         );
@@ -170,9 +173,55 @@ impl SniResolver {
         let mut priority_wildcard: HashSet<String> = HashSet::new();
 
         // Load SNI certificates
-        for sni_config in &config.additional_certs {
-            let cert = load_certified_key(&sni_config.cert_file, &sni_config.key_file)?;
-            let cert = Arc::new(cert);
+        for (i, sni_config) in config.additional_certs.iter().enumerate() {
+            // Resolve paths for this SNI cert
+            let (sni_cert_path_buf, sni_key_path_buf);
+            let (sni_cert_path, sni_key_path) = match (&sni_config.cert_file, &sni_config.key_file)
+            {
+                (Some(cert), Some(key)) => (cert.as_path(), key.as_path()),
+                _ if sni_config.acme.is_some() => {
+                    let acme = sni_config.acme.as_ref().unwrap();
+                    let primary = acme.domains.first().ok_or_else(|| {
+                        TlsError::ConfigBuild("SNI ACME configuration has no domains".to_string())
+                    })?;
+                    sni_cert_path_buf = acme.storage.join("domains").join(primary).join("cert.pem");
+                    sni_key_path_buf = acme.storage.join("domains").join(primary).join("key.pem");
+                    (sni_cert_path_buf.as_path(), sni_key_path_buf.as_path())
+                }
+                _ => unreachable!("Config validation ensures certs or acme"),
+            };
+
+            let cert = match load_certified_key(sni_cert_path, sni_key_path) {
+                Ok(cert) => Arc::new(cert),
+                Err(e) => {
+                    // If ACME is configured, the certificate might not exist yet.
+                    // We log a warning and skip this certificate for now.
+                    // It will be loaded later via hot-reload once issued.
+                    if let Some(acme) = &sni_config.acme {
+                        let primary = acme
+                            .domains
+                            .first()
+                            .map(|s| s.as_str())
+                            .unwrap_or("unknown");
+                        warn!(
+                            listener_id = %listener_id_str,
+                            sni_index = i,
+                            primary_domain = %primary,
+                            error = %e,
+                            "ACME SNI certificate not yet available, skipping initial load"
+                        );
+
+                        // Record metric for observability
+                        if let Some(metrics) = crate::tls_metrics::get_tls_metrics() {
+                            metrics.record_sni_cert_skip(listener_id_str, primary);
+                        }
+
+                        continue;
+                    } else {
+                        return Err(e);
+                    }
+                }
+            };
 
             // Build priority set for this cert (lowercased for consistent matching)
             let priority_set: HashSet<String> = sni_config
@@ -182,37 +231,40 @@ impl SniResolver {
                 .collect();
             let has_priority = !priority_set.is_empty();
 
-            // Determine hostnames: use explicit config or auto-extract from certificate.
-            // When priority_hostnames is set, we always auto-extract (hostnames will be
-            // empty due to mutual exclusion validation in the config parser).
-            let hostnames = if sni_config.hostnames.is_empty() {
-                let extracted =
-                    extract_hostnames_from_cert(cert.cert.first().ok_or_else(|| {
-                        TlsError::InvalidCertificate(format!(
-                            "No certificates in chain for {:?}",
-                            sni_config.cert_file
-                        ))
-                    })?)?;
-
-                if has_priority {
-                    info!(
-                        cert_file = %sni_config.cert_file.display(),
-                        hostnames = ?extracted,
-                        priority_hostnames = ?sni_config.priority_hostnames,
-                        "Auto-extracted hostnames from certificate CN/SAN (with priority tie-breaking)"
-                    );
-                } else {
-                    info!(
-                        cert_file = %sni_config.cert_file.display(),
-                        hostnames = ?extracted,
-                        "Auto-extracted hostnames from certificate CN/SAN"
-                    );
-                }
-
-                extracted
-            } else {
+            // Determine hostnames: use explicit config, acme domains, or auto-extract from certificate.
+            let hostnames = if !sni_config.hostnames.is_empty() {
                 sni_config.hostnames.clone()
+            } else if !priority_set.is_empty() {
+                // When priority_hostnames is set, we always auto-extract.
+                extract_hostnames_from_cert(cert.cert.first().unwrap())?
+            } else if let Some(ref acme) = sni_config.acme {
+                // If ACME is present and no explicit hostnames, use ACME domains.
+                acme.domains.clone()
+            } else {
+                // Fallback to auto-extraction
+                extract_hostnames_from_cert(cert.cert.first().unwrap())?
             };
+
+            if has_priority {
+                info!(
+                    cert_file = %sni_cert_path.display(),
+                    hostnames = ?hostnames,
+                    priority_hostnames = ?sni_config.priority_hostnames,
+                    "Loaded SNI certificate with priority tie-breaking"
+                );
+            } else if sni_config.hostnames.is_empty() && sni_config.acme.is_none() {
+                info!(
+                    cert_file = %sni_cert_path.display(),
+                    hostnames = ?hostnames,
+                    "Loaded SNI certificate (auto-extracted hostnames)"
+                );
+            } else {
+                info!(
+                    cert_file = %sni_cert_path.display(),
+                    hostnames = ?hostnames,
+                    "Loaded SNI certificate"
+                );
+            }
 
             for hostname in &hostnames {
                 let hostname_lower = hostname.to_lowercase();
@@ -231,14 +283,14 @@ impl SniResolver {
                                 return Err(TlsError::ConfigBuild(format!(
                                     "Conflicting priority-hostnames: wildcard '*.{}' is claimed as priority by multiple certificates (including {:?}).",
                                     domain,
-                                    sni_config.cert_file
+                                    sni_cert_path
                                 )));
                             } else if is_priority {
                                 // New cert has priority, overwrite the existing one
                                 debug!(
                                     pattern = %hostname,
                                     domain = %domain,
-                                    cert_file = %sni_config.cert_file.display(),
+                                    cert_file = %sni_cert_path.display(),
                                     "Priority wildcard SNI certificate overwrites previous registration"
                                 );
                             } else if existing_has_priority {
@@ -246,7 +298,7 @@ impl SniResolver {
                                 debug!(
                                     pattern = %hostname,
                                     domain = %domain,
-                                    cert_file = %sni_config.cert_file.display(),
+                                    cert_file = %sni_cert_path.display(),
                                     "Skipping wildcard SNI registration, existing cert has priority"
                                 );
                                 continue;
@@ -256,7 +308,7 @@ impl SniResolver {
                                     "Ambiguous SNI configuration: wildcard '*.{}' matches multiple certificates (including {:?}). \
                                      Use explicit 'hostnames' or 'priority-hostnames' to resolve the conflict.",
                                     domain,
-                                    sni_config.cert_file
+                                    sni_cert_path
                                 )));
                             }
                         }
@@ -270,7 +322,7 @@ impl SniResolver {
                         pattern = %hostname,
                         domain = %domain,
                         priority = is_priority,
-                        cert_file = %sni_config.cert_file.display(),
+                        cert_file = %sni_cert_path.display(),
                         "Registered wildcard SNI certificate"
                     );
                 } else {
@@ -284,20 +336,20 @@ impl SniResolver {
                                 return Err(TlsError::ConfigBuild(format!(
                                     "Conflicting priority-hostnames: hostname '{}' is claimed as priority by multiple certificates (including {:?}).",
                                     hostname_lower,
-                                    sni_config.cert_file
+                                    sni_cert_path
                                 )));
                             } else if is_priority {
                                 // New cert has priority, overwrite
                                 debug!(
                                     hostname = %hostname_lower,
-                                    cert_file = %sni_config.cert_file.display(),
+                                    cert_file = %sni_cert_path.display(),
                                     "Priority SNI certificate overwrites previous registration"
                                 );
                             } else if existing_has_priority {
                                 // Existing cert has priority, skip
                                 debug!(
                                     hostname = %hostname_lower,
-                                    cert_file = %sni_config.cert_file.display(),
+                                    cert_file = %sni_cert_path.display(),
                                     "Skipping SNI registration, existing cert has priority"
                                 );
                                 continue;
@@ -307,7 +359,7 @@ impl SniResolver {
                                     "Ambiguous SNI configuration: hostname '{}' matches multiple certificates (including {:?}). \
                                      Use explicit 'hostnames' or 'priority-hostnames' to resolve the conflict.",
                                     hostname_lower,
-                                    sni_config.cert_file
+                                    sni_cert_path
                                 )));
                             }
                         }
@@ -320,7 +372,7 @@ impl SniResolver {
                     debug!(
                         hostname = %hostname_lower,
                         priority = is_priority,
-                        cert_file = %sni_config.cert_file.display(),
+                        cert_file = %sni_cert_path.display(),
                         "Registered SNI certificate"
                     );
                 }
@@ -328,6 +380,7 @@ impl SniResolver {
         }
 
         info!(
+            listener_id = %listener_id_str,
             exact_certs = sni_certs.len(),
             wildcard_certs = wildcard_certs.len(),
             "SNI resolver initialized"
@@ -401,6 +454,8 @@ pub struct HotReloadableSniResolver {
     inner: RwLock<Arc<SniResolver>>,
     /// Original config for reloading
     config: RwLock<TlsConfig>,
+    /// Listener ID for observability
+    listener_id: String,
     /// Last reload time
     last_reload: RwLock<Instant>,
 }
@@ -409,18 +464,24 @@ impl std::fmt::Debug for HotReloadableSniResolver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HotReloadableSniResolver")
             .field("last_reload", &*self.last_reload.read())
+            .field("listener_id", &self.listener_id)
             .finish()
     }
 }
 
 impl HotReloadableSniResolver {
     /// Create a new hot-reloadable resolver from TLS configuration
-    pub fn from_config(config: TlsConfig) -> Result<Self, TlsError> {
-        let resolver = SniResolver::from_config(&config)?;
+    pub fn from_config(
+        config: TlsConfig,
+        listener_id: impl Into<String>,
+    ) -> Result<Self, TlsError> {
+        let listener_id = listener_id.into();
+        let resolver = SniResolver::from_config(&config, Some(&listener_id))?;
 
         Ok(Self {
             inner: RwLock::new(Arc::new(resolver)),
             config: RwLock::new(config),
+            listener_id,
             last_reload: RwLock::new(Instant::now()),
         })
     }
@@ -439,33 +500,40 @@ impl HotReloadableSniResolver {
             .unwrap_or_else(|| "(acme-managed)".to_string());
 
         info!(
+            listener_id = %self.listener_id,
             cert_file = %cert_file_display,
             sni_count = config.additional_certs.len(),
             "Reloading TLS certificates"
         );
 
         // Try to load new certificates
-        let new_resolver = SniResolver::from_config(&config)?;
+        let new_resolver = SniResolver::from_config(&config, Some(&self.listener_id))?;
 
         // Swap in the new resolver atomically
         *self.inner.write() = Arc::new(new_resolver);
         *self.last_reload.write() = Instant::now();
 
-        info!("TLS certificates reloaded successfully");
+        info!(
+            listener_id = %self.listener_id,
+            "TLS certificates reloaded successfully"
+        );
         Ok(())
     }
 
     /// Update configuration and reload
     pub fn update_config(&self, new_config: TlsConfig) -> Result<(), TlsError> {
         // Load with new config first
-        let new_resolver = SniResolver::from_config(&new_config)?;
+        let new_resolver = SniResolver::from_config(&new_config, Some(&self.listener_id))?;
 
         // Update both config and resolver
         *self.config.write() = new_config;
         *self.inner.write() = Arc::new(new_resolver);
         *self.last_reload.write() = Instant::now();
 
-        info!("TLS configuration updated and certificates reloaded");
+        info!(
+            listener_id = %self.listener_id,
+            "TLS configuration updated and certificates reloaded"
+        );
         Ok(())
     }
 
@@ -1471,8 +1539,11 @@ fn resolve_cipher_suites(names: &[String]) -> Result<Vec<rustls::SupportedCipher
 /// A future update to the Pingora fork should accept a pre-built
 /// `ServerConfig` via `TlsSettings`, at which point this function's
 /// output will be wired into the listener setup.
-pub fn build_server_config(config: &TlsConfig) -> Result<ServerConfig, TlsError> {
-    let resolver = SniResolver::from_config(config)?;
+pub fn build_server_config(
+    config: &TlsConfig,
+    listener_id: &str,
+) -> Result<ServerConfig, TlsError> {
+    let resolver = SniResolver::from_config(config, Some(listener_id))?;
 
     // Resolve protocol versions from config
     let versions = resolve_protocol_versions(config);
@@ -1577,17 +1648,33 @@ pub fn validate_tls_config(config: &TlsConfig) -> Result<(), TlsError> {
 
     // Check SNI certificates
     for sni in &config.additional_certs {
-        if !sni.cert_file.exists() {
-            return Err(TlsError::CertificateLoad(format!(
-                "SNI certificate file not found: {}",
-                sni.cert_file.display()
-            )));
+        // If ACME is configured for this SNI cert, skip existence check
+        if sni.acme.is_some() {
+            trace!("Skipping manual cert validation for ACME-managed SNI certificate");
+            continue;
         }
-        if !sni.key_file.exists() {
-            return Err(TlsError::KeyLoad(format!(
-                "SNI key file not found: {}",
-                sni.key_file.display()
-            )));
+
+        // Standard certificate validation
+        match (&sni.cert_file, &sni.key_file) {
+            (Some(cert_file), Some(key_file)) => {
+                if !cert_file.exists() {
+                    return Err(TlsError::CertificateLoad(format!(
+                        "SNI certificate file not found: {}",
+                        cert_file.display()
+                    )));
+                }
+                if !key_file.exists() {
+                    return Err(TlsError::KeyLoad(format!(
+                        "SNI key file not found: {}",
+                        key_file.display()
+                    )));
+                }
+            }
+            _ => {
+                return Err(TlsError::ConfigBuild(
+                    "SNI certificate requires cert_file and key_file (or ACME block)".to_string(),
+                ));
+            }
         }
     }
 

--- a/crates/proxy/src/tls_metrics.rs
+++ b/crates/proxy/src/tls_metrics.rs
@@ -1,0 +1,58 @@
+//! TLS-related Prometheus metrics.
+//!
+//! Provides metrics for tracking certificate status, resolution,
+//! and SNI cold-start events.
+
+use anyhow::{Context, Result};
+use once_cell::sync::OnceCell;
+use prometheus::{register_int_counter_vec, IntCounterVec};
+use std::sync::Arc;
+
+/// Global TLS metrics instance.
+static TLS_METRICS: OnceCell<Arc<TlsMetrics>> = OnceCell::new();
+
+/// Get or initialize the global TLS metrics.
+pub fn get_tls_metrics() -> Option<Arc<TlsMetrics>> {
+    TLS_METRICS.get().cloned()
+}
+
+/// Initialize the global TLS metrics.
+pub fn init_tls_metrics() -> Result<Arc<TlsMetrics>> {
+    if let Some(metrics) = TLS_METRICS.get() {
+        return Ok(metrics.clone());
+    }
+
+    let metrics = Arc::new(TlsMetrics::new()?);
+    let _ = TLS_METRICS.set(metrics.clone());
+    Ok(metrics)
+}
+
+/// TLS metrics collector.
+pub struct TlsMetrics {
+    /// Number of SNI certificates skipped at startup due to missing files (ACME)
+    /// Labels: listener, primary_domain
+    sni_certs_skipped_total: IntCounterVec,
+}
+
+impl TlsMetrics {
+    /// Create new TLS metrics and register with Prometheus.
+    pub fn new() -> Result<Self> {
+        let sni_certs_skipped_total = register_int_counter_vec!(
+            "zentinel_tls_sni_certs_skipped_total",
+            "Total number of SNI certificates skipped during initialization (usually pending ACME issuance)",
+            &["listener", "primary_domain"]
+        )
+        .context("Failed to register zentinel_tls_sni_certs_skipped_total metric")?;
+
+        Ok(Self {
+            sni_certs_skipped_total,
+        })
+    }
+
+    /// Record an SNI certificate skip event.
+    pub fn record_sni_cert_skip(&self, listener_id: &str, primary_domain: &str) {
+        self.sni_certs_skipped_total
+            .with_label_values(&[listener_id, primary_domain])
+            .inc();
+    }
+}

--- a/crates/proxy/tests/acme_startup_test.rs
+++ b/crates/proxy/tests/acme_startup_test.rs
@@ -85,7 +85,7 @@ mod storage_resolver_integration {
         };
 
         // SniResolver should load the cert files that storage wrote
-        let resolver = SniResolver::from_config(&config);
+        let resolver = SniResolver::from_config(&config, Some("test-listener"));
         assert!(
             resolver.is_ok(),
             "SniResolver should load storage-managed certs: {:?}",

--- a/crates/proxy/tests/tls_sni_test.rs
+++ b/crates/proxy/tests/tls_sni_test.rs
@@ -51,14 +51,16 @@ fn multi_sni_tls_config() -> TlsConfig {
             SniCertificate {
                 hostnames: vec!["api.example.com".to_string()],
                 priority_hostnames: vec![],
-                cert_file: fixtures.join("server-api.crt"),
-                key_file: fixtures.join("server-api.key"),
+                cert_file: Some(fixtures.join("server-api.crt")),
+                key_file: Some(fixtures.join("server-api.key")),
+                acme: None,
             },
             SniCertificate {
                 hostnames: vec!["secure.example.com".to_string()],
                 priority_hostnames: vec![],
-                cert_file: fixtures.join("server-secure.crt"),
-                key_file: fixtures.join("server-secure.key"),
+                cert_file: Some(fixtures.join("server-secure.crt")),
+                key_file: Some(fixtures.join("server-secure.key")),
+                acme: None,
             },
         ],
         ca_file: None,
@@ -81,8 +83,9 @@ fn wildcard_tls_config() -> TlsConfig {
         additional_certs: vec![SniCertificate {
             hostnames: vec!["*.example.com".to_string()],
             priority_hostnames: vec![],
-            cert_file: fixtures.join("server-wildcard.crt"),
-            key_file: fixtures.join("server-wildcard.key"),
+            cert_file: Some(fixtures.join("server-wildcard.crt")),
+            key_file: Some(fixtures.join("server-wildcard.key")),
+            acme: None,
         }],
         ca_file: None,
         min_version: zentinel_common::types::TlsVersion::Tls12,
@@ -123,7 +126,7 @@ mod sni_resolver {
     #[test]
     fn test_create_from_minimal_config() {
         let config = minimal_tls_config();
-        let resolver = SniResolver::from_config(&config);
+        let resolver = SniResolver::from_config(&config, Some("test-listener"));
         assert!(
             resolver.is_ok(),
             "Failed to create resolver: {:?}",
@@ -134,7 +137,7 @@ mod sni_resolver {
     #[test]
     fn test_create_from_multi_sni_config() {
         let config = multi_sni_tls_config();
-        let resolver = SniResolver::from_config(&config);
+        let resolver = SniResolver::from_config(&config, Some("test-listener"));
         assert!(
             resolver.is_ok(),
             "Failed to create resolver: {:?}",
@@ -145,7 +148,7 @@ mod sni_resolver {
     #[test]
     fn test_create_from_wildcard_config() {
         let config = wildcard_tls_config();
-        let resolver = SniResolver::from_config(&config);
+        let resolver = SniResolver::from_config(&config, Some("test-listener"));
         assert!(
             resolver.is_ok(),
             "Failed to create resolver: {:?}",
@@ -156,7 +159,7 @@ mod sni_resolver {
     #[test]
     fn test_resolve_without_sni_returns_default() {
         let config = multi_sni_tls_config();
-        let resolver = SniResolver::from_config(&config).unwrap();
+        let resolver = SniResolver::from_config(&config, Some("test-listener")).unwrap();
 
         // When no SNI is provided, should return default cert
         let cert = resolver.resolve(None);
@@ -166,7 +169,7 @@ mod sni_resolver {
     #[test]
     fn test_resolve_unknown_hostname_returns_default() {
         let config = multi_sni_tls_config();
-        let resolver = SniResolver::from_config(&config).unwrap();
+        let resolver = SniResolver::from_config(&config, Some("test-listener")).unwrap();
 
         // Unknown hostname should fall back to default
         let cert = resolver.resolve(Some("unknown.example.org"));
@@ -176,7 +179,7 @@ mod sni_resolver {
     #[test]
     fn test_case_insensitive_matching() {
         let config = multi_sni_tls_config();
-        let resolver = SniResolver::from_config(&config).unwrap();
+        let resolver = SniResolver::from_config(&config, Some("test-listener")).unwrap();
 
         // All these should match the same cert
         let cert1 = resolver.resolve(Some("api.example.com"));
@@ -197,7 +200,7 @@ mod sni_resolver {
     #[test]
     fn test_different_sni_hostnames_return_different_certs() {
         let config = multi_sni_tls_config();
-        let resolver = SniResolver::from_config(&config).unwrap();
+        let resolver = SniResolver::from_config(&config, Some("test-listener")).unwrap();
 
         let api_cert = resolver.resolve(Some("api.example.com"));
         let secure_cert = resolver.resolve(Some("secure.example.com"));
@@ -212,7 +215,7 @@ mod sni_resolver {
     #[test]
     fn test_wildcard_matching() {
         let config = wildcard_tls_config();
-        let resolver = SniResolver::from_config(&config).unwrap();
+        let resolver = SniResolver::from_config(&config, Some("test-listener")).unwrap();
 
         // These should all match *.example.com
         let wildcard_cert = resolver.resolve(Some("foo.example.com"));
@@ -227,7 +230,7 @@ mod sni_resolver {
     #[test]
     fn test_wildcard_does_not_match_exact_domain() {
         let config = wildcard_tls_config();
-        let resolver = SniResolver::from_config(&config).unwrap();
+        let resolver = SniResolver::from_config(&config, Some("test-listener")).unwrap();
 
         // *.example.com should NOT match example.com (no subdomain)
         // This should fall back to the default certificate
@@ -245,7 +248,7 @@ mod sni_resolver {
     #[test]
     fn test_multi_level_subdomain_wildcard_matching() {
         let config = wildcard_tls_config();
-        let resolver = SniResolver::from_config(&config).unwrap();
+        let resolver = SniResolver::from_config(&config, Some("test-listener")).unwrap();
 
         // *.example.com should match foo.bar.example.com because we try multiple levels
         let deep_cert = resolver.resolve(Some("foo.bar.example.com"));
@@ -269,14 +272,16 @@ mod sni_resolver {
                 SniCertificate {
                     hostnames: vec!["*.example.com".to_string()],
                     priority_hostnames: vec![],
-                    cert_file: fixtures.join("server-wildcard.crt"),
-                    key_file: fixtures.join("server-wildcard.key"),
+                    cert_file: Some(fixtures.join("server-wildcard.crt")),
+                    key_file: Some(fixtures.join("server-wildcard.key")),
+                    acme: None,
                 },
                 SniCertificate {
                     hostnames: vec!["api.example.com".to_string()],
                     priority_hostnames: vec![],
-                    cert_file: fixtures.join("server-api.crt"),
-                    key_file: fixtures.join("server-api.key"),
+                    cert_file: Some(fixtures.join("server-api.crt")),
+                    key_file: Some(fixtures.join("server-api.key")),
+                    acme: None,
                 },
             ],
             ca_file: None,
@@ -289,7 +294,7 @@ mod sni_resolver {
             acme: None,
         };
 
-        let resolver = SniResolver::from_config(&config).unwrap();
+        let resolver = SniResolver::from_config(&config, Some("test-listener")).unwrap();
 
         // api.example.com should use exact match, not wildcard
         let api_cert = resolver.resolve(Some("api.example.com"));
@@ -320,7 +325,7 @@ mod sni_resolver {
             acme: None,
         };
 
-        let result = SniResolver::from_config(&config);
+        let result = SniResolver::from_config(&config, Some("test-listener"));
         assert!(result.is_err());
         match result.unwrap_err() {
             TlsError::CertificateLoad(_) => {}
@@ -345,7 +350,7 @@ mod sni_resolver {
             acme: None,
         };
 
-        let result = SniResolver::from_config(&config);
+        let result = SniResolver::from_config(&config, Some("test-listener"));
         assert!(result.is_err());
         match result.unwrap_err() {
             TlsError::KeyLoad(_) => {}
@@ -362,8 +367,9 @@ mod sni_resolver {
             additional_certs: vec![SniCertificate {
                 hostnames: vec!["api.example.com".to_string()],
                 priority_hostnames: vec![],
-                cert_file: fixtures.join("nonexistent.crt"),
-                key_file: fixtures.join("server-api.key"),
+                cert_file: Some(fixtures.join("nonexistent.crt")),
+                key_file: Some(fixtures.join("server-api.key")),
+                acme: None,
             }],
             ca_file: None,
             min_version: zentinel_common::types::TlsVersion::Tls12,
@@ -375,7 +381,7 @@ mod sni_resolver {
             acme: None,
         };
 
-        let result = SniResolver::from_config(&config);
+        let result = SniResolver::from_config(&config, Some("test-listener"));
         assert!(result.is_err());
     }
 }
@@ -397,8 +403,9 @@ mod sni_auto_extraction {
             additional_certs: vec![SniCertificate {
                 hostnames: vec![], // Empty: auto-extract from cert
                 priority_hostnames: vec![],
-                cert_file: fixtures.join("server-api.crt"),
-                key_file: fixtures.join("server-api.key"),
+                cert_file: Some(fixtures.join("server-api.crt")),
+                key_file: Some(fixtures.join("server-api.key")),
+                acme: None,
             }],
             ca_file: None,
             min_version: zentinel_common::types::TlsVersion::Tls12,
@@ -415,7 +422,7 @@ mod sni_auto_extraction {
     fn test_auto_extract_resolves_san_hostname() {
         // server-api.crt has SAN: DNS:api.example.com, DNS:localhost
         let config = auto_extract_tls_config();
-        let resolver = SniResolver::from_config(&config).unwrap();
+        let resolver = SniResolver::from_config(&config, Some("test-listener")).unwrap();
 
         let api_cert = resolver.resolve(Some("api.example.com"));
         let default_cert = resolver.resolve(Some("unknown.example.com"));
@@ -431,7 +438,7 @@ mod sni_auto_extraction {
     fn test_auto_extract_resolves_all_san_entries() {
         // server-api.crt has SAN: DNS:api.example.com, DNS:localhost
         let config = auto_extract_tls_config();
-        let resolver = SniResolver::from_config(&config).unwrap();
+        let resolver = SniResolver::from_config(&config, Some("test-listener")).unwrap();
 
         let api_cert = resolver.resolve(Some("api.example.com"));
         let localhost_cert = resolver.resolve(Some("localhost"));
@@ -453,8 +460,9 @@ mod sni_auto_extraction {
             additional_certs: vec![SniCertificate {
                 hostnames: vec![], // Auto-extract
                 priority_hostnames: vec![],
-                cert_file: fixtures.join("server-wildcard.crt"),
-                key_file: fixtures.join("server-wildcard.key"),
+                cert_file: Some(fixtures.join("server-wildcard.crt")),
+                key_file: Some(fixtures.join("server-wildcard.key")),
+                acme: None,
             }],
             ca_file: None,
             min_version: zentinel_common::types::TlsVersion::Tls12,
@@ -466,7 +474,7 @@ mod sni_auto_extraction {
             acme: None,
         };
 
-        let resolver = SniResolver::from_config(&config).unwrap();
+        let resolver = SniResolver::from_config(&config, Some("test-listener")).unwrap();
 
         // *.example.com wildcard should match subdomains
         let sub_cert = resolver.resolve(Some("foo.example.com"));
@@ -491,14 +499,16 @@ mod sni_auto_extraction {
                 SniCertificate {
                     hostnames: vec!["secure.example.com".to_string()], // Explicit
                     priority_hostnames: vec![],
-                    cert_file: fixtures.join("server-secure.crt"),
-                    key_file: fixtures.join("server-secure.key"),
+                    cert_file: Some(fixtures.join("server-secure.crt")),
+                    key_file: Some(fixtures.join("server-secure.key")),
+                    acme: None,
                 },
                 SniCertificate {
                     hostnames: vec![], // Auto-extract from server-api.crt
                     priority_hostnames: vec![],
-                    cert_file: fixtures.join("server-api.crt"),
-                    key_file: fixtures.join("server-api.key"),
+                    cert_file: Some(fixtures.join("server-api.crt")),
+                    key_file: Some(fixtures.join("server-api.key")),
+                    acme: None,
                 },
             ],
             ca_file: None,
@@ -511,7 +521,7 @@ mod sni_auto_extraction {
             acme: None,
         };
 
-        let resolver = SniResolver::from_config(&config).unwrap();
+        let resolver = SniResolver::from_config(&config, Some("test-listener")).unwrap();
 
         let secure_cert = resolver.resolve(Some("secure.example.com"));
         let api_cert = resolver.resolve(Some("api.example.com"));
@@ -534,14 +544,16 @@ mod sni_auto_extraction {
                 SniCertificate {
                     hostnames: vec![], // Auto-extract: SAN includes "localhost"
                     priority_hostnames: vec![],
-                    cert_file: fixtures.join("server-api.crt"),
-                    key_file: fixtures.join("server-api.key"),
+                    cert_file: Some(fixtures.join("server-api.crt")),
+                    key_file: Some(fixtures.join("server-api.key")),
+                    acme: None,
                 },
                 SniCertificate {
                     hostnames: vec![], // Auto-extract: SAN also includes "localhost"
                     priority_hostnames: vec![],
-                    cert_file: fixtures.join("server-secure.crt"),
-                    key_file: fixtures.join("server-secure.key"),
+                    cert_file: Some(fixtures.join("server-secure.crt")),
+                    key_file: Some(fixtures.join("server-secure.key")),
+                    acme: None,
                 },
             ],
             ca_file: None,
@@ -554,7 +566,7 @@ mod sni_auto_extraction {
             acme: None,
         };
 
-        let result = SniResolver::from_config(&config);
+        let result = SniResolver::from_config(&config, Some("test-listener"));
         assert!(
             result.is_err(),
             "Overlapping auto-extracted hostnames should error"
@@ -578,8 +590,9 @@ mod sni_auto_extraction {
             additional_certs: vec![SniCertificate {
                 hostnames: vec!["custom.example.com".to_string()], // Explicit, not in cert
                 priority_hostnames: vec![],
-                cert_file: fixtures.join("server-api.crt"),
-                key_file: fixtures.join("server-api.key"),
+                cert_file: Some(fixtures.join("server-api.crt")),
+                key_file: Some(fixtures.join("server-api.key")),
+                acme: None,
             }],
             ca_file: None,
             min_version: zentinel_common::types::TlsVersion::Tls12,
@@ -591,7 +604,7 @@ mod sni_auto_extraction {
             acme: None,
         };
 
-        let resolver = SniResolver::from_config(&config).unwrap();
+        let resolver = SniResolver::from_config(&config, Some("test-listener")).unwrap();
 
         // Should match the explicit hostname
         let custom_cert = resolver.resolve(Some("custom.example.com"));
@@ -672,7 +685,7 @@ mod acme_resolver {
         .unwrap();
 
         let config = acme_tls_config(temp_dir.path().to_path_buf());
-        let resolver = SniResolver::from_config(&config);
+        let resolver = SniResolver::from_config(&config, Some("test-listener"));
         assert!(
             resolver.is_ok(),
             "SniResolver should load ACME-managed certs: {:?}",
@@ -691,7 +704,7 @@ mod acme_resolver {
         // Clear domains
         config.acme.as_mut().unwrap().domains.clear();
 
-        let result = SniResolver::from_config(&config);
+        let result = SniResolver::from_config(&config, Some("test-listener"));
         assert!(result.is_err(), "Empty domains should fail");
         match result.unwrap_err() {
             TlsError::ConfigBuild(msg) => {
@@ -721,7 +734,7 @@ mod acme_resolver {
             acme: None,
         };
 
-        let result = SniResolver::from_config(&config);
+        let result = SniResolver::from_config(&config, Some("test-listener"));
         assert!(result.is_err(), "No cert and no ACME should fail");
         match result.unwrap_err() {
             TlsError::ConfigBuild(msg) => {
@@ -744,7 +757,7 @@ mod acme_resolver {
         std::fs::create_dir_all(&domain_dir).unwrap();
 
         let config = acme_tls_config(temp_dir.path().to_path_buf());
-        let result = SniResolver::from_config(&config);
+        let result = SniResolver::from_config(&config, Some("test-listener"));
         assert!(result.is_err(), "Missing ACME cert files should fail");
         match result.unwrap_err() {
             TlsError::CertificateLoad(_) => {}
@@ -767,7 +780,7 @@ mod acme_resolver {
         std::fs::copy(fixtures.join("server-default.key"), &key_path).unwrap();
 
         let config = acme_tls_config(temp_dir.path().to_path_buf());
-        let resolver = HotReloadableSniResolver::from_config(config).unwrap();
+        let resolver = HotReloadableSniResolver::from_config(config, "test-listener").unwrap();
 
         let cert_before = resolver.resolve(None);
 
@@ -788,6 +801,238 @@ mod acme_resolver {
             "Certificate should change after reload with new ACME cert files"
         );
     }
+
+    #[test]
+    fn test_from_config_with_sni_acme_implicit_hostnames() {
+        // This test verifies that an SNI block with ACME but no explicit hostnames
+        // correctly derives its routing hostnames from the ACME domain list.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let domain_dir = temp_dir.path().join("domains").join("tenant.com");
+        std::fs::create_dir_all(&domain_dir).unwrap();
+
+        let fixtures = fixtures_path();
+        std::fs::copy(fixtures.join("server-api.crt"), domain_dir.join("cert.pem")).unwrap();
+        std::fs::copy(fixtures.join("server-api.key"), domain_dir.join("key.pem")).unwrap();
+
+        let config = TlsConfig {
+            cert_file: Some(fixtures.join("server-default.crt")),
+            key_file: Some(fixtures.join("server-default.key")),
+            additional_certs: vec![SniCertificate {
+                hostnames: vec![], // Implicit: should use acme.domains
+                priority_hostnames: vec![],
+                cert_file: None,
+                key_file: None,
+                acme: Some(AcmeConfig {
+                    email: "tenant@example.com".to_string(),
+                    domains: vec!["tenant.com".to_string(), "www.tenant.com".to_string()],
+                    server_url: None,
+                    staging: true,
+                    eab: None,
+                    storage: temp_dir.path().to_path_buf(),
+                    renew_before_days: 30,
+                    challenge_type: AcmeChallengeType::Http01,
+                    key_type: AcmeKeyType::EcdsaP256,
+                    dns_provider: None,
+                }),
+            }],
+            ca_file: None,
+            min_version: zentinel_common::types::TlsVersion::Tls12,
+            max_version: None,
+            cipher_suites: vec![],
+            client_auth: false,
+            ocsp_stapling: false,
+            session_resumption: true,
+            acme: None,
+        };
+
+        let resolver = SniResolver::from_config(&config, Some("test-listener")).unwrap();
+
+        // Should resolve for both domains in the ACME list
+        let cert1 = resolver.resolve(Some("tenant.com"));
+        let cert2 = resolver.resolve(Some("www.tenant.com"));
+        let default_cert = resolver.resolve(Some("other.com"));
+
+        assert!(
+            !Arc::ptr_eq(&cert1, &default_cert),
+            "Should match tenant.com"
+        );
+        assert!(
+            Arc::ptr_eq(&cert1, &cert2),
+            "Both domains should use same cert"
+        );
+    }
+
+    #[test]
+    fn test_implicit_wildcard_derivation() {
+        // Verify that implicit derivation handles wildcards correctly.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let domain_dir = temp_dir.path().join("domains").join("*.wildcard.com");
+        std::fs::create_dir_all(&domain_dir).unwrap();
+
+        let fixtures = fixtures_path();
+        std::fs::copy(fixtures.join("server-api.crt"), domain_dir.join("cert.pem")).unwrap();
+        std::fs::copy(fixtures.join("server-api.key"), domain_dir.join("key.pem")).unwrap();
+
+        let config = TlsConfig {
+            cert_file: Some(fixtures.join("server-default.crt")),
+            key_file: Some(fixtures.join("server-default.key")),
+            additional_certs: vec![SniCertificate {
+                hostnames: vec![],
+                priority_hostnames: vec![],
+                cert_file: None,
+                key_file: None,
+                acme: Some(AcmeConfig {
+                    email: "test@example.com".to_string(),
+                    domains: vec!["*.wildcard.com".to_string()],
+                    server_url: None,
+                    staging: true,
+                    eab: None,
+                    storage: temp_dir.path().to_path_buf(),
+                    renew_before_days: 30,
+                    challenge_type: AcmeChallengeType::Http01,
+                    key_type: AcmeKeyType::EcdsaP256,
+                    dns_provider: None,
+                }),
+            }],
+            ca_file: None,
+            min_version: zentinel_common::types::TlsVersion::Tls12,
+            max_version: None,
+            cipher_suites: vec![],
+            client_auth: false,
+            ocsp_stapling: false,
+            session_resumption: true,
+            acme: None,
+        };
+
+        let resolver = SniResolver::from_config(&config, Some("test")).unwrap();
+        let matched = resolver.resolve(Some("sub.wildcard.com"));
+        let default_cert = resolver.resolve(Some("other.com"));
+        assert!(
+            !Arc::ptr_eq(&matched, &default_cert),
+            "Wildcard SNI should match"
+        );
+    }
+
+    #[test]
+    fn test_cold_start_skip_behavior() {
+        // Verify that missing ACME files result in skipped entries instead of errors.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let fixtures = fixtures_path();
+
+        let config = TlsConfig {
+            cert_file: Some(fixtures.join("server-default.crt")),
+            key_file: Some(fixtures.join("server-default.key")),
+            additional_certs: vec![SniCertificate {
+                hostnames: vec!["app.com".to_string()],
+                priority_hostnames: vec![],
+                cert_file: None,
+                key_file: None,
+                acme: Some(AcmeConfig {
+                    email: "test@example.com".to_string(),
+                    domains: vec!["app.com".to_string()],
+                    server_url: None,
+                    staging: true,
+                    eab: None,
+                    storage: temp_dir.path().to_path_buf(),
+                    renew_before_days: 30,
+                    challenge_type: AcmeChallengeType::Http01,
+                    key_type: AcmeKeyType::EcdsaP256,
+                    dns_provider: None,
+                }),
+            }],
+            ca_file: None,
+            min_version: zentinel_common::types::TlsVersion::Tls12,
+            max_version: None,
+            cipher_suites: vec![],
+            client_auth: false,
+            ocsp_stapling: false,
+            session_resumption: true,
+            acme: None,
+        };
+
+        // This should NOT fail even though the cert file is missing
+        let resolver = SniResolver::from_config(&config, Some("test"));
+        assert!(resolver.is_ok(), "Cold start should skip, not fail");
+    }
+
+    #[test]
+    fn test_validate_acme_domains_case_insensitive() {
+        use zentinel_config::Config;
+
+        // We'll test this via the actual semantic validation logic
+        let kdl = r#"
+system {
+    worker-threads 1
+}
+listeners {
+    listener "https" {
+        address "0.0.0.0:443"
+        protocol "https"
+        tls {
+            acme {
+                email "admin@example.com"
+                domains "Example.COM"
+            }
+            sni {
+                acme {
+                    email "user@example.com"
+                    domains "example.com"
+                }
+            }
+        }
+    }
+}
+"#;
+        let config = Config::from_kdl(kdl).unwrap();
+        // We verify our logic in validation.rs works.
+        let result = config.validate();
+        assert!(
+            result.is_err(),
+            "Should have caught duplicate domain with different case"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("example.com")
+                && err_msg.contains("configured in multiple ACME blocks")
+        );
+    }
+
+    #[test]
+    fn test_sni_certificate_mutual_exclusion() {
+        use zentinel_config::Config;
+
+        // Test that specifying both manual files and acme fails
+        let kdl = r#"
+system { worker-threads 1 }
+listeners {
+    listener "https" {
+        address "0.0.0.0:443"
+        protocol "https"
+        tls {
+            cert-file "test.crt"
+            key-file "test.key"
+            sni {
+                cert-file "sni.crt"
+                key-file "sni.key"
+                acme {
+                    email "test@example.com"
+                    domains "example.com"
+                }
+            }
+        }
+    }
+}
+"#;
+        let result = Config::from_kdl(kdl);
+        assert!(
+            result.is_err(),
+            "Should fail when both manual files and acme are present"
+        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("cannot specify both manual files and an 'acme' block"));
+    }
 }
 
 // ============================================================================
@@ -800,14 +1045,14 @@ mod hot_reload {
     #[test]
     fn test_create_hot_reloadable_resolver() {
         let config = minimal_tls_config();
-        let resolver = HotReloadableSniResolver::from_config(config);
+        let resolver = HotReloadableSniResolver::from_config(config, "test-listener");
         assert!(resolver.is_ok());
     }
 
     #[test]
     fn test_hot_reload_success() {
         let config = minimal_tls_config();
-        let resolver = HotReloadableSniResolver::from_config(config).unwrap();
+        let resolver = HotReloadableSniResolver::from_config(config, "test-listener").unwrap();
 
         // Reload should succeed (certs haven't changed)
         let result = resolver.reload();
@@ -817,7 +1062,7 @@ mod hot_reload {
     #[test]
     fn test_last_reload_age() {
         let config = minimal_tls_config();
-        let resolver = HotReloadableSniResolver::from_config(config).unwrap();
+        let resolver = HotReloadableSniResolver::from_config(config, "test-listener").unwrap();
 
         let age1 = resolver.last_reload_age();
         std::thread::sleep(std::time::Duration::from_millis(10));
@@ -829,7 +1074,7 @@ mod hot_reload {
     #[test]
     fn test_reload_resets_age() {
         let config = minimal_tls_config();
-        let resolver = HotReloadableSniResolver::from_config(config).unwrap();
+        let resolver = HotReloadableSniResolver::from_config(config, "test-listener").unwrap();
 
         std::thread::sleep(std::time::Duration::from_millis(10));
         let age_before = resolver.last_reload_age();
@@ -843,7 +1088,7 @@ mod hot_reload {
     #[test]
     fn test_hot_reload_resolves_certificates() {
         let config = multi_sni_tls_config();
-        let resolver = HotReloadableSniResolver::from_config(config).unwrap();
+        let resolver = HotReloadableSniResolver::from_config(config, "test-listener").unwrap();
 
         // Test that the hot reloadable resolver can resolve certificates
         let cert = resolver.resolve(Some("api.example.com"));
@@ -853,7 +1098,7 @@ mod hot_reload {
     #[test]
     fn test_update_config() {
         let config1 = minimal_tls_config();
-        let resolver = HotReloadableSniResolver::from_config(config1).unwrap();
+        let resolver = HotReloadableSniResolver::from_config(config1, "test-listener-1").unwrap();
 
         // Update with a multi-SNI config
         let config2 = multi_sni_tls_config();
@@ -890,7 +1135,7 @@ mod hot_reload {
             acme: None,
         };
 
-        let resolver = HotReloadableSniResolver::from_config(config).unwrap();
+        let resolver = HotReloadableSniResolver::from_config(config, "test-listener").unwrap();
 
         // Get initial certificate
         let cert_before = resolver.resolve(None);
@@ -943,7 +1188,7 @@ mod hot_reload {
             acme: None,
         };
 
-        let resolver = HotReloadableSniResolver::from_config(config).unwrap();
+        let resolver = HotReloadableSniResolver::from_config(config, "test-listener").unwrap();
         let cert_before = resolver.resolve(None);
 
         // Replace with invalid cert content
@@ -989,7 +1234,7 @@ mod hot_reload {
             acme: None,
         };
 
-        let resolver = HotReloadableSniResolver::from_config(config).unwrap();
+        let resolver = HotReloadableSniResolver::from_config(config, "test-listener").unwrap();
         let cert_before = resolver.resolve(None);
 
         // Delete the certificate file
@@ -1029,7 +1274,8 @@ mod certificate_reloader {
     fn test_register_single_resolver() {
         let reloader = CertificateReloader::new();
         let config = minimal_tls_config();
-        let resolver = Arc::new(HotReloadableSniResolver::from_config(config).unwrap());
+        let resolver =
+            Arc::new(HotReloadableSniResolver::from_config(config, "test-listener").unwrap());
 
         reloader.register("https-main", resolver);
 
@@ -1043,11 +1289,13 @@ mod certificate_reloader {
         let reloader = CertificateReloader::new();
 
         let config1 = minimal_tls_config();
-        let resolver1 = Arc::new(HotReloadableSniResolver::from_config(config1).unwrap());
+        let resolver1 =
+            Arc::new(HotReloadableSniResolver::from_config(config1, "test-listener-1").unwrap());
         reloader.register("https-main", resolver1);
 
         let config2 = multi_sni_tls_config();
-        let resolver2 = Arc::new(HotReloadableSniResolver::from_config(config2).unwrap());
+        let resolver2 =
+            Arc::new(HotReloadableSniResolver::from_config(config2, "test-listener-2").unwrap());
         reloader.register("https-api", resolver2);
 
         let status = reloader.status();
@@ -1061,11 +1309,13 @@ mod certificate_reloader {
         let reloader = CertificateReloader::new();
 
         let config1 = minimal_tls_config();
-        let resolver1 = Arc::new(HotReloadableSniResolver::from_config(config1).unwrap());
+        let resolver1 =
+            Arc::new(HotReloadableSniResolver::from_config(config1, "test-listener-1").unwrap());
         reloader.register("https-main", resolver1);
 
         let config2 = multi_sni_tls_config();
-        let resolver2 = Arc::new(HotReloadableSniResolver::from_config(config2).unwrap());
+        let resolver2 =
+            Arc::new(HotReloadableSniResolver::from_config(config2, "test-listener-2").unwrap());
         reloader.register("https-api", resolver2);
 
         // Reload all - should succeed
@@ -1083,7 +1333,8 @@ mod certificate_reloader {
 
         // First resolver with valid config
         let config1 = minimal_tls_config();
-        let resolver1 = Arc::new(HotReloadableSniResolver::from_config(config1).unwrap());
+        let resolver1 =
+            Arc::new(HotReloadableSniResolver::from_config(config1, "test-listener-1").unwrap());
         reloader.register("https-valid", resolver1);
 
         // Second resolver with temp files that we'll delete
@@ -1108,7 +1359,8 @@ mod certificate_reloader {
             session_resumption: true,
             acme: None,
         };
-        let resolver2 = Arc::new(HotReloadableSniResolver::from_config(config2).unwrap());
+        let resolver2 =
+            Arc::new(HotReloadableSniResolver::from_config(config2, "test-listener-2").unwrap());
         reloader.register("https-will-fail", resolver2);
 
         // Delete the cert file for the second resolver
@@ -1129,7 +1381,8 @@ mod certificate_reloader {
         let reloader = CertificateReloader::new();
 
         let config = minimal_tls_config();
-        let resolver = Arc::new(HotReloadableSniResolver::from_config(config).unwrap());
+        let resolver =
+            Arc::new(HotReloadableSniResolver::from_config(config, "test-listener").unwrap());
         reloader.register("https-main", resolver);
 
         let status_before = reloader.status();
@@ -1148,7 +1401,8 @@ mod certificate_reloader {
         let reloader = CertificateReloader::new();
 
         let config = minimal_tls_config();
-        let resolver = Arc::new(HotReloadableSniResolver::from_config(config).unwrap());
+        let resolver =
+            Arc::new(HotReloadableSniResolver::from_config(config, "test-listener").unwrap());
         reloader.register("https-main", resolver);
 
         std::thread::sleep(std::time::Duration::from_millis(10));
@@ -1255,8 +1509,9 @@ mod validation {
             additional_certs: vec![SniCertificate {
                 hostnames: vec!["test.example.com".to_string()],
                 priority_hostnames: vec![],
-                cert_file: fixtures.join("nonexistent.crt"),
-                key_file: fixtures.join("server-api.key"),
+                cert_file: Some(fixtures.join("nonexistent.crt")),
+                key_file: Some(fixtures.join("server-api.key")),
+                acme: None,
             }],
             ca_file: None,
             min_version: zentinel_common::types::TlsVersion::Tls12,
@@ -1314,7 +1569,7 @@ mod server_config {
     fn test_build_server_config_minimal() {
         ensure_crypto_provider();
         let config = minimal_tls_config();
-        let result = build_server_config(&config);
+        let result = build_server_config(&config, "test-listener");
         assert!(
             result.is_ok(),
             "Failed to build server config: {:?}",
@@ -1331,7 +1586,7 @@ mod server_config {
     fn test_build_server_config_with_sni() {
         ensure_crypto_provider();
         let config = multi_sni_tls_config();
-        let result = build_server_config(&config);
+        let result = build_server_config(&config, "test-listener");
         assert!(
             result.is_ok(),
             "Failed to build server config with SNI: {:?}",
@@ -1343,7 +1598,7 @@ mod server_config {
     fn test_build_server_config_with_mtls() {
         ensure_crypto_provider();
         let config = mtls_tls_config();
-        let result = build_server_config(&config);
+        let result = build_server_config(&config, "test-listener");
         assert!(
             result.is_ok(),
             "Failed to build mTLS server config: {:?}",
@@ -1355,7 +1610,7 @@ mod server_config {
     fn test_build_server_config_with_wildcard() {
         ensure_crypto_provider();
         let config = wildcard_tls_config();
-        let result = build_server_config(&config);
+        let result = build_server_config(&config, "test-listener");
         assert!(
             result.is_ok(),
             "Failed to build wildcard server config: {:?}",
@@ -1381,14 +1636,16 @@ mod server_config {
                 SniCertificate {
                     hostnames: vec![],
                     priority_hostnames: vec!["localhost".to_string()],
-                    cert_file: fixtures.join("server-api.crt"),
-                    key_file: fixtures.join("server-api.key"),
+                    cert_file: Some(fixtures.join("server-api.crt")),
+                    key_file: Some(fixtures.join("server-api.key")),
+                    acme: None,
                 },
                 SniCertificate {
                     hostnames: vec![],
                     priority_hostnames: vec![],
-                    cert_file: fixtures.join("server-secure.crt"),
-                    key_file: fixtures.join("server-secure.key"),
+                    cert_file: Some(fixtures.join("server-secure.crt")),
+                    key_file: Some(fixtures.join("server-secure.key")),
+                    acme: None,
                 },
             ],
             ca_file: None,
@@ -1401,7 +1658,7 @@ mod server_config {
             acme: None,
         };
 
-        let resolver = SniResolver::from_config(&config).unwrap();
+        let resolver = SniResolver::from_config(&config, Some("test-listener")).unwrap();
 
         // "localhost" should resolve to server-api.crt (the priority cert)
         let localhost_cert = resolver.resolve(Some("localhost"));
@@ -1430,8 +1687,9 @@ mod server_config {
             additional_certs: vec![SniCertificate {
                 hostnames: vec![],
                 priority_hostnames: vec!["localhost".to_string()],
-                cert_file: fixtures.join("server-api.crt"),
-                key_file: fixtures.join("server-api.key"),
+                cert_file: Some(fixtures.join("server-api.crt")),
+                key_file: Some(fixtures.join("server-api.key")),
+                acme: None,
             }],
             ca_file: None,
             min_version: zentinel_common::types::TlsVersion::Tls12,
@@ -1443,7 +1701,7 @@ mod server_config {
             acme: None,
         };
 
-        let resolver = SniResolver::from_config(&config).unwrap();
+        let resolver = SniResolver::from_config(&config, Some("test-listener")).unwrap();
         let default_cert = resolver.resolve(Some("unknown.example.com"));
 
         // All SANs should be registered, not just the priority one
@@ -1470,14 +1728,16 @@ mod server_config {
                 SniCertificate {
                     hostnames: vec![],
                     priority_hostnames: vec!["localhost".to_string()],
-                    cert_file: fixtures.join("server-api.crt"),
-                    key_file: fixtures.join("server-api.key"),
+                    cert_file: Some(fixtures.join("server-api.crt")),
+                    key_file: Some(fixtures.join("server-api.key")),
+                    acme: None,
                 },
                 SniCertificate {
                     hostnames: vec![],
                     priority_hostnames: vec!["localhost".to_string()],
-                    cert_file: fixtures.join("server-secure.crt"),
-                    key_file: fixtures.join("server-secure.key"),
+                    cert_file: Some(fixtures.join("server-secure.crt")),
+                    key_file: Some(fixtures.join("server-secure.key")),
+                    acme: None,
                 },
             ],
             ca_file: None,
@@ -1490,7 +1750,7 @@ mod server_config {
             acme: None,
         };
 
-        let result = SniResolver::from_config(&config);
+        let result = SniResolver::from_config(&config, Some("test-listener"));
         assert!(
             result.is_err(),
             "Conflicting priority-hostnames should error"
@@ -1516,14 +1776,16 @@ mod server_config {
                 SniCertificate {
                     hostnames: vec![],
                     priority_hostnames: vec!["localhost".to_string()],
-                    cert_file: fixtures.join("server-wildcard.crt"),
-                    key_file: fixtures.join("server-wildcard.key"),
+                    cert_file: Some(fixtures.join("server-wildcard.crt")),
+                    key_file: Some(fixtures.join("server-wildcard.key")),
+                    acme: None,
                 },
                 SniCertificate {
                     hostnames: vec![],
                     priority_hostnames: vec![],
-                    cert_file: fixtures.join("server-api.crt"),
-                    key_file: fixtures.join("server-api.key"),
+                    cert_file: Some(fixtures.join("server-api.crt")),
+                    key_file: Some(fixtures.join("server-api.key")),
+                    acme: None,
                 },
             ],
             ca_file: None,
@@ -1536,7 +1798,7 @@ mod server_config {
             acme: None,
         };
 
-        let resolver = SniResolver::from_config(&config).unwrap();
+        let resolver = SniResolver::from_config(&config, Some("test-listener")).unwrap();
 
         // "localhost" should resolve to server-wildcard.crt
         let localhost_cert = resolver.resolve(Some("localhost"));
@@ -1567,14 +1829,16 @@ mod server_config {
                 SniCertificate {
                     hostnames: vec![],
                     priority_hostnames: vec![],
-                    cert_file: fixtures.join("server-secure.crt"),
-                    key_file: fixtures.join("server-secure.key"),
+                    cert_file: Some(fixtures.join("server-secure.crt")),
+                    key_file: Some(fixtures.join("server-secure.key")),
+                    acme: None,
                 },
                 SniCertificate {
                     hostnames: vec![],
                     priority_hostnames: vec!["localhost".to_string()],
-                    cert_file: fixtures.join("server-api.crt"),
-                    key_file: fixtures.join("server-api.key"),
+                    cert_file: Some(fixtures.join("server-api.crt")),
+                    key_file: Some(fixtures.join("server-api.key")),
+                    acme: None,
                 },
             ],
             ca_file: None,
@@ -1587,7 +1851,7 @@ mod server_config {
             acme: None,
         };
 
-        let resolver = SniResolver::from_config(&config).unwrap();
+        let resolver = SniResolver::from_config(&config, Some("test-listener")).unwrap();
 
         // "localhost" should resolve to server-api.crt (priority), even though
         // server-secure.crt was registered first and also has "localhost" in SAN


### PR DESCRIPTION
## Summary

This PR enables independent ACME certificate management for SNI blocks, a key feature for multi-tenant TLS environments. It allows different tenants/domains on the same listener to have their own ACME configurations (e.g., different account emails, storage locations, or challenge providers) and independent renewal cycles.

### Key Changes:
- **Configuration Model**: Extended `SniCertificate` to support an optional `acme` block. Manual certificate paths (`cert-file`/`key-file`) are now optional when ACME is configured.
- **Option B Scheduler Architecture**: Refactored the ACME initialization logic to instantiate a separate `RenewalScheduler` and `AcmeClient` for every ACME configuration block. This provides full isolation: a failure or delay in one domain's issuance (e.g., DNS propagation) won't stall the renewal of others.
- **Global Domain Validation**: Added a semantic validator that ensures every domain is managed by exactly one ACME block across the entire configuration, preventing physical storage path collisions and renewal race conditions.
- **Implicit Hostname Derivation**: Streamlined configuration by allowing SNI blocks to automatically use their ACME `domains` for routing if explicit `hostnames` are omitted.
- **Downstream Consistency**: Updated `zentinel-gateway` and existing TLS tests to align with the new `SniCertificate` schema.

### Design Rationale: Design Rationale for Implicit Hostname Derivation

A key design choice in this PR is allowing the SNI block to omit the `hostnames` node when an `acme` block is present. In such cases, routing hostnames are automatically derived from the `acme.domains` list. This design is based on the following technical considerations:

#### 1. Unified Wildcard Support
Zentinel’s `SniResolver` and the ACME protocol (via DNS-01 challenges) share identical rules for wildcard patterns. In `crates/proxy/src/tls.rs`, the resolver explicitly checks if a hostname starts with `*.`. If it does, the certificate is registered in a dedicated `wildcard_certs` lookup table. Since ACME wildcard requests use the same `*.` prefix, the domains listed in an ACME block are perfectly compatible with the SNI matching engine.

#### 2. Resolution Precedence
To maintain flexibility while ensuring "no implicit behavior" by default, we implemented a strict precedence for hostname registration:
1. **Explicit Hostnames**: If the user provides a `hostnames` list, it is used exclusively.
2. **ACME Domains (New)**: If `hostnames` is omitted but `acme` is configured, the domain list from the ACME block is used for routing.
3. **Certificate Extraction**: If neither is provided, the proxy falls back to extracting SAN/CN values from the issued certificate on disk.

#### 3. Solving the "Cold Start" Problem
Without this derivation logic, a listener configured with ACME but no explicit hostnames would face a "chicken and egg" problem: the `SniResolver` cannot extract hostnames from a certificate that has not yet been issued. By using the intended domains defined in the `acme` block, the proxy can correctly register SNI routes immediately upon startup, ensuring that once the background task completes the challenge flow, the routing is already pre-configured and ready to serve traffic after the first hot-reload.

#### 4. Safety via Global Validation
The risk of routing ambiguity (e.g., two ACME blocks claiming the same domain) is mitigated by the newly introduced **Global Domain Uniqueness Check**. The semantic validator ensures that any domain (exact or wildcard) is managed by exactly one ACME block across the entire proxy configuration, preventing physical storage collisions and ensuring deterministic SNI resolution.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes - reorganized initialization for scalability)

## Manifesto Alignment

- [x] **Bounded** — Implemented "Option B" renewal architecture. Every tenant's ACME flow is isolated in its own background task, bounding the blast radius of network or provider failures.
- [x] **Observable** — Initialization logs now include a `source` field (e.g., `source="listener 'https' (sni cert #0)"`) to provide clear visibility into which configuration block is being processed.
- [x] **Fails safely** — Introduced strict global validation to prevent misconfigurations. The proxy gracefully skips loading unissued ACME certificates on startup, relying on the hot-reload mechanism once the scheduler completes the issuance.
- [x] **No implicit behavior** — While supporting implicit hostnames for better DX, the behavior is explicitly validated and can be overridden by providing a `hostnames` list.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] My changes align with the architectural direction discussed with maintainers (Option B architecture)
- [x] My code follows the project's coding standards
- [x] I have updated existing tests and downstream components (`zentinel-gateway`) to match the new schema
- [x] All functional changes are organized into logical, clean commits

## Testing

The feature was validated through configuration linting and unit/integration tests.

1. **Conflict Detection**: Verified that the semantic validator correctly rejects configurations with overlapping ACME domains.
2. **Schema Validation**: Confirmed that `zentinel-gateway` correctly translates SNI configurations under the new model.
3. **Unit Tests**: Updated `crates/proxy/tests/tls_sni_test.rs` to verify that `SniResolver` correctly handles both manual and (simulated) ACME certificates.

```bash
# Verify global domain uniqueness check
zentinel lint --config tests/test-conflict-acme.kdl
# Output: Error: Domain '...' is configured in multiple ACME blocks...

# Verify test suite
cargo test -p zentinel-proxy --test tls_sni_test
cargo test -p zentinel-config
```

## Related Issues

See #203 

---

### Commit History Notes
This PR is organized into five focused commits:
1. `feat(config)`: Foundational model changes, global validation, and downstream adaptations (Gateway/Tests) to ensure each commit is buildable.
2. `feat(proxy)`: Core SNI resolver enhancements and proxy state updates.
3. `feat(proxy)`: Orchestration refactor for multi-scheduler support (Option B).
4. `test(proxy)`: New unit tests specifically for ACME-managed SNI certificates and implicit hostnames.
5. `docs`: Updated ACME documentation to cover multi-tenant SNI support and independent schedulers.

### Discussion: Potential SNI "Shadowing" during Cold Start

While implementing the Option B scheduler and implicit hostnames, I identified a specific behavior regarding how the proxy handles missing ACME certificates during initial startup (the "cold start" phase). I’d like to get your thoughts on whether this aligns with Zentinel’s security model.

#### The Scenario
1. **Tenant A** has a successfully issued wildcard certificate: `*.example.com`.
2. **Tenant B** adds a new SNI ACME block for a sub-domain: `app.example.com`.
3. On the first startup, Tenant B's certificate does not exist yet.
4. Currently, `SniResolver::from_config` logs a warning and **skips** the registration for Tenant B's SNI slot because the files are missing.

#### The Resulting Behavior
When a client requests `app.example.com`:
- Since Tenant B's specific SNI entry wasn't registered, the `SniResolver` follows standard TLS fallback rules.
- It will find and match **Tenant A's** wildcard certificate (`*.example.com`) because they are on the same Listener.
- The client receives Tenant A's certificate, resulting in a browser security warning (Common Name mismatch) or a "shadowing" effect where one tenant's certificate covers another's unissued domain.

#### Mitigation in this PR
- **Global Uniqueness Check**: Our new `validate_acme_domains` prevents two tenants from claiming the *exact* same domain (e.g., both claiming `app.example.com`).
- **Self-Healing**: As soon as the background ACME task completes the challenge, it triggers a hot-reload, and Tenant B correctly "reclaims" their domain with the proper certificate.

#### Question for Maintainers
Is this "temporary fallback to matching wildcard" acceptable for Zentinel, or should we implement a stricter mode? 

Possible alternatives (if current behavior is undesirable):
1. **Placeholder Mode**: Register the SNI slot even if the certificate is missing, and intentionally fail the TLS handshake for that specific domain until the cert is issued.
2. **Strict Block**: If an ACME block is defined but the cert is missing, prevent the proxy from starting (though this might break the "availability first" principle).

I believe the current behavior is the most pragmatic for a "fail-open" availability approach, but I'd appreciate your guidance on whether this constitutes a "security boundary" concern in Zentinel's multi-tenant vision.
