### PR TITLE
chore(ci): run Conformance on main and group wasmtime bumps

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -227,33 +227,53 @@ This runs `fmt-check` + `lint` (clippy) + `docs-check` — the fast CI jobs that
 
 ## Release Process
 
-### Version Bump
+Zentinel uses [CalVer](https://calver.org/) (`YY.MM_PATCH`) as the operator-facing version
+and [SemVer](https://semver.org/) for crate versions on crates.io. The Release workflow
+(`.github/workflows/release.yml`) is triggered by **CalVer tags** matching
+`[0-9][0-9].[0-9][0-9]_[0-9]*` (e.g. `26.04_7`). It builds platform binaries, signs them,
+publishes all workspace crates to crates.io, and creates the GitHub Release.
 
-1. Update version in `Cargo.toml` (workspace)
-2. Update `CHANGELOG.md`
-3. Commit: `chore: bump version to X.Y.Z`
-4. Tag: `git tag vX.Y.Z`
-5. Push: `git push && git push --tags`
+### Cutting a release
 
-### Crates.io Publishing
+1. **Bump PR**: open `chore/bump-X.Y.Z` against `main` containing:
+   - Workspace version bump in root `Cargo.toml` (`[workspace.package].version`).
+   - `cargo update --workspace` so `Cargo.lock` reflects the bump.
+   - New entry in `CHANGELOG.md` (both the overview table and the dated section).
+   - Commit message: `chore: bump version to X.Y.Z for release YY.MM_PATCH`.
+2. **Merge** the PR to `main` once CI is green.
+3. **Tag immediately** on the merge commit. The tag must be the **CalVer** form, not
+   SemVer. SemVer-form tags do not trigger the workflow.
+   ```bash
+   git fetch origin main
+   git tag -a YY.MM_PATCH origin/main -m "Release YY.MM_PATCH (semver X.Y.Z)"
+   git push origin YY.MM_PATCH
+   ```
+4. **Verify** the Release workflow at `gh run list --workflow Release --limit 1` —
+   it builds 4 platform targets, signs with cosign, publishes crates.io, creates the
+   GitHub Release, and pushes a follow-up "bump to X.Y.Z+1" commit to `main`.
+
+> **Important:** if you skip step 3, the bump merges silently and no release is cut.
+> This is what happened to `26.04_6` (PR #207) before it was tagged retroactively.
+> Always tag immediately after merging the bump PR.
+
+### Crates.io publishing
+
+The Release workflow handles publishing automatically once the tag is pushed. Manual
+publishing (in dependency order) is only needed when re-publishing or recovering from
+a failure:
 
 ```bash
-# Publish in dependency order
 cargo publish -p zentinel-common
 cargo publish -p zentinel-config
 cargo publish -p zentinel-agent-protocol
+cargo publish -p zentinel-wasm-runtime
 cargo publish -p zentinel-proxy
+cargo publish -p zentinel-gateway
+cargo publish -p zentinel-stack
 ```
 
-### GitHub Release
-
-```bash
-# Create release with notes
-gh release create vX.Y.Z --title "vX.Y.Z" --notes-file RELEASE_NOTES.md
-
-# Attach binaries (if not done by CI)
-gh release upload vX.Y.Z target/release/zentinel
-```
+Crates excluded from the workspace (`crates/sim`, `crates/playground-wasm`,
+`crates/config-inspect`) are not published as part of the release.
 
 ---
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,18 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      # wasmtime and wasmtime-wasi must move together: their major
+      # versions are tightly coupled, and bumping one without the
+      # other produces uncompilable code (e.g. wasmtime 44 with
+      # wasmtime-wasi 43 fails to type-check ResourceTable/Linker).
+      wasmtime:
+        patterns:
+          - "wasmtime"
+          - "wasmtime-*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
     commit-message:
       prefix: "deps"
     labels:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -3,12 +3,22 @@
 # Builds the gateway controller and proxy, deploys to a kind cluster,
 # and runs the official Gateway API conformance test suite.
 #
-# Runs on PRs that touch the gateway crate or conformance tests.
+# Runs on PRs that touch the gateway crate or conformance tests, and
+# on every push to main so we always have a known-good baseline to
+# compare against when a PR fails.
 
 name: Conformance
 
 on:
   pull_request:
+    paths:
+      - 'crates/gateway/**'
+      - 'conformance/**'
+      - 'deploy/helm/zentinel-gateway/**'
+      - '.github/workflows/conformance.yml'
+  push:
+    branches:
+      - main
     paths:
       - 'crates/gateway/**'
       - 'conformance/**'


### PR DESCRIPTION
## Summary

Three small ergonomics fixes that close root causes for problems hit in the last few days.

1. **Conformance on main.** The workflow now also runs on push to `main` (same path filters as the PR trigger). Previously, runs only happened on PRs touching gateway/conformance paths, so when a PR's run failed there was no baseline on main to compare against. This forced a manual `workflow_dispatch` every time somebody asked "is this a regression or pre-existing?" — confirmed today on #213, where the conformance failure turned out to be pre-existing on main.

2. **Group wasmtime + wasmtime-wasi in Dependabot.** Their major versions are tightly coupled: `wasmtime 44` with `wasmtime-wasi 43` fails to type-check `ResourceTable` / `Linker`. The current setup produced two separate PRs (#210, #212) that are individually unmergeable.

3. **Fix the release process docs.** `workflow.md` documented SemVer-form tags (`vX.Y.Z`) which do not trigger the Release workflow — only CalVer tags (`YY.MM_PATCH`) do. This is the gap that caused `26.04_6` (PR #207) to be silently version-bumped on 2026-04-26 without ever being released, until I backfilled the tag today. Updated docs spell out the correct format, that tagging must happen immediately after merge, and lists all 7 publishable workspace crates (the prior list was missing `zentinel-wasm-runtime`, `zentinel-gateway`, `zentinel-stack`).

## Test plan

- [ ] CI green on this PR
- [ ] After merge, push-to-main triggers a Conformance run on the next gateway-touching merge
- [ ] Next wasmtime release produces a single grouped PR (covers major + minor + patch)
- [ ] Future bump PRs follow the corrected workflow.md procedure