### PR TITLE
feat(install): provision systemd unit, system user, and starter config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,20 @@ for details.
 
 ---
 
+## [Unreleased]
+
+### Added
+- **Systemd service bootstrap in the install script.** `curl -fsSL https://get.zentinelproxy.io | sh` now installs `/etc/systemd/system/zentinel.service`, a sysusers snippet at `/usr/lib/sysusers.d/zentinel.conf`, and a starter config at `/etc/zentinel/zentinel.kdl` on Linux hosts running systemd. Service enable and start are opt-in via `--enable-service` (or `ZENTINEL_ENABLE_SERVICE=1`). Resolves discussion #218.
+- **`deploy/zentinel.starter.kdl`** — annotated starter configuration dropped at `/etc/zentinel/zentinel.kdl`. An existing file is preserved on re-install.
+- **`deploy/sysusers.d/zentinel.conf`** — declarative system user, applied via `systemd-sysusers` with a `useradd` fallback.
+- **`crates/proxy/docs/deployment.md`** — systemd deployment reference (file layout, lifecycle, capabilities, sandboxing).
+
+### Changed
+- **`deploy/zentinel.service`** now passes `--config /etc/zentinel/zentinel.kdl` explicitly and grants `AmbientCapabilities=CAP_NET_BIND_SERVICE` so listeners can bind ports below 1024 without root.
+- **Canonical config path renamed `config.kdl` → `zentinel.kdl`.** Aligns the unit file, Dockerfile, `docker-compose.yml`, and `deploy/deploy.sh` with the path already documented in the README. Helm chart still uses `config.kdl` internally; tracked as a follow-up.
+
+---
+
 ## [26.05_1] - 2026-05-01
 
 **Crate version:** 0.6.11

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ FROM gcr.io/distroless/cc-debian12:nonroot AS proxy
 COPY --from=builder /app/target/release/zentinel /zentinel
 
 # Copy default configuration
-COPY config/docker/default.kdl /etc/zentinel/config.kdl
+COPY config/docker/default.kdl /etc/zentinel/zentinel.kdl
 
 # Labels for container metadata
 LABEL org.opencontainers.image.title="Zentinel" \
@@ -125,12 +125,12 @@ USER nonroot:nonroot
 # Distroless has no shell, so HEALTHCHECK with curl/wget isn't possible.
 # Use one of these approaches:
 # 1. Kubernetes: Configure livenessProbe/readinessProbe with httpGet to /_builtin/health
-# 2. Docker Compose: Use `test: ["CMD", "/zentinel", "test", "-c", "/etc/zentinel/config.kdl"]`
+# 2. Docker Compose: Use `test: ["CMD", "/zentinel", "test", "-c", "/etc/zentinel/zentinel.kdl"]`
 # 3. External monitoring: Poll http://container:8080/_builtin/health
 
 # Zentinel handles SIGTERM/SIGHUP natively via signal_hook - no tini needed
 ENTRYPOINT ["/zentinel"]
-CMD ["-c", "/etc/zentinel/config.kdl"]
+CMD ["-c", "/etc/zentinel/zentinel.kdl"]
 
 ################################################################################
 # Debug image: Alpine with shell for troubleshooting
@@ -148,7 +148,7 @@ RUN apk add --no-cache \
 COPY --from=builder /app/target/release/zentinel /usr/local/bin/zentinel
 
 # Copy default configuration
-COPY config/docker/default.kdl /etc/zentinel/config.kdl
+COPY config/docker/default.kdl /etc/zentinel/zentinel.kdl
 
 # Create directories with correct ownership
 RUN mkdir -p /var/lib/zentinel /var/log/zentinel && \
@@ -167,7 +167,7 @@ HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
     CMD curl -sf http://localhost:8080/_builtin/health || exit 1
 
 ENTRYPOINT ["/usr/local/bin/zentinel"]
-CMD ["-c", "/etc/zentinel/config.kdl"]
+CMD ["-c", "/etc/zentinel/zentinel.kdl"]
 
 ################################################################################
 # Pre-built binary stage (for CI multi-arch builds)
@@ -185,7 +185,7 @@ FROM gcr.io/distroless/cc-debian12:nonroot AS proxy-prebuilt
 COPY zentinel /zentinel
 
 # Copy default configuration
-COPY config/docker/default.kdl /etc/zentinel/config.kdl
+COPY config/docker/default.kdl /etc/zentinel/zentinel.kdl
 
 LABEL org.opencontainers.image.title="Zentinel" \
       org.opencontainers.image.description="Security-first reverse proxy built on Pingora"
@@ -198,7 +198,7 @@ EXPOSE 8080 8443 9090
 USER nonroot:nonroot
 
 ENTRYPOINT ["/zentinel"]
-CMD ["-c", "/etc/zentinel/config.kdl"]
+CMD ["-c", "/etc/zentinel/zentinel.kdl"]
 
 ################################################################################
 # Echo agent image (for testing agent functionality)

--- a/README.md
+++ b/README.md
@@ -50,8 +50,11 @@ Production-ready core (proxy, routing, TLS, caching, load balancing). Agents are
 ## Quick Start
 
 ```bash
-# Install
+# Install (binary only)
 curl -fsSL https://get.zentinelproxy.io | sh
+
+# Install and start as a systemd service (Linux, root or sudo)
+curl -fsSL https://get.zentinelproxy.io | sh -s -- --enable-service
 
 # Or via Cargo
 cargo install zentinel-proxy
@@ -60,6 +63,8 @@ cargo install zentinel-proxy
 docker run -v $(pwd)/zentinel.kdl:/etc/zentinel/zentinel.kdl \
   ghcr.io/zentinelproxy/zentinel --config /etc/zentinel/zentinel.kdl
 ```
+
+On systemd hosts the install script also drops `/etc/systemd/system/zentinel.service`, a sysusers snippet, and a starter config at `/etc/zentinel/zentinel.kdl`. Service enable and start are opt-in via `--enable-service`. See [`crates/proxy/docs/deployment.md`](crates/proxy/docs/deployment.md).
 
 Save this as `zentinel.kdl` — it proxies `localhost:8080` to a backend on port `8081`:
 

--- a/config/docker/default.kdl
+++ b/config/docker/default.kdl
@@ -1,6 +1,6 @@
 // Zentinel Default Docker Configuration
 // Minimal config that starts the proxy without requiring a backend
-// Override by mounting your config to /etc/zentinel/config.kdl
+// Override by mounting your config to /etc/zentinel/zentinel.kdl
 
 system {
     worker-threads 0  // auto-detect CPU cores

--- a/crates/config/src/defaults.rs
+++ b/crates/config/src/defaults.rs
@@ -397,4 +397,16 @@ mod tests {
         assert!(config.routes.iter().any(|r| r.id == "cache-stats"));
         assert!(config.routes.iter().any(|r| r.id == "cache-purge"));
     }
+
+    /// Guard the starter config dropped by the installer at
+    /// /etc/zentinel/zentinel.kdl. Breaking its syntax breaks first-run UX
+    /// for `curl | sh` users, so we parse and validate it in tests.
+    #[test]
+    fn test_starter_config_parses_and_validates() {
+        const STARTER: &str = include_str!("../../../deploy/zentinel.starter.kdl");
+        let config = Config::from_kdl(STARTER).expect("starter config must parse as valid KDL");
+        config
+            .validate()
+            .expect("starter config must pass schema validation");
+    }
 }

--- a/crates/proxy/docs/deployment.md
+++ b/crates/proxy/docs/deployment.md
@@ -1,0 +1,138 @@
+# Deployment
+
+This document covers running Zentinel as a long-lived systemd service on Linux. For Docker, Kubernetes, and other targets, see the user-facing docs at https://docs.zentinelproxy.io/deployment.
+
+## Install via the official script
+
+```bash
+# Binary only (default)
+curl -fsSL https://get.zentinelproxy.io | sh
+
+# Binary + systemd unit + sysusers + starter config (no auto-start)
+curl -fsSL https://get.zentinelproxy.io | sh
+sudo systemctl enable --now zentinel
+
+# Caddy-style: install everything and start the service
+curl -fsSL https://get.zentinelproxy.io | sh -s -- --enable-service
+```
+
+The script:
+
+1. Downloads the latest released binary for your platform and installs it to `/usr/local/bin/zentinel` (falling back to `~/.local/bin` when `/usr/local/bin` is not writable).
+2. On Linux with systemd, when run as root or via sudo:
+   - Installs `/etc/systemd/system/zentinel.service`.
+   - Installs `/usr/lib/sysusers.d/zentinel.conf` and creates the `zentinel` system user (via `systemd-sysusers`, falling back to `useradd`).
+   - Drops a starter config at `/etc/zentinel/zentinel.kdl`. An existing file is preserved.
+   - Runs `systemctl daemon-reload`.
+   - With `--enable-service` (or `ZENTINEL_ENABLE_SERVICE=1`), runs `systemctl enable --now zentinel.service`.
+3. On macOS, in containers, or when systemd is unavailable, only the binary is installed.
+
+Pass `--skip-service` (or `--binary-only`) to install only the binary even on systemd hosts.
+
+## File layout
+
+| Path | Purpose | Mode | Owner |
+|------|---------|------|-------|
+| `/usr/local/bin/zentinel` | Binary | 0755 | root |
+| `/etc/systemd/system/zentinel.service` | Unit file | 0644 | root |
+| `/usr/lib/sysusers.d/zentinel.conf` | System user declaration | 0644 | root |
+| `/etc/zentinel/zentinel.kdl` | Configuration | 0644 | root |
+| `/etc/zentinel/env` (optional) | Environment overrides loaded by the unit | 0600 | root |
+| `/var/lib/zentinel/` | Runtime state (managed by `StateDirectory=`) | 0700 | zentinel |
+| `/var/log/zentinel/` | Log files (managed by `LogsDirectory=`) | 0755 | zentinel |
+| `/run/zentinel/` | PID file and sockets (managed by `RuntimeDirectory=`) | 0755 | zentinel |
+
+The `/var/lib`, `/var/log`, and `/run` directories are created and chowned by systemd on each service start; you do not need to provision them manually.
+
+## Service lifecycle
+
+```bash
+# Enable and start at boot
+sudo systemctl enable --now zentinel
+
+# Reload config without dropping connections (SIGHUP)
+sudo systemctl reload zentinel
+
+# Restart (drops connections)
+sudo systemctl restart zentinel
+
+# Stop and disable
+sudo systemctl disable --now zentinel
+
+# Inspect status
+systemctl status zentinel
+journalctl -u zentinel -f
+```
+
+## Binding privileged ports (80, 443)
+
+The shipped unit grants `AmbientCapabilities=CAP_NET_BIND_SERVICE` and bounds the capability set to the same. To bind 80 or 443, edit the listener address in `/etc/zentinel/zentinel.kdl`:
+
+```kdl
+listeners {
+    listener "default-http" {
+        address "0.0.0.0:80"
+        protocol "http"
+    }
+}
+```
+
+No further setup is required. The proxy still runs as the unprivileged `zentinel` user.
+
+## Sandboxing
+
+The unit applies the following hardening directives. Edit the unit if your environment requires changes; do not relax these defaults without reason.
+
+- `User=zentinel`, `Group=zentinel`, `UMask=0077`
+- `NoNewPrivileges=true`
+- `ProtectSystem=strict`, `ProtectHome=true`, `PrivateTmp=true`
+- `Protect{Kernel,Tunables,Modules,Logs,Clock,Hostname,ControlGroups}=true`
+- `RestrictNamespaces=true`, `RestrictRealtime=true`, `RestrictSUIDSGID=true`, `LockPersonality=true`, `RemoveIPC=true`
+- `RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6`
+- `SystemCallFilter=@system-service`, `SystemCallErrorNumber=EPERM`, `SystemCallArchitectures=native`
+- `LimitNOFILE=65535`, `LimitNPROC=4096`, `MemoryMax=2G`, `MemoryHigh=1500M`, `TasksMax=4096`
+- `OOMScoreAdjust=-500`
+
+If you add new outbound integrations (e.g., a Unix domain socket to an agent at `/run/agents/foo.sock`), `ProtectSystem=strict` blocks writes outside `RuntimeDirectory=`, `StateDirectory=`, and `LogsDirectory=`. Use `ReadWritePaths=` rather than relaxing `ProtectSystem`.
+
+## Environment overrides
+
+The unit honors `/etc/zentinel/env` when present (loaded with `EnvironmentFile=-/etc/zentinel/env`, where the leading `-` makes it optional). Use it to adjust log levels or feature flags without editing the unit:
+
+```sh
+# /etc/zentinel/env
+RUST_LOG=zentinel=debug,pingora=info
+```
+
+Restart the service after editing.
+
+## Validating the config
+
+```bash
+# Without starting
+sudo zentinel test --config /etc/zentinel/zentinel.kdl
+
+# With network and agent connectivity probes
+sudo zentinel validate --config /etc/zentinel/zentinel.kdl
+```
+
+The starter config dropped by the installer passes both checks out of the box.
+
+## Uninstalling
+
+```bash
+sudo systemctl disable --now zentinel
+sudo rm -f /etc/systemd/system/zentinel.service
+sudo rm -f /usr/lib/sysusers.d/zentinel.conf
+sudo systemctl daemon-reload
+sudo userdel zentinel 2>/dev/null || true
+sudo rm -rf /etc/zentinel /var/lib/zentinel /var/log/zentinel
+sudo rm -f /usr/local/bin/zentinel
+```
+
+## See also
+
+- [`deploy/zentinel.service`](../../../deploy/zentinel.service) — the unit shipped by the installer
+- [`deploy/sysusers.d/zentinel.conf`](../../../deploy/sysusers.d/zentinel.conf) — system user declaration
+- [`deploy/zentinel.starter.kdl`](../../../deploy/zentinel.starter.kdl) — starter config dropped at `/etc/zentinel/zentinel.kdl`
+- [`install.sh`](../../../install.sh) — installer script (also served at https://get.zentinelproxy.io)

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -182,12 +182,19 @@ install_services() {
 deploy_config() {
     log_info "Deploying configuration..."
 
-    # Deploy main config
-    if [ -f "config/zentinel.kdl" ]; then
-        cp "config/zentinel.kdl" "$CONFIG_DIR/config.kdl"
-        chown "$SERVICE_USER:$SERVICE_GROUP" "$CONFIG_DIR/config.kdl"
-        chmod 644 "$CONFIG_DIR/config.kdl"
+    # Deploy main config (preserve user edits if the target already exists)
+    if [ -f "$CONFIG_DIR/zentinel.kdl" ]; then
+        log_info "Preserving existing $CONFIG_DIR/zentinel.kdl"
+    elif [ -f "config/zentinel.kdl" ]; then
+        cp "config/zentinel.kdl" "$CONFIG_DIR/zentinel.kdl"
+        chown "$SERVICE_USER:$SERVICE_GROUP" "$CONFIG_DIR/zentinel.kdl"
+        chmod 644 "$CONFIG_DIR/zentinel.kdl"
         log_info "Deployed main configuration"
+    elif [ -f "deploy/zentinel.starter.kdl" ]; then
+        cp "deploy/zentinel.starter.kdl" "$CONFIG_DIR/zentinel.kdl"
+        chown "$SERVICE_USER:$SERVICE_GROUP" "$CONFIG_DIR/zentinel.kdl"
+        chmod 644 "$CONFIG_DIR/zentinel.kdl"
+        log_info "Deployed starter configuration"
     else
         log_warn "No configuration file found, using defaults"
     fi
@@ -203,7 +210,7 @@ deploy_config() {
     cat > "$CONFIG_DIR/env" <<EOF
 # Zentinel Proxy Environment Variables
 RUST_LOG=info
-ZENTINEL_CONFIG=$CONFIG_DIR/config.kdl
+ZENTINEL_CONFIG=$CONFIG_DIR/zentinel.kdl
 ZENTINEL_WORKERS=0
 EOF
 
@@ -327,7 +334,7 @@ validate_config() {
     if [ -f "$INSTALL_PREFIX/bin/$PROXY_BIN" ]; then
         "$INSTALL_PREFIX/bin/$PROXY_BIN" \
             --validate \
-            --config "$CONFIG_DIR/config.kdl" || {
+            --config "$CONFIG_DIR/zentinel.kdl" || {
             log_error "Configuration validation failed"
             exit 1
         }

--- a/deploy/sysusers.d/zentinel.conf
+++ b/deploy/sysusers.d/zentinel.conf
@@ -1,0 +1,9 @@
+# Declarative system user and group for the Zentinel reverse proxy.
+# Installed at /usr/lib/sysusers.d/zentinel.conf and applied via:
+#   systemd-sysusers
+#
+# Format reference: man sysusers.d(5)
+#
+# Type Name      ID  GECOS                            Home              Shell
+u      zentinel  -   "Zentinel reverse proxy"         /var/lib/zentinel  /usr/sbin/nologin
+g      zentinel  -   -                                -                  -

--- a/deploy/zentinel.service
+++ b/deploy/zentinel.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Zentinel Security-First Reverse Proxy
-Documentation=https://github.com/zentinelproxy/zentinel
+Documentation=https://docs.zentinelproxy.io https://github.com/zentinelproxy/zentinel
 After=network-online.target
 Wants=network-online.target
 StartLimitIntervalSec=60
@@ -8,7 +8,7 @@ StartLimitBurst=3
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/zentinel
+ExecStart=/usr/local/bin/zentinel --config /etc/zentinel/zentinel.kdl
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStop=/bin/kill -TERM $MAINPID
 Restart=on-failure
@@ -18,17 +18,19 @@ TimeoutStopSec=30
 KillMode=mixed
 KillSignal=SIGTERM
 
-# User and permissions
+# User and permissions. The system user is declared in
+# /usr/lib/sysusers.d/zentinel.conf and created via systemd-sysusers.
 User=zentinel
 Group=zentinel
 UMask=0077
 
 # Environment
 Environment="RUST_LOG=info"
-Environment="ZENTINEL_CONFIG=/etc/zentinel/config.kdl"
+Environment="ZENTINEL_CONFIG=/etc/zentinel/zentinel.kdl"
 EnvironmentFile=-/etc/zentinel/env
 
-# Working directory
+# Working directory and managed directories.
+# systemd creates and chowns these to User= on each start.
 WorkingDirectory=/var/lib/zentinel
 RuntimeDirectory=zentinel
 RuntimeDirectoryMode=0755
@@ -56,7 +58,6 @@ LockPersonality=true
 ProtectClock=true
 ProtectHostname=true
 ProtectKernelLogs=true
-RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 SystemCallFilter=@system-service
 SystemCallErrorNumber=EPERM
 SystemCallArchitectures=native
@@ -70,23 +71,19 @@ CPUWeight=100
 MemoryMax=2G
 MemoryHigh=1500M
 
-# IO limits (optional, adjust as needed)
-# IOWeight=100
-# IOReadBandwidthMax=/dev/sda 100M
-# IOWriteBandwidthMax=/dev/sda 50M
-
-# Network
-# Uncomment to bind to specific capabilities
-# AmbientCapabilities=CAP_NET_BIND_SERVICE
-# CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+# Network capabilities.
+# CAP_NET_BIND_SERVICE lets the proxy bind to ports < 1024 (e.g. 80, 443)
+# without running as root. Edit listener addresses in /etc/zentinel/zentinel.kdl
+# to use them.
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
 # Logging
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=zentinel
 
-# Process management
-# Set OOM score to avoid being killed
+# OOM behavior: stay alive when the host is under memory pressure.
 OOMScoreAdjust=-500
 
 # Watchdog (optional, requires implementation in proxy)

--- a/deploy/zentinel.starter.kdl
+++ b/deploy/zentinel.starter.kdl
@@ -1,0 +1,123 @@
+// Zentinel starter configuration.
+//
+// This file is dropped by the installer at /etc/zentinel/zentinel.kdl.
+// It is preserved across re-installs once you edit it.
+//
+// Out of the box it returns a JSON status page on :8080 and exposes
+// /health and /metrics on :9090. To turn this into a real reverse proxy,
+// uncomment the "backend" route and upstream below and point them at
+// your service.
+//
+// Documentation: https://docs.zentinelproxy.io
+// KDL reference: https://kdl.dev
+
+schema-version "1.0"
+
+server {
+    worker-threads 0           // 0 = auto-detect CPU cores
+    max-connections 10000
+    graceful-shutdown-timeout-secs 30
+}
+
+listeners {
+    // Public listener.
+    //
+    // The systemd unit grants CAP_NET_BIND_SERVICE, so you can change this
+    // to "0.0.0.0:80" without running the proxy as root.
+    listener "default-http" {
+        address "0.0.0.0:8080"
+        protocol "http"
+        request-timeout-secs 60
+        keepalive-timeout-secs 75
+        default-route "status"
+    }
+
+    // Admin listener. Bind to localhost in production.
+    listener "admin" {
+        address "127.0.0.1:9090"
+        protocol "http"
+        request-timeout-secs 5
+        keepalive-timeout-secs 30
+        default-route "health"
+    }
+}
+
+routes {
+    // JSON status response on the public listener.
+    //
+    // Replace this with a route that points at your "backend" upstream below
+    // once you are ready to proxy real traffic.
+    route "status" {
+        priority "low"
+        matches { path-prefix "/" }
+        service-type "builtin"
+        builtin-handler "status"
+    }
+
+    // Uncomment to forward all traffic to the backend defined below.
+    //
+    // route "backend" {
+    //     priority "normal"
+    //     matches { path-prefix "/" }
+    //     upstream "backend"
+    //     policies {
+    //         timeout-secs 30
+    //         failure-mode "closed"
+    //     }
+    // }
+
+    route "health" {
+        priority "high"
+        matches {
+            path "/health"
+            path "/healthz"
+            path "/ready"
+        }
+        service-type "builtin"
+        builtin-handler "health"
+    }
+
+    route "metrics" {
+        priority "high"
+        matches { path "/metrics" }
+        service-type "builtin"
+        builtin-handler "metrics"
+    }
+}
+
+// Uncomment when you wire up the "backend" route above.
+//
+// upstreams {
+//     upstream "backend" {
+//         target "127.0.0.1:8081" weight=1
+//         load-balancing "round_robin"
+//         health-check {
+//             type "tcp"
+//             interval-secs 10
+//             timeout-secs 5
+//             healthy-threshold 2
+//             unhealthy-threshold 3
+//         }
+//     }
+// }
+
+limits {
+    max-header-size-bytes 8192
+    max-header-count 100
+    max-body-size-bytes 1048576       // 1 MiB
+    max-connections-per-client 100
+}
+
+// Metrics are served by the "metrics" builtin route on the admin listener.
+observability {
+    logging {
+        level "info"
+        format "json"
+
+        error-log {
+            enabled #true
+            file "/var/log/zentinel/error.log"
+            level "warn"
+        }
+    }
+}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,7 +10,7 @@ services:
   proxy:
     environment:
       RUST_LOG: debug,zentinel_proxy=trace
-      ZENTINEL_CONFIG: /etc/zentinel/config.kdl
+      ZENTINEL_CONFIG: /etc/zentinel/zentinel.kdl
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9090/health"]
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,13 +12,13 @@ services:
       - "8443:8443"   # HTTPS
       - "9090:9090"   # Health/Metrics
     volumes:
-      - ./config/docker/proxy.kdl:/etc/zentinel/config.kdl:ro
+      - ./config/docker/proxy.kdl:/etc/zentinel/zentinel.kdl:ro
       - proxy-data:/var/lib/zentinel
       - proxy-logs:/var/log/zentinel
       - agent-sockets:/var/run/zentinel
     environment:
       RUST_LOG: info,zentinel_proxy=debug
-      ZENTINEL_CONFIG: /etc/zentinel/config.kdl
+      ZENTINEL_CONFIG: /etc/zentinel/zentinel.kdl
     networks:
       - zentinel
     depends_on:

--- a/install.sh
+++ b/install.sh
@@ -2,15 +2,28 @@
 # Zentinel Install Script
 # Usage: curl -fsSL https://get.zentinelproxy.io | sh
 #
-# This script detects your OS and architecture, downloads the appropriate
-# pre-built binary, and installs it to /usr/local/bin (or ~/.local/bin if
+# Detects your OS and architecture, downloads the appropriate pre-built
+# binary, and installs it to /usr/local/bin (or ~/.local/bin if
 # /usr/local/bin is not writable).
 #
-# After installation, use `zentinel bundle install` to install bundled agents
-# (WAF, rate limiter, denylist). See https://zentinelproxy.io/docs/deployment/bundle/
+# On systemd hosts (when running as root or via sudo) it also installs:
+#   - /etc/systemd/system/zentinel.service
+#   - /usr/lib/sysusers.d/zentinel.conf
+#   - /etc/zentinel/zentinel.kdl  (starter config; preserved if present)
+#
+# Service enable and start are opt-in. Pass --enable-service to enable
+# and start zentinel.service after install. Pass --skip-service to skip
+# all systemd setup.
+#
+# After installation, use `zentinel bundle install` to install bundled
+# agents (WAF, rate limiter, denylist).
+# See https://zentinelproxy.io/docs/deployment/bundle/
 #
 # Options:
-#   --help      Show help message
+#   --help              Show help message
+#   --enable-service    Enable and start zentinel.service after install
+#   --skip-service      Skip systemd unit, sysusers, and starter config
+#   --binary-only       Alias for --skip-service
 
 set -e
 
@@ -19,6 +32,16 @@ REPO="zentinelproxy/zentinel"
 BINARY_NAME="zentinel"
 INSTALL_DIR="/usr/local/bin"
 FALLBACK_DIR="$HOME/.local/bin"
+
+# Systemd / config layout
+SYSTEMD_UNIT_PATH="/etc/systemd/system/zentinel.service"
+SYSUSERS_PATH="/usr/lib/sysusers.d/zentinel.conf"
+CONFIG_DIR="/etc/zentinel"
+CONFIG_FILE="${CONFIG_DIR}/zentinel.kdl"
+
+# Flags
+ENABLE_SERVICE=0
+SKIP_SERVICE=0
 
 # Colors for output
 RED='\033[0;31m'
@@ -236,15 +259,188 @@ check_path() {
     esac
 }
 
+# Run a command as root, using sudo if available and not already root.
+# Returns non-zero if elevation is impossible.
+as_root() {
+    if [ "$(id -u)" -eq 0 ]; then
+        "$@"
+    elif command -v sudo >/dev/null 2>&1; then
+        sudo "$@"
+    else
+        return 1
+    fi
+}
+
+# Fetch a file from the repo at $version (or main as fallback) into $1.
+# $1 = destination path
+# $2 = repo-relative source path
+fetch_repo_file() {
+    local dest="$1"
+    local src="$2"
+    local version="$3"
+
+    local tag_url="https://raw.githubusercontent.com/${REPO}/${version}/${src}"
+    local main_url="https://raw.githubusercontent.com/${REPO}/main/${src}"
+
+    if curl -fsSL "$tag_url" -o "$dest" 2>/dev/null; then
+        return 0
+    fi
+    if curl -fsSL "$main_url" -o "$dest" 2>/dev/null; then
+        warn "Using ${src} from main branch (release tag ${version} did not include it)"
+        return 0
+    fi
+    return 1
+}
+
+# Set up the systemd unit, sysusers snippet, and starter config.
+# Skips with a clear message when systemd is unavailable, the user is not
+# root and cannot escalate, or --skip-service was passed.
+setup_systemd() {
+    local version="$1"
+    local tmp_dir="$2"
+
+    if [ "$SKIP_SERVICE" = 1 ]; then
+        info "Skipping systemd setup (--skip-service)"
+        return 0
+    fi
+
+    if [ "$(uname -s)" != "Linux" ]; then
+        return 0
+    fi
+
+    if ! command -v systemctl >/dev/null 2>&1; then
+        info "systemd not detected; skipping service setup"
+        return 0
+    fi
+
+    # We need to be able to write to /etc, /usr/lib, and run systemctl.
+    if [ "$(id -u)" -ne 0 ] && ! command -v sudo >/dev/null 2>&1; then
+        warn "Cannot configure systemd unit (not root and sudo unavailable)"
+        warn "Re-run as root or with sudo to install the zentinel.service unit"
+        return 0
+    fi
+
+    info "Configuring systemd unit and starter config..."
+
+    # Stage files in tmp dir, then copy under sudo in a single batch.
+    local stage_unit="${tmp_dir}/zentinel.service"
+    local stage_sysusers="${tmp_dir}/zentinel.sysusers.conf"
+    local stage_starter="${tmp_dir}/zentinel.starter.kdl"
+
+    if ! fetch_repo_file "$stage_unit" "deploy/zentinel.service" "$version"; then
+        warn "Failed to fetch deploy/zentinel.service; skipping systemd setup"
+        return 0
+    fi
+    if ! fetch_repo_file "$stage_sysusers" "deploy/sysusers.d/zentinel.conf" "$version"; then
+        warn "Failed to fetch deploy/sysusers.d/zentinel.conf; skipping systemd setup"
+        return 0
+    fi
+    if ! fetch_repo_file "$stage_starter" "deploy/zentinel.starter.kdl" "$version"; then
+        warn "Failed to fetch deploy/zentinel.starter.kdl; skipping systemd setup"
+        return 0
+    fi
+
+    if [ "$(id -u)" -ne 0 ]; then
+        info "systemd setup requires administrator privileges; you may be prompted."
+    fi
+
+    # Drop the sysusers snippet, then apply via systemd-sysusers when
+    # available. Verify the user exists afterwards and fall back to useradd
+    # if needed.
+    as_root install -D -m 0644 "$stage_sysusers" "$SYSUSERS_PATH" \
+        || error "Failed to install ${SYSUSERS_PATH}"
+
+    if as_root sh -c 'command -v systemd-sysusers >/dev/null 2>&1'; then
+        as_root systemd-sysusers || warn "systemd-sysusers exited non-zero; will verify user separately"
+    fi
+
+    if ! getent passwd zentinel >/dev/null 2>&1; then
+        info "Creating zentinel system user via useradd..."
+        as_root useradd --system --shell /usr/sbin/nologin \
+            --home-dir /var/lib/zentinel --comment "Zentinel reverse proxy" \
+            zentinel || warn "Failed to create zentinel user; service will not start"
+    fi
+
+    # Install the unit file.
+    as_root install -D -m 0644 "$stage_unit" "$SYSTEMD_UNIT_PATH" \
+        || error "Failed to install ${SYSTEMD_UNIT_PATH}"
+
+    # Install the starter config (preserve any existing edits).
+    as_root install -d -m 0755 "$CONFIG_DIR"
+    if [ -e "$CONFIG_FILE" ]; then
+        info "Preserving existing ${CONFIG_FILE}"
+    else
+        as_root install -m 0644 "$stage_starter" "$CONFIG_FILE" \
+            || error "Failed to install ${CONFIG_FILE}"
+    fi
+
+    # Reload systemd to pick up the new unit.
+    as_root systemctl daemon-reload \
+        || warn "systemctl daemon-reload failed; you may need to reload manually"
+
+    if [ "$ENABLE_SERVICE" = 1 ]; then
+        info "Enabling and starting zentinel.service..."
+        if as_root systemctl enable --now zentinel.service; then
+            success "zentinel.service is active"
+        else
+            warn "Failed to enable/start zentinel.service. Check: journalctl -u zentinel"
+        fi
+    fi
+}
+
+# Print next-step hints once the install is complete.
+print_next_steps() {
+    local final_dir="$1"
+    local version="$2"
+
+    echo ""
+    if [ -e "$SYSTEMD_UNIT_PATH" ]; then
+        if [ "$ENABLE_SERVICE" = 1 ]; then
+            printf "${GREEN}zentinel.service${NC} is enabled and running.\n"
+            printf "  Logs:    ${BLUE}journalctl -u zentinel -f${NC}\n"
+            printf "  Status:  ${BLUE}systemctl status zentinel${NC}\n"
+            printf "  Config:  ${BLUE}%s${NC}\n" "$CONFIG_FILE"
+        else
+            printf "${YELLOW}Next steps${NC} (service is installed but not started):\n"
+            printf "  1. Edit config:   ${BLUE}sudoedit %s${NC}\n" "$CONFIG_FILE"
+            printf "  2. Validate:      ${BLUE}zentinel test --config %s${NC}\n" "$CONFIG_FILE"
+            printf "  3. Enable+start:  ${BLUE}sudo systemctl enable --now zentinel${NC}\n"
+            printf "  4. Tail logs:     ${BLUE}journalctl -u zentinel -f${NC}\n"
+        fi
+    else
+        printf "${YELLOW}Next steps${NC}:\n"
+        printf "  1. Run the proxy:    ${BLUE}zentinel${NC}            # uses embedded default config\n"
+        printf "  2. With your config: ${BLUE}zentinel --config zentinel.kdl${NC}\n"
+        printf "  3. Validate config:  ${BLUE}zentinel test --config zentinel.kdl${NC}\n"
+    fi
+    echo ""
+    printf "Documentation: ${BLUE}https://docs.zentinelproxy.io${NC}\n"
+    printf "GitHub:        ${BLUE}https://github.com/${REPO}${NC}\n"
+    echo ""
+    printf "${YELLOW}Tip:${NC} To install bundled agents (WAF, rate limiter, denylist):\n"
+    printf "     ${GREEN}sudo zentinel bundle install${NC}\n"
+    echo ""
+}
+
 # Show help message
 show_help() {
     cat << EOF
 Zentinel Install Script
 
-Usage: curl -fsSL https://raw.githubusercontent.com/zentinelproxy/zentinel/main/install.sh | sh
+Usage: curl -fsSL https://get.zentinelproxy.io | sh
+       curl -fsSL https://get.zentinelproxy.io | sh -s -- [options]
 
 Options:
-    --help      Show this help message
+    --help              Show this help message
+    --enable-service    Enable and start zentinel.service after install
+                        (also accepts ZENTINEL_ENABLE_SERVICE=1)
+    --skip-service      Skip systemd unit, sysusers, and starter config
+    --binary-only       Alias for --skip-service
+
+Default behavior on systemd hosts:
+    Installs the systemd unit, sysusers snippet, and starter config at
+    /etc/zentinel/zentinel.kdl, but does not enable or start the service.
+    Pass --enable-service for Caddy/Nginx-style auto-start.
 
 After installing Zentinel, you can install bundled agents using:
 
@@ -258,7 +454,7 @@ This downloads and installs:
 See the bundle command documentation:
     https://zentinelproxy.io/docs/deployment/bundle/
 
-For more information: https://zentinelproxy.io/docs
+For more information: https://docs.zentinelproxy.io
 EOF
 }
 
@@ -270,12 +466,23 @@ parse_args() {
                 show_help
                 exit 0
                 ;;
+            --enable-service)
+                ENABLE_SERVICE=1
+                ;;
+            --skip-service|--binary-only)
+                SKIP_SERVICE=1
+                ;;
             *)
                 warn "Unknown option: $1"
                 ;;
         esac
         shift
     done
+
+    # Environment variable opt-in
+    case "${ZENTINEL_ENABLE_SERVICE:-}" in
+        1|true|yes) ENABLE_SERVICE=1 ;;
+    esac
 }
 
 # Main installation
@@ -296,9 +503,6 @@ main() {
     local os=$(detect_os)
     local arch=$(detect_arch)
     info "Detected platform: ${os}-${arch}"
-
-    # Check for unsupported combinations
-    # (all four platform/arch combos are now built in CI)
 
     # Create temporary directory
     local tmp_dir=$(mktemp -d)
@@ -321,7 +525,7 @@ main() {
 
     # Success!
     echo ""
-    success "Zentinel ${version} installed successfully!"
+    success "Zentinel ${version} installed to ${final_dir}/${BINARY_NAME}"
     echo ""
 
     # Check if in PATH
@@ -344,19 +548,12 @@ main() {
     if command -v zentinel >/dev/null 2>&1; then
         info "Verifying installation..."
         zentinel --version 2>/dev/null || true
-    else
-        echo "Run 'zentinel --help' to get started"
     fi
 
-    echo ""
-    printf "Documentation: ${BLUE}https://zentinelproxy.io${NC}\n"
-    printf "GitHub: ${BLUE}https://github.com/${REPO}${NC}\n"
-    echo ""
+    # Optional systemd setup (Linux + systemd only)
+    setup_systemd "$version" "$tmp_dir"
 
-    # Hint about bundled agents
-    printf "${YELLOW}Tip:${NC} To install bundled agents (WAF, rate limiter, denylist):\n"
-    printf "     ${GREEN}sudo zentinel bundle install${NC}\n"
-    echo ""
+    print_next_steps "$final_dir" "$version"
 }
 
 # Run main


### PR DESCRIPTION
## Summary

- Install script (`install.sh`, served at `get.zentinelproxy.io`) now provisions a managed-service layout on systemd hosts: unit file, sysusers snippet, starter config at `/etc/zentinel/zentinel.kdl`. Service enable and start are opt-in (`--enable-service`).
- Systemd unit gains `AmbientCapabilities=CAP_NET_BIND_SERVICE` so listeners bind 80/443 without root, and now passes `--config` explicitly.
- Canonical config path standardized on `zentinel.kdl` across the unit, Dockerfile, docker-compose stacks, and `deploy.sh` (was inconsistent with README).
- New `crates/proxy/docs/deployment.md` covers the systemd flow end to end.

Closes #223. Resolves discussion #218.

## What changed

| File | Purpose |
|------|---------|
| `install.sh` | Adds `--enable-service` / `--skip-service` / `--binary-only`, fetches deploy files from the resolved release tag (falls back to `main`), runs `systemd-sysusers` with `useradd` fallback, idempotent re-runs |
| `deploy/zentinel.service` | `--config /etc/zentinel/zentinel.kdl`, `CAP_NET_BIND_SERVICE`, deduplicated directives |
| `deploy/sysusers.d/zentinel.conf` | New: declarative system user |
| `deploy/zentinel.starter.kdl` | New: annotated starter config dropped at `/etc/zentinel/zentinel.kdl` |
| `crates/proxy/docs/deployment.md` | New: file layout, lifecycle, capabilities, sandboxing, uninstall |
| `crates/config/src/defaults.rs` | New test: starter KDL parses and passes `Config::validate` |
| `Dockerfile`, `docker-compose.yml`, `docker-compose.test.yml`, `deploy/deploy.sh`, `config/docker/default.kdl` | Path rename `config.kdl` → `zentinel.kdl` for consistency |
| `README.md` | Quick Start mentions the `--enable-service` flow and links the deployment doc |
| `CHANGELOG.md` | Unreleased entry |

## Default install behavior (no flags)

```
$ curl -fsSL https://get.zentinelproxy.io | sh
... binary installed to /usr/local/bin/zentinel
... unit installed at /etc/systemd/system/zentinel.service
... sysusers snippet at /usr/lib/sysusers.d/zentinel.conf
... zentinel system user created
... starter config at /etc/zentinel/zentinel.kdl
... systemctl daemon-reload

Next steps (service is installed but not started):
  1. Edit config:   sudoedit /etc/zentinel/zentinel.kdl
  2. Validate:      zentinel test --config /etc/zentinel/zentinel.kdl
  3. Enable+start:  sudo systemctl enable --now zentinel
  4. Tail logs:     journalctl -u zentinel -f
```

## With `--enable-service`

```
$ curl -fsSL https://get.zentinelproxy.io | sh -s -- --enable-service
... binary, unit, sysusers, starter config installed
... systemctl enable --now zentinel.service
✓ zentinel.service is active
```

## Skipped on non-systemd hosts

macOS, containers, BSDs, and Linux without systemctl get the binary-only path with no warnings, behaviorally identical to the previous installer.

## Tests

- `cargo test -p zentinel-config --lib defaults::tests::test_starter_config_parses_and_validates` (new)
- `cargo test -p zentinel-config --lib` — 151 passed, 0 failed
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p zentinel-config --all-targets -- -D warnings` — clean

## Out of scope (follow-ups)

- Helm chart `config.kdl` rename (separate review; chart has its own config-key flow)
- Deb / RPM packages
- macOS launchd plist
- Marketing site (`zentinelproxy.io`) Getting Started copy
- User-facing docs (`zentinelproxy.io-docs`) deployment page

## Test plan

- [ ] Fresh systemd host (Debian 12 / Ubuntu 24.04): default install creates `/etc/zentinel/zentinel.kdl`, `/etc/systemd/system/zentinel.service`, `/usr/lib/sysusers.d/zentinel.conf`, `zentinel` user; service does NOT start
- [ ] Same host: `sudo systemctl enable --now zentinel` succeeds, `journalctl -u zentinel` shows clean startup, `curl http://localhost:8080/` returns the builtin status JSON
- [ ] Edit `/etc/zentinel/zentinel.kdl` to bind `0.0.0.0:80`; `systemctl restart zentinel`; verify port 80 is bound by the unprivileged `zentinel` user (`ss -ltnp | grep :80`)
- [ ] `--enable-service` flag: service enabled and started in one shot
- [ ] Re-run installer: `/etc/zentinel/zentinel.kdl` is preserved after edit
- [ ] `--skip-service` / `--binary-only`: only the binary is installed
- [ ] macOS: only the binary is installed, no systemd warnings
- [ ] Existing flows: `cargo install zentinel-proxy` and `docker run ghcr.io/zentinelproxy/zentinel` still work