### PR TITLE
fix(deps): bump rand in sim crate (Dependabot alert #47)

### DIFF
--- a/crates/sim/Cargo.lock
+++ b/crates/sim/Cargo.lock
@@ -43,9 +43,9 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arc-swap"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -775,9 +775,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -893,55 +893,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "zentinel-common"
-version = "0.4.9"
-dependencies = [
- "anyhow",
- "chrono",
- "http",
- "parking_lot",
- "serde",
- "serde_json",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "zentinel-config"
-version = "0.4.9"
-dependencies = [
- "anyhow",
- "arc-swap",
- "kdl",
- "miette",
- "once_cell",
- "parking_lot",
- "zentinel-common",
- "serde",
- "serde_json",
- "thiserror",
- "toml",
- "tracing",
- "url",
- "validator",
-]
-
-[[package]]
-name = "zentinel-sim"
-version = "0.4.3"
-dependencies = [
- "insta",
- "proptest",
- "regex",
- "zentinel-common",
- "zentinel-config",
- "serde",
- "serde_json",
- "thiserror",
- "xxhash-rust",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -1131,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.11+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1141,32 +1092,32 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.14",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 0.7.14",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -1566,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"
@@ -1609,6 +1560,55 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zentinel-common"
+version = "0.6.8"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "http",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "zentinel-config"
+version = "0.6.8"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "kdl",
+ "miette",
+ "once_cell",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "toml",
+ "tracing",
+ "url",
+ "validator",
+ "zentinel-common",
+]
+
+[[package]]
+name = "zentinel-sim"
+version = "0.6.8"
+dependencies = [
+ "insta",
+ "proptest",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "xxhash-rust",
+ "zentinel-common",
+ "zentinel-config",
 ]
 
 [[package]]

--- a/crates/sim/Cargo.toml
+++ b/crates/sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-sim"
-version = "0.5.4"
+version = "0.6.8"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"
@@ -13,8 +13,8 @@ categories = ["simulation", "wasm", "network-programming"]
 
 [dependencies]
 # Local crates (WASM-compatible - disable runtime features)
-zentinel-config = { path = "../config", version = "0.5.4", default-features = false }
-zentinel-common = { path = "../common", version = "0.5.4", default-features = false }
+zentinel-config = { path = "../config", version = "0.6.8", default-features = false }
+zentinel-common = { path = "../common", version = "0.6.8", default-features = false }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/sim/src/upstream.rs
+++ b/crates/sim/src/upstream.rs
@@ -402,6 +402,7 @@ mod tests {
                 })
                 .collect(),
             load_balancing: algorithm,
+            sticky_session: None,
             health_check: None,
             connection_pool: Default::default(),
             timeouts: Default::default(),


### PR DESCRIPTION
## Summary
- Bumps `rand` from 0.9.2 → 0.9.4 in `crates/sim/Cargo.lock` to resolve [GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc) (Dependabot alert #47, low severity).
- Synced stale path-dep version pins in `crates/sim/Cargo.toml` (0.5.4 → 0.6.8) so cargo could regenerate the lockfile. The sim crate is excluded from the workspace and had drifted behind workspace versions.
- Added missing `sticky_session: None` to a test helper in `src/upstream.rs` to keep up with the `UpstreamConfig` schema.

## Notes
- Alert #54 (`rustls-webpki` < 0.103.13) is already resolved on `main` — root `Cargo.lock` has 0.103.13. The alert should auto-close on next Dependabot scan.
- Sim crate has pre-existing fmt/clippy drift (it's not in the workspace, not linted by CI). Out of scope for this security fix; left for a follow-up cleanup.

## Test plan
- [x] `cargo test --lib` in `crates/sim/` — 42 passed
- [x] `cargo check` in `crates/sim/` clean
- [ ] Dependabot rescan closes alerts #47 and #54 after merge