### PR TITLE
chore: bump version to 0.6.12 for release 26.05_2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ for details.
 
 | CalVer | Crate Version | Date | Highlights |
 |--------|---------------|------|------------|
+| [26.05_2](#26052---2026-05-03) | 0.6.12 | 2026-05-03 | Install script provisions systemd unit, system user, and starter config |
 | [26.05_1](#26051---2026-05-01) | 0.6.11 | 2026-05-01 | Per-SNI ACME certificates for multi-tenant TLS, dependency updates |
 | [26.04_7](#26047---2026-04-28) | 0.6.10 | 2026-04-28 | Security: rand fix in `zentinel-sim` |
 | [26.04_6](#26046---2026-04-25) | 0.6.9 | 2026-04-25 | Security: openssl & rand fixes, ACME schema docs, CI update |
@@ -44,17 +45,19 @@ for details.
 
 ---
 
-## [Unreleased]
+## [26.05_2] - 2026-05-03
+
+**Crate version:** 0.6.12
 
 ### Added
-- **Systemd service bootstrap in the install script.** `curl -fsSL https://get.zentinelproxy.io | sh` now installs `/etc/systemd/system/zentinel.service`, a sysusers snippet at `/usr/lib/sysusers.d/zentinel.conf`, and a starter config at `/etc/zentinel/zentinel.kdl` on Linux hosts running systemd. Service enable and start are opt-in via `--enable-service` (or `ZENTINEL_ENABLE_SERVICE=1`). Resolves discussion #218.
-- **`deploy/zentinel.starter.kdl`** — annotated starter configuration dropped at `/etc/zentinel/zentinel.kdl`. An existing file is preserved on re-install.
-- **`deploy/sysusers.d/zentinel.conf`** — declarative system user, applied via `systemd-sysusers` with a `useradd` fallback.
-- **`crates/proxy/docs/deployment.md`** — systemd deployment reference (file layout, lifecycle, capabilities, sandboxing).
+- **Systemd service bootstrap in the install script.** `curl -fsSL https://get.zentinelproxy.io | sh` now installs `/etc/systemd/system/zentinel.service`, a sysusers snippet at `/usr/lib/sysusers.d/zentinel.conf`, and a starter config at `/etc/zentinel/zentinel.kdl` on Linux hosts running systemd. Service enable and start are opt-in via `--enable-service` (or `ZENTINEL_ENABLE_SERVICE=1`). Resolves discussion #218. (#224)
+- **`deploy/zentinel.starter.kdl`** — annotated starter configuration dropped at `/etc/zentinel/zentinel.kdl`. An existing file is preserved on re-install. (#224)
+- **`deploy/sysusers.d/zentinel.conf`** — declarative system user, applied via `systemd-sysusers` with a `useradd` fallback. (#224)
+- **`crates/proxy/docs/deployment.md`** — systemd deployment reference (file layout, lifecycle, capabilities, sandboxing). (#224)
 
 ### Changed
-- **`deploy/zentinel.service`** now passes `--config /etc/zentinel/zentinel.kdl` explicitly and grants `AmbientCapabilities=CAP_NET_BIND_SERVICE` so listeners can bind ports below 1024 without root.
-- **Canonical config path renamed `config.kdl` → `zentinel.kdl`.** Aligns the unit file, Dockerfile, `docker-compose.yml`, and `deploy/deploy.sh` with the path already documented in the README. Helm chart still uses `config.kdl` internally; tracked as a follow-up.
+- **`deploy/zentinel.service`** now passes `--config /etc/zentinel/zentinel.kdl` explicitly and grants `AmbientCapabilities=CAP_NET_BIND_SERVICE` so listeners can bind ports below 1024 without root. (#224)
+- **Canonical config path renamed `config.kdl` → `zentinel.kdl`.** Aligns the unit file, Dockerfile, `docker-compose.yml`, and `deploy/deploy.sh` with the path already documented in the README. Helm chart still uses `config.kdl` internally; tracked as a follow-up. (#224)
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8277,7 +8277,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8317,7 +8317,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8339,7 +8339,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8418,7 +8418,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8449,7 +8449,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8540,7 +8540,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8557,7 +8557,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.11"
+version = "0.6.12"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bumps workspace version 0.6.11 → 0.6.12 in preparation for CalVer release 26.05_2.

## Highlights

- Install script provisions systemd unit, system user, and starter config (#224).
- Canonical config path standardized on `zentinel.kdl` across the unit, Dockerfile, docker-compose, and `deploy/deploy.sh`.
- New deployment reference at `crates/proxy/docs/deployment.md`.

Resolves #218 and #223.

## Bumped

- `Cargo.toml` workspace version: 0.6.11 → 0.6.12
- `Cargo.lock` regenerated via `cargo update --workspace`
- `CHANGELOG.md` overview row + dated section for 26.05_2

After merge, tag immediately:

```bash
git fetch origin main
git tag -a 26.05_2 origin/main -m "Release 26.05_2 (semver 0.6.12)"
git push origin 26.05_2
```