### PR TITLE
docs(readme): add request-flow diagram between Status and Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,33 @@ Zentinel is a high-performance reverse proxy built on [Cloudflare Pingora](https
 
 Production-ready core (proxy, routing, TLS, caching, load balancing). Agents are individually versioned — WAF, Auth, and AI Gateway are stable; others are beta or alpha. See [zentinelproxy.io/agents](https://zentinelproxy.io/agents/) for per-agent status.
 
+## Request Flow
+
+```
+   ┌────────┐                                       ┌──────────┐
+   │ Client │                                       │ Upstream │
+   └────┬───┘                                       └─────▲────┘
+        │                                                 │
+        ▼                                                 │
+   ╔═══════════ Zentinel (core, single binary) ══════════╤════╗
+   ║                                                     │    ║
+   ║  Listener ─▶ Routing ─▶ Filter chain ─▶ Forward ────┘    ║
+   ║  TLS, H2     priority   rate-limit,     LB,              ║
+   ║              + LRU      cache, hooks    retries          ║
+   ║                              │                           ║
+   ╚══════════════════════════════╪═══════════════════════════╝
+                                  │ UDS / gRPC (v2 agent protocol)
+                                  ▼
+          ╔═══════ External agents (separate processes) ═══════╗
+          ║   WAF · Auth · Rate-limit · …                      ║
+          ║   crash-isolated, any language                     ║
+          ╚════════════════════════════════════════════════════╝
+```
+
+> *Response retraces the filter chain back to the Client. Access logs and metrics emit at completion.*
+
+The dataplane runs as a single binary. Security and policy logic that is parsing-heavy or operationally risky lives in **external agents** behind UDS or gRPC, so a buggy agent cannot take the proxy down with it. See the [Manifesto](MANIFESTO.md) for the reasoning, and [`crates/proxy/docs/architecture.md`](crates/proxy/docs/architecture.md) for the per-phase details.
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a 16-line ASCII request-flow diagram to the README, placed between the **Status** and **Quick Start** sections.

```
   ┌────────┐                                       ┌──────────┐
   │ Client │                                       │ Upstream │
   └────┬───┘                                       └─────▲────┘
        │                                                 │
        ▼                                                 │
   ╔═══════════ Zentinel (core, single binary) ══════════╤════╗
   ║                                                     │    ║
   ║  Listener ─▶ Routing ─▶ Filter chain ─▶ Forward ────┘    ║
   ║  TLS, H2     priority   rate-limit,     LB,              ║
   ║              + LRU      cache, hooks    retries          ║
   ║                              │                           ║
   ╚══════════════════════════════╪═══════════════════════════╝
                                  │ UDS / gRPC (v2 agent protocol)
                                  ▼
          ╔═══════ External agents (separate processes) ═══════╗
          ║   WAF · Auth · Rate-limit · …                      ║
          ║   crash-isolated, any language                     ║
          ╚════════════════════════════════════════════════════╝
```

## Why

Readers currently assemble the request mental model from prose scattered across the Features table, the Use Cases list, and the Agents section. A diagram between Status and Quick Start gives them a concrete model first, so the install commands and the feature inventory below land in context.

## Visual conventions

- **Double-line boxes** for the major system components (Zentinel core, external agents).
- **Single-line boxes** for peripheral entities (Client, Upstream).
- Linear left-to-right pipeline inside Zentinel matches the code path order (`request_filter` → `upstream_peer` → `response_filter` in `ProxyHttp`).
- Side channel to agents drawn vertically with the wire labelled (UDS/gRPC, v2 protocol).

## Scope

- Single file: `README.md`. 27 lines added (diagram + caption + one paragraph of context).
- No duplication: `.claude/CLAUDE.md` keeps its higher-level org-chart of the system, `crates/proxy/docs/architecture.md` keeps its per-phase reference. The README sits between them.

## Test plan

- [ ] Render on github.com and verify monospace alignment of the box characters.
- [ ] Render on docs.zentinelproxy.io / zentinelproxy.io README mirrors (if any).
- [ ] Confirm the link to `crates/proxy/docs/architecture.md` resolves.