### PR TITLE
chore(config): use `system` block in bundled KDL configs (#233)

### DIFF
--- a/config/example-multi-file/README.md
+++ b/config/example-multi-file/README.md
@@ -83,7 +83,7 @@ The main file contains global settings and defaults:
 
 ```kdl
 // zentinel.kdl - Core server configuration
-server {
+system {
     worker-threads 4
     graceful-shutdown-timeout "30s"
 }
@@ -189,7 +189,7 @@ Production-specific settings that override defaults:
 // environments/production.kdl
 // These settings override base configuration when --environment=production
 
-server {
+system {
     worker-threads 16  // More workers for production
 }
 

--- a/config/examples/ai-guardrails.kdl
+++ b/config/examples/ai-guardrails.kdl
@@ -3,7 +3,7 @@
 // This example demonstrates how to configure semantic guardrails for
 // LLM/AI endpoints including prompt injection detection and PII protection.
 
-server {
+system {
     worker-threads 4
     max-connections 5000
 }

--- a/config/examples/api-schema-validation.kdl
+++ b/config/examples/api-schema-validation.kdl
@@ -7,7 +7,7 @@
 //  - Inline JSON schema definitions (request-schema/response-schema)
 
 // Server Configuration
-server {
+system {
     workers 4
     daemon #false
 }

--- a/config/examples/distributed-rate-limit.kdl
+++ b/config/examples/distributed-rate-limit.kdl
@@ -3,7 +3,7 @@
 // This example demonstrates how to configure distributed rate limiting
 // using Redis or Memcached backends for multi-instance deployments.
 
-server {
+system {
     worker-threads 4
     max-connections 10000
 }

--- a/config/examples/http-caching.kdl
+++ b/config/examples/http-caching.kdl
@@ -3,7 +3,7 @@
 // This example demonstrates how to configure HTTP response caching
 // with different storage backends (memory, disk, hybrid).
 
-server {
+system {
     worker-threads 4
     max-connections 10000
 }

--- a/config/examples/inference-routing.kdl
+++ b/config/examples/inference-routing.kdl
@@ -3,7 +3,7 @@
 // This example demonstrates how to configure Zentinel for LLM/AI inference
 // endpoints with token-based rate limiting, model routing, and cost tracking.
 
-server {
+system {
     worker-threads 4
     max-connections 5000
     graceful-shutdown-timeout-secs 30

--- a/config/examples/namespaces.kdl
+++ b/config/examples/namespaces.kdl
@@ -7,7 +7,7 @@
 // - Resource exports for sharing across namespaces
 // - Hierarchical scope resolution (service → namespace → global)
 
-server {
+system {
     worker-threads 4
     max-connections 20000
 }

--- a/config/examples/shadow-traffic.kdl
+++ b/config/examples/shadow-traffic.kdl
@@ -6,7 +6,7 @@
 // - Load testing without affecting production
 // - Debugging and comparison testing
 
-server {
+system {
     worker-threads 4
     max-connections 10000
 }

--- a/deploy/zentinel.starter.kdl
+++ b/deploy/zentinel.starter.kdl
@@ -13,7 +13,7 @@
 
 schema-version "1.0"
 
-server {
+system {
     worker-threads 0           // 0 = auto-detect CPU cores
     max-connections 10000
     graceful-shutdown-timeout-secs 30


### PR DESCRIPTION
Closes #233. Follow-up to #232.

PR #232 fixed the embedded `DEFAULT_CONFIG_KDL` so the binary stops emitting the `server` deprecation warning on first run. The same deprecated keyword still appeared in every bundled config file users are likely to copy or follow, so the warning would still surface on any real deployment.

This PR sweeps the remaining `server { ... }` blocks to `system { ... }`:

- `deploy/zentinel.starter.kdl` — installer drop-in at `/etc/zentinel/zentinel.kdl` for `curl | sh` users
- `config/examples/ai-guardrails.kdl`
- `config/examples/api-schema-validation.kdl`
- `config/examples/distributed-rate-limit.kdl`
- `config/examples/http-caching.kdl`
- `config/examples/inference-routing.kdl`
- `config/examples/namespaces.kdl`
- `config/examples/shadow-traffic.kdl`
- `config/example-multi-file/README.md` (two snippets)

Pure keyword rename. The KDL parser already accepts both `system` (preferred) and `server` (deprecated) — see `crates/config/src/kdl/mod.rs:72-84` — and the fields inside the block are unchanged.

## Test plan

- [x] `cargo test -p zentinel-config --lib defaults` passes locally — including `test_starter_config_parses_and_validates`, the guard that exercises `deploy/zentinel.starter.kdl`.
- [x] `grep -rn "^server {" deploy/ config/` returns no results after the sweep.
- [ ] (For CI) full clippy / docs / fmt run — local toolchain here is rustc 1.92 and the workspace requires 1.94.1, so I let CI validate the wider build. This change is markdown + KDL only with no Rust source touched, so risk is minimal.

## Out of scope

- The Rust struct field `Config.server` and `ServerConfig` type name. Renaming those is a larger API change.
- The unrelated `server:` YAML keys in `config/agents/ratelimit.yaml` and `config/docker/ratelimit.yaml` — those belong to the rate-limit agent's own schema, not Zentinel's KDL.