### PR TITLE
chore: bump version to 0.6.10 for release 26.04_7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ for details.
 
 | CalVer | Crate Version | Date | Highlights |
 |--------|---------------|------|------------|
+| [26.04_7](#26047---2026-04-28) | 0.6.10 | 2026-04-28 | Security: rand fix in `zentinel-sim` |
 | [26.04_6](#26046---2026-04-25) | 0.6.9 | 2026-04-25 | Security: openssl & rand fixes, ACME schema docs, CI update |
 | [26.04_5](#26045---2026-04-20) | 0.6.8 | 2026-04-20 | Configurable ACME certificate key type (ECDSA P-256/P-384) |
 | [26.04_4](#26044---2026-04-19) | 0.6.7 | 2026-04-19 | Cloudflare DNS-01, custom ACME servers, EAB, SAN renewal fix |
@@ -39,6 +40,15 @@ for details.
 | [26.01_0](#26010---2026-01-01) | 0.2.0 | 2026-01-01 | First CalVer release |
 | [25.12](#2512) | 0.1.x | 2025-12 | Initial public releases |
 | [24.12](#2412) | 0.1.0 | 2024-12 | Initial development |
+
+---
+
+## [26.04_7] - 2026-04-28
+
+**Crate version:** 0.6.10
+
+### Security
+- **Bump `rand` 0.9.2 → 0.9.4 in `zentinel-sim`** — closes Dependabot alert for [GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc) (rand unsoundness with custom logger using `rand::rng()`). Also re-syncs `zentinel-sim`'s stale path-dep version pins to the workspace so its lockfile is regenerable. (#214)
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8384,7 +8384,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8424,7 +8424,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8446,7 +8446,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8525,7 +8525,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8556,7 +8556,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8647,7 +8647,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8664,7 +8664,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.9"
+version = "0.6.10"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Bumps workspace version 0.6.9 → 0.6.10 (CalVer codename `26.04_7`).
- Picks up the `rand` 0.9.2 → 0.9.4 fix in `zentinel-sim` from #214 (Dependabot alert #47, GHSA-cq8v-f236-94qc).

## Test plan
- [x] `cargo build --workspace` clean at 0.6.10
- [x] `cargo update --workspace` produced no other compatible bumps
- [ ] CI green
- [ ] Tag `v0.6.10` after merge