### PR TITLE
deps+fix: bump hickory-resolver to 0.26.1 and adapt to new API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,18 +1702,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "enum-ordinalize"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,23 +2294,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
+ "jni",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -2331,21 +2318,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.10.1",
  "resolv-conf",
  "smallvec",
+ "system-configuration 0.7.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2844,6 +2856,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ipnetwork"
@@ -3540,6 +3555,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "neli"
@@ -4539,6 +4560,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f561214012d3fc240a1f9c817cc4d57f5310910d066069c1b093f766bb5966"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5152,7 +5184,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -6037,7 +6069,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -6045,6 +6088,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/crates/proxy/Cargo.toml
+++ b/crates/proxy/Cargo.toml
@@ -165,7 +165,7 @@ instant-acme = "0.8"
 rcgen = "0.14"
 
 # DNS resolution for DNS-01 challenge propagation checking
-hickory-resolver = "0.25"
+hickory-resolver = "0.26"
 
 [features]
 default = []

--- a/crates/proxy/src/acme/dns/propagation.rs
+++ b/crates/proxy/src/acme/dns/propagation.rs
@@ -3,13 +3,13 @@
 //! Verifies that TXT records have propagated to authoritative nameservers
 //! before notifying the ACME server.
 
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;
 
 use hickory_resolver::config::{NameServerConfig, ResolverConfig, ResolverOpts};
-use hickory_resolver::name_server::TokioConnectionProvider;
-use hickory_resolver::proto::xfer::Protocol;
-use hickory_resolver::{Resolver, TokioResolver};
+use hickory_resolver::net::runtime::TokioRuntimeProvider;
+use hickory_resolver::proto::rr::RData;
+use hickory_resolver::TokioResolver;
 use tokio::time::Instant;
 use tracing::{debug, trace, warn};
 
@@ -70,12 +70,9 @@ impl PropagationChecker {
         let resolver_config = if config.nameservers.is_empty() {
             ResolverConfig::default()
         } else {
-            let mut resolver_config = ResolverConfig::new();
+            let mut resolver_config = ResolverConfig::from_parts(None, vec![], vec![]);
             for ip in &config.nameservers {
-                resolver_config.add_name_server(NameServerConfig::new(
-                    SocketAddr::new(*ip, 53),
-                    Protocol::Udp,
-                ));
+                resolver_config.add_name_server(NameServerConfig::udp(*ip));
             }
             resolver_config
         };
@@ -85,12 +82,10 @@ impl PropagationChecker {
         opts.attempts = 3;
         opts.cache_size = 0; // Disable caching for propagation checks
 
-        // hickory-resolver 0.25 uses builder pattern
-        let resolver =
-            Resolver::builder_with_config(resolver_config, TokioConnectionProvider::default())
-                .with_options(opts)
-                .build();
-        Ok(resolver)
+        TokioResolver::builder_with_config(resolver_config, TokioRuntimeProvider::default())
+            .with_options(opts)
+            .build()
+            .map_err(|e| DnsProviderError::Configuration(format!("DNS resolver build failed: {e}")))
     }
 
     /// Wait for a TXT record to propagate
@@ -161,10 +156,14 @@ impl PropagationChecker {
 
         match lookup {
             Ok(records) => {
-                for record in records.iter() {
+                for record in records.answers() {
+                    let RData::TXT(txt) = &record.data else {
+                        continue;
+                    };
+
                     // TXT records can have multiple strings, join them
-                    let value: String = record
-                        .txt_data()
+                    let value: String = txt
+                        .txt_data
                         .iter()
                         .map(|data| String::from_utf8_lossy(data))
                         .collect();


### PR DESCRIPTION
Supersedes #228 (Dependabot's bump-only PR which fails CI because hickory-resolver 0.26 has breaking API changes).

This PR bundles the dep bump with the call-site adaptations needed to compile against the new API.

## Why bundle the bump and the fix

hickory-resolver 0.26.1 ships fixes for two RustSec advisories:

- [RUSTSEC-2026-0119](https://rustsec.org/advisories/RUSTSEC-2026-0119.html)
- [RUSTSEC-2026-0120](https://rustsec.org/advisories/RUSTSEC-2026-0120.html)

We want them in. The bump alone breaks the build, so Dependabot's PR cannot land. This PR is the dep bump rebased on top of `main` plus the necessary call-site changes in one branch.

## API changes touched

All in `crates/proxy/src/acme/dns/propagation.rs` (the DNS-01 propagation checker):

| 0.25 | 0.26 |
|------|------|
| `hickory_resolver::name_server::TokioConnectionProvider` (private module now) | `hickory_resolver::net::runtime::TokioRuntimeProvider` |
| `hickory_resolver::proto::xfer::Protocol` (used to specify UDP) | Not needed; `NameServerConfig::udp(IpAddr)` is the new convenience constructor |
| `ResolverConfig::new()` | `ResolverConfig::from_parts(None, vec![], vec![])` |
| `NameServerConfig::new(SocketAddr, Protocol)` | `NameServerConfig::udp(IpAddr)` |
| `Resolver::builder_with_config(...).build() -> Resolver` | `TokioResolver::builder_with_config(cfg, TokioRuntimeProvider::default()).build() -> Result<Resolver, NetError>` |
| `Lookup::iter()` (yielded `&RData`) | `Lookup::answers()` (yields `&Record`); `record.data` is the public `RData` field |
| `record.txt_data()` (method on RData) | Pattern-match `RData::TXT(txt)` then read public `txt.txt_data` field |

Behavior is unchanged: still queries the configured upstreams over UDP on port 53 and matches TXT contents byte-for-byte. The new `build()` Result is surfaced through `DnsProviderError::Configuration`.

## Tests

- `cargo build -p zentinel-proxy`: clean.
- `cargo clippy -p zentinel-proxy --all-targets --all-features -- -D warnings`: clean.
- `cargo test -p zentinel-proxy --lib acme::dns`: 34 passed, 0 failed.
- `cargo fmt --all -- --check`: clean.

## Closes

- Closes #228 (supersedes Dependabot's bump-only PR).

## Test plan

- [ ] CI passes on PR.
- [ ] Sanity-check ACME DNS-01 issuance against a real domain after merge (or rely on existing integration tests).