### PR TITLE
deps: bump sysinfo to 0.39.1 + Rust toolchain to 1.95.0

### DIFF
--- a/.claude/rules/rust-standards.md
+++ b/.claude/rules/rust-standards.md
@@ -1,7 +1,7 @@
 # Rust Coding Standards
 
-> Minimum Rust version: **1.94.0** (Edition 2021)
-> Last updated: 2026-01-13
+> Minimum Rust version: **1.95.0** (Edition 2021)
+> Last updated: 2026-05-12
 
 These standards apply to all Rust code in Zentinel. They enforce the [Manifesto](../../MANIFESTO.md) principles of **explicit behavior**, **bounded resources**, and **production correctness**.
 
@@ -507,6 +507,7 @@ let handler = async |request: Request| {
 
 | Date | Rust Version | Changes |
 |------|--------------|---------|
+| 2026-05-12 | 1.95.0 | Bumped toolchain to unblock sysinfo 0.39 (requires 1.95) |
 | 2026-03-06 | 1.94.0 | Bumped toolchain; added array_windows, LazyLock::get |
 | 2026-01-13 | 1.92.0 | Integrated with Zentinel rules structure |
 | 2026-01-10 | 1.92.0 | Initial standards, added div_ceil, or_default, RwLock::downgrade |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,6 +1616,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3781,12 +3791,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
 ]
 
 [[package]]
@@ -3797,6 +3834,17 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -6015,15 +6063,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.4"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+checksum = "a4deba334e1190ba7cb498327affa11e5ece10d26a30ab2f27fcf09504b8d8b6"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
+ "objc2-open-directory",
  "windows",
 ]
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -37,7 +37,7 @@ chrono = { workspace = true }
 parking_lot = { workspace = true }
 
 # System metrics (not WASM-compatible)
-sysinfo = { version = "0.38", optional = true }
+sysinfo = { version = "0.39", optional = true }
 
 [features]
 default = ["runtime"]

--- a/crates/config/src/filters.rs
+++ b/crates/config/src/filters.rs
@@ -183,15 +183,11 @@ impl Filter {
     /// Validate the filter configuration
     pub fn validate(&self, available_agents: &[String]) -> Result<(), String> {
         match self {
-            Filter::RateLimit(r) => {
-                if r.max_rps == 0 {
-                    return Err("rate-limit max-rps must be > 0".into());
-                }
+            Filter::RateLimit(r) if r.max_rps == 0 => {
+                return Err("rate-limit max-rps must be > 0".into());
             }
-            Filter::Compress(c) => {
-                if c.algorithms.is_empty() {
-                    return Err("compress filter requires at least one algorithm".into());
-                }
+            Filter::Compress(c) if c.algorithms.is_empty() => {
+                return Err("compress filter requires at least one algorithm".into());
             }
             Filter::Geo(g) => {
                 if g.database_path.is_empty() {
@@ -207,13 +203,11 @@ impl Filter {
                     }
                 }
             }
-            Filter::Agent(a) => {
-                if !available_agents.contains(&a.agent) {
-                    return Err(format!(
-                        "agent filter references unknown agent '{}'. Available: {:?}",
-                        a.agent, available_agents
-                    ));
-                }
+            Filter::Agent(a) if !available_agents.contains(&a.agent) => {
+                return Err(format!(
+                    "agent filter references unknown agent '{}'. Available: {:?}",
+                    a.agent, available_agents
+                ));
             }
             _ => {}
         }

--- a/crates/proxy/src/proxy/filters.rs
+++ b/crates/proxy/src/proxy/filters.rs
@@ -36,18 +36,14 @@ pub async fn apply_request_filters(
         };
 
         match &filter_config.filter {
-            Filter::Redirect(redirect) => {
-                if apply_redirect(session, ctx, redirect).await? {
-                    return Ok(true); // Redirect sent, short-circuit
-                }
+            Filter::Redirect(redirect) if apply_redirect(session, ctx, redirect).await? => {
+                return Ok(true); // Redirect sent, short-circuit
             }
             Filter::UrlRewrite(rewrite) => {
                 apply_url_rewrite(session, ctx, rewrite);
             }
-            Filter::Cors(cors) => {
-                if apply_cors_preflight(session, ctx, cors).await? {
-                    return Ok(true); // Preflight handled, short-circuit
-                }
+            Filter::Cors(cors) if apply_cors_preflight(session, ctx, cors).await? => {
+                return Ok(true); // Preflight handled, short-circuit
             }
             Filter::Timeout(timeout) => {
                 apply_timeout_override(ctx, timeout);

--- a/crates/proxy/tests/websocket_test.rs
+++ b/crates/proxy/tests/websocket_test.rs
@@ -87,6 +87,8 @@ async fn handle_connection(stream: TcpStream) {
         match msg_result {
             Ok(msg) => {
                 // Echo back non-close messages
+                #[allow(clippy::collapsible_match)]
+                // collapsed form moves bound values consumed in arm body
                 match msg {
                     Message::Text(_) | Message::Binary(_) => {
                         if write.send(msg).await.is_err() {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.94.1"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]
 profile = "default"


### PR DESCRIPTION
## Summary

- `sysinfo` 0.38.4 → 0.39.1 (Dependabot #242)
- `rust-toolchain.toml`: 1.94.1 → 1.95.0 (required by sysinfo 0.39)
- Fixes new `collapsible_match` lints surfaced by Clippy 1.95 in `crates/config/src/filters.rs` and `crates/proxy/src/proxy/filters.rs`
- Updates MSRV note in `.claude/rules/rust-standards.md`

## Why bundled

`sysinfo 0.39.1` requires `rustc >= 1.95`, so #242 cannot land alone. Pairing the dep bump with the toolchain bump avoids leaving main in a broken state.

One match arm in `crates/proxy/tests/websocket_test.rs` keeps the original `if`-form (with inline `#[allow(clippy::collapsible_match)]`) because the collapsed match-guard form moves a bound value the arm body still consumes.

Supersedes #242 (to be closed once this merges).

## Test plan

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean locally on 1.95.0
- [x] `cargo fmt --all --check` clean
- [ ] CI green (Formatting / Clippy / Documentation)