### PR TITLE
chore: bump version to 0.6.14 for release 26.05_4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ for details.
 
 | CalVer | Crate Version | Date | Highlights |
 |--------|---------------|------|------------|
+| [26.05_4](#26054---2026-05-12) | 0.6.14 | 2026-05-12 | Dependency maintenance: OpenTelemetry 0.32, sysinfo 0.39, Rust toolchain 1.95 |
 | [26.05_3](#26053---2026-05-05) | 0.6.13 | 2026-05-05 | Embedded and bundled KDL configs use `system` block; ACME hickory-resolver 0.26 fix |
 | [26.05_2](#26052---2026-05-03) | 0.6.12 | 2026-05-03 | Install script provisions systemd unit, system user, and starter config |
 | [26.05_1](#26051---2026-05-01) | 0.6.11 | 2026-05-01 | Per-SNI ACME certificates for multi-tenant TLS, dependency updates |
@@ -43,6 +44,20 @@ for details.
 | [26.01_0](#26010---2026-01-01) | 0.2.0 | 2026-01-01 | First CalVer release |
 | [25.12](#2512) | 0.1.x | 2025-12 | Initial public releases |
 | [24.12](#2412) | 0.1.0 | 2024-12 | Initial development |
+
+---
+
+## [26.05_4] - 2026-05-12
+
+**Crate version:** 0.6.14
+
+### Changed
+- **Bump `opentelemetry`, `opentelemetry_sdk`, `opentelemetry-otlp` 0.31 → 0.32** as a coordinated stack. Bumping individually leaves the workspace with two versions of `opentelemetry` in the dependency graph, breaking trait resolution at the proxy boundary. (#244, supersedes #238 #239 #241)
+- **Bump `opentelemetry-semantic-conventions` 0.31 → 0.32.** (#240)
+- **Bump `sysinfo` 0.38.4 → 0.39.1.** Requires `rustc >= 1.95`, paired with the toolchain bump below. (#246, supersedes #242)
+- **Bump Rust toolchain 1.94.1 → 1.95.0** in `rust-toolchain.toml` and the workspace `rust-version`. Fixes three new `collapsible_match` lints surfaced by Clippy 1.95 in `crates/config/src/filters.rs` and `crates/proxy/src/proxy/filters.rs`. (#246)
+- **Bump `openssl` 0.10.78 → 0.10.79.** (#236)
+- **Bump rust-minor group.** Two batches of patch/minor bumps from the `rust-minor` Dependabot group. (#237, #245)
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8320,7 +8320,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8360,7 +8360,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8382,7 +8382,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8461,7 +8461,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8492,7 +8492,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8583,7 +8583,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8600,7 +8600,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,13 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.13"
+version = "0.6.14"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/zentinelproxy/zentinel"
 homepage = "https://github.com/zentinelproxy/zentinel"
-rust-version = "1.94.1"
+rust-version = "1.95.0"
 
 [workspace.dependencies]
 # Core dependencies (using our fork with security fixes, rebased on 0.8.0)


### PR DESCRIPTION
## Summary

Version bump PR for release **26.05_4** (crate version **0.6.14**).

- Workspace `version`: 0.6.13 → 0.6.14
- Workspace `rust-version`: 1.94.1 → 1.95.0 (matches `rust-toolchain.toml`)
- `cargo update --workspace` to refresh `Cargo.lock`
- `CHANGELOG.md` entry under `[26.05_4]` covering the dependency maintenance landed since 26.05_3

## Release contents (changes since 26.05_3)

- OpenTelemetry 0.31 → 0.32 (combined stack: #244, supersedes #238/#239/#241)
- `opentelemetry-semantic-conventions` 0.31 → 0.32 (#240)
- `sysinfo` 0.38.4 → 0.39.1 + Rust toolchain 1.95.0 (#246, supersedes #242)
- `openssl` 0.10.78 → 0.10.79 (#236)
- rust-minor group bumps (#237, #245)

## Test plan

- [ ] CI green (Formatting / Clippy / Documentation)
- [ ] After merge, tag `26.05_4` on the merge commit to trigger the Release workflow