### PR TITLE
fix(config): use `system` block in embedded default config (#231)

### DIFF
--- a/crates/config/src/defaults.rs
+++ b/crates/config/src/defaults.rs
@@ -18,7 +18,7 @@ pub const DEFAULT_CONFIG_KDL: &str = r#"
 // Configuration schema version - used for compatibility checking
 schema-version "1.0"
 
-server {
+system {
     worker-threads 0  // Auto-detect CPU cores
     max-connections 10000
     graceful-shutdown-timeout-secs 30


### PR DESCRIPTION
Closes #231.

The embedded \`DEFAULT_CONFIG_KDL\` in \`crates/config/src/defaults.rs\` still declared a \`server { ... }\` block, which was deprecated in favor of \`system { ... }\`. Result: every fresh start without an external config file (Docker without a mount, the \`zentinel\` binary with no \`-c\`) printed:

\`\`\`
WARN zentinel_config::kdl: The 'server' block is deprecated. Please use 'system' instead. This will be removed in a future version.
\`\`\`

Same fields, same semantics — only the container keyword changes.

## Test plan

- [x] Diff is exactly the keyword rename (\`server\` → \`system\`) on line 21 of \`crates/config/src/defaults.rs\`. The four child fields (\`worker-threads\`, \`max-connections\`, \`graceful-shutdown-timeout-secs\`) are unchanged.
- [ ] (For maintainer) — local toolchain here is rustc 1.92 and the workspace requires 1.94.1, so I couldn't run \`cargo test -p zentinel-config\` locally. The change is a 1-byte string-literal edit on a deprecated keyword that the parser already accepts, so risk is minimal, but a CI green pass would confirm.