### PR TITLE
fix: make the documented quickstart work out of the box (#254 #255 #256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,16 @@ for details.
 
 ---
 
+## [Unreleased]
+
+### Added
+- **Standalone Prometheus metrics server.** When `observability.metrics.enabled` is set, the proxy binds a dedicated HTTP listener on `observability.metrics.address` (default `0.0.0.0:9090`) and serves the Prometheus exposition format at `observability.metrics.path` (default `/metrics`), logging a `Metrics server listening` line at startup. Previously `address` was parsed but never consumed, so nothing bound the port — a silent failure that violated the "fail loudly" principle. (#256)
+
+### Fixed
+- **Default Docker image starts cleanly as a non-root user.** The distroless `proxy` and `proxy-prebuilt` images now ship `/var/log/zentinel` and `/var/lib/zentinel` owned by uid/gid 65532, and the bundled container config logs to stdout/stderr rather than a file. Previously the default config failed to initialize file logging under `/var/log/zentinel` (not writable by the non-root user), and a `tmpfs` mount did not resolve it. (#255)
+
+---
+
 ## [26.05_4] - 2026-05-12
 
 **Crate version:** 0.6.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ for details.
 
 ### Fixed
 - **Default Docker image starts cleanly as a non-root user.** The distroless `proxy` and `proxy-prebuilt` images now ship `/var/log/zentinel` and `/var/lib/zentinel` owned by uid/gid 65532, and the bundled container config logs to stdout/stderr rather than a file. Previously the default config failed to initialize file logging under `/var/log/zentinel` (not writable by the non-root user), and a `tmpfs` mount did not resolve it. (#255)
+- **Upstream `target` syntax is now identical across single-file and multi-file configs.** The two KDL parsers previously accepted *disjoint* target syntaxes — the single-file parser only took the `target "host:port"` shorthand while the multi-file parser only took the `targets { target { address … } }` block form — so a config copied between layouts (or from the docs) could fail with "requires at least one target". A single shared parser now accepts the shorthand, block form, property form, the `targets { … }` wrapper, and the top-level `address` shorthand in both. This was the root cause behind #254. (#254)
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,19 @@ RUN find . -name "main.rs" -exec touch {} \; && \
 RUN cargo build --release --package zentinel-proxy --package zentinel-echo-agent --package zentinel-gateway
 
 ################################################################################
+# Runtime directory stage
+#
+# Distroless images have no shell, so we cannot mkdir/chown inside them at build
+# time. This tiny stage materializes the runtime state and log directories so
+# they can be COPYed into the distroless stages with the correct non-root
+# ownership (uid/gid 65532). Without these, the default config cannot open its
+# error log under /var/log/zentinel as the non-root user. See
+# zentinelproxy/zentinel#255.
+################################################################################
+FROM busybox:1.37 AS runtime-dirs
+RUN mkdir -p /var/log/zentinel /var/lib/zentinel
+
+################################################################################
 # Production image: Distroless (smallest, most secure)
 #
 # Uses gcr.io/distroless/cc-debian12 which includes:
@@ -96,6 +109,10 @@ COPY --from=builder /app/target/release/zentinel /zentinel
 
 # Copy default configuration
 COPY config/docker/default.kdl /etc/zentinel/zentinel.kdl
+
+# Writable runtime directories owned by the non-root user (uid/gid 65532).
+COPY --from=runtime-dirs --chown=65532:65532 /var/log/zentinel /var/log/zentinel
+COPY --from=runtime-dirs --chown=65532:65532 /var/lib/zentinel /var/lib/zentinel
 
 # Labels for container metadata
 LABEL org.opencontainers.image.title="Zentinel" \
@@ -186,6 +203,10 @@ COPY zentinel /zentinel
 
 # Copy default configuration
 COPY config/docker/default.kdl /etc/zentinel/zentinel.kdl
+
+# Writable runtime directories owned by the non-root user (uid/gid 65532).
+COPY --from=runtime-dirs --chown=65532:65532 /var/log/zentinel /var/log/zentinel
+COPY --from=runtime-dirs --chown=65532:65532 /var/lib/zentinel /var/lib/zentinel
 
 LABEL org.opencontainers.image.title="Zentinel" \
       org.opencontainers.image.description="Security-first reverse proxy built on Pingora"

--- a/config/docker/default.kdl
+++ b/config/docker/default.kdl
@@ -61,5 +61,13 @@ observability {
     logging {
         level "info"
         format "json"
+        // Containers log to stdout/stderr by default; `docker logs` and
+        // Kubernetes capture that stream. File logging is left disabled so the
+        // default config starts cleanly even when /var/log is read-only or a
+        // tmpfs/volume owned by root. To keep on-disk logs, enable this and
+        // mount a writable volume at /var/log/zentinel.
+        error-log {
+            enabled #false
+        }
     }
 }

--- a/crates/config/docs/kdl-format.md
+++ b/crates/config/docs/kdl-format.md
@@ -346,6 +346,38 @@ upstreams {
 }
 ```
 
+#### Target syntax
+
+Targets accept several equivalent forms — use whichever reads best. The
+shorthand (`target "host:port"`) is recommended:
+
+```kdl
+upstream "backend" {
+    // Shorthand: address as the first argument (recommended)
+    target "127.0.0.1:8081"
+    target "127.0.0.1:8082" weight=2
+
+    // Block form: address (and weight) as child nodes
+    target { address "127.0.0.1:8083"; weight 3 }
+
+    // Property form
+    target address="127.0.0.1:8084" weight=4
+
+    // Optional `targets { ... }` wrapper around any of the above
+    targets {
+        target "127.0.0.1:8085"
+    }
+}
+
+// Single-target shorthand on the upstream itself
+upstream "single" {
+    address "127.0.0.1:8086"
+}
+```
+
+All forms are accepted identically whether the config is a single file or
+split across multiple files.
+
 ### Filters Block
 
 ```kdl

--- a/crates/config/src/defaults.rs
+++ b/crates/config/src/defaults.rs
@@ -131,14 +131,17 @@ limits {
 
 // Observability uses defaults:
 // - Metrics enabled at /metrics
-// - JSON logging at info level
-// - Error log enabled at /var/log/zentinel/error.log (level: warn)
+// - JSON logging at info level to stdout/stderr
+//
+// File logging is left disabled in the embedded default so `zentinel` with no
+// config file starts cleanly for any user — writing to /var/log/zentinel
+// requires a writable directory the process may not own. Enable the error/
+// access/audit logs explicitly (and ensure the directory is writable) to get
+// on-disk logs; the systemd unit provisions /var/log/zentinel via LogsDirectory.
 observability {
     logging {
         error-log {
-            enabled #true
-            file "/var/log/zentinel/error.log"
-            level "warn"
+            enabled #false
         }
     }
 }

--- a/crates/config/src/kdl/helpers.rs
+++ b/crates/config/src/kdl/helpers.rs
@@ -2,6 +2,10 @@
 //!
 //! Common utilities for extracting values from KDL nodes.
 
+use std::collections::HashMap;
+
+use crate::upstreams::UpstreamTarget;
+
 /// Convert a byte offset to line and column numbers (1-indexed)
 pub fn offset_to_line_col(content: &str, offset: usize) -> (usize, usize) {
     let mut line = 1;
@@ -64,4 +68,115 @@ pub fn get_first_arg_string(node: &kdl::KdlNode) -> Option<String> {
         .first()
         .and_then(|e| e.value().as_string())
         .map(|s| s.to_string())
+}
+
+/// Read a named property entry as a string (e.g. `address="host:port"`).
+fn named_string_entry(node: &kdl::KdlNode, name: &str) -> Option<String> {
+    node.entries()
+        .iter()
+        .find(|e| e.name().map(|n| n.value()) == Some(name))
+        .and_then(|e| e.value().as_string())
+        .map(|s| s.to_string())
+}
+
+/// Read a named property entry as an integer (e.g. `weight=2`).
+fn named_int_entry(node: &kdl::KdlNode, name: &str) -> Option<i128> {
+    node.entries()
+        .iter()
+        .find(|e| e.name().map(|n| n.value()) == Some(name))
+        .and_then(|e| e.value().as_integer())
+}
+
+/// Resolve an `address` given as a property (`address="x"`) or child node (`address "x"`).
+fn target_address_field(node: &kdl::KdlNode) -> Option<String> {
+    named_string_entry(node, "address").or_else(|| get_string_entry(node, "address"))
+}
+
+/// Resolve a single `target` node's address and weight across every accepted form.
+fn parse_single_target(node: &kdl::KdlNode) -> Option<UpstreamTarget> {
+    // Address: first positional arg, else an `address` property/child node.
+    let address = get_first_arg_string(node).or_else(|| target_address_field(node))?;
+
+    // Weight: `weight=N` property, else `weight N` child node; defaults to 1.
+    let weight = named_int_entry(node, "weight")
+        .or_else(|| get_int_entry(node, "weight"))
+        .map(|v| v as u32)
+        .unwrap_or(1);
+
+    Some(UpstreamTarget {
+        address,
+        weight,
+        max_requests: None,
+        metadata: HashMap::new(),
+    })
+}
+
+/// Parse upstream targets from an `upstream` node.
+///
+/// Shared by the single-file and multi-file parsers so both accept the same
+/// syntax — the divergence here was the root cause of zentinelproxy/zentinel#254.
+/// Every form below is accepted:
+///
+/// ```kdl
+/// // Shorthand: address as the first argument
+/// target "127.0.0.1:8081"
+/// target "127.0.0.1:8082" weight=2
+///
+/// // Block form: address (and weight) as child nodes or properties
+/// target { address "127.0.0.1:8081"; weight 2 }
+/// target address="127.0.0.1:8081" weight=2
+///
+/// // Wrapped in a `targets` block
+/// targets {
+///     target "127.0.0.1:8081"
+///     target { address "127.0.0.1:8082" weight=2 }
+/// }
+///
+/// // Single-target shorthand on the upstream itself
+/// address "127.0.0.1:8081"
+/// ```
+///
+/// Targets without a resolvable address are skipped (rather than silently
+/// defaulted), so a misconfigured upstream surfaces as "no targets" during
+/// validation instead of pointing at a bogus address.
+pub fn parse_upstream_targets(upstream: &kdl::KdlNode) -> Vec<UpstreamTarget> {
+    let mut targets = Vec::new();
+
+    if let Some(children) = upstream.children() {
+        for node in children.nodes() {
+            match node.name().value() {
+                "target" => {
+                    if let Some(target) = parse_single_target(node) {
+                        targets.push(target);
+                    }
+                }
+                "targets" => {
+                    if let Some(target_children) = node.children() {
+                        for target_node in target_children.nodes() {
+                            if target_node.name().value() == "target" {
+                                if let Some(target) = parse_single_target(target_node) {
+                                    targets.push(target);
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // Single-target shorthand: `address "host:port"` directly on the upstream.
+    if targets.is_empty() {
+        if let Some(address) = target_address_field(upstream) {
+            targets.push(UpstreamTarget {
+                address,
+                weight: 1,
+                max_requests: None,
+                metadata: HashMap::new(),
+            });
+        }
+    }
+
+    targets
 }

--- a/crates/config/src/kdl/mod.rs
+++ b/crates/config/src/kdl/mod.rs
@@ -22,6 +22,7 @@ use tracing::{debug, trace, warn};
 // Re-export commonly used items
 pub use helpers::{
     get_bool_entry, get_first_arg_string, get_int_entry, get_string_entry, offset_to_line_col,
+    parse_upstream_targets,
 };
 
 pub use filters::parse_filter_definitions;

--- a/crates/config/src/kdl/upstreams.rs
+++ b/crates/config/src/kdl/upstreams.rs
@@ -9,7 +9,7 @@ use zentinel_common::types::{HealthCheckType, LoadBalancingAlgorithm};
 
 use crate::upstreams::*;
 
-use super::helpers::{get_first_arg_string, get_int_entry};
+use super::helpers::{get_first_arg_string, get_int_entry, parse_upstream_targets};
 
 /// Parse upstreams configuration block
 pub fn parse_upstreams(node: &kdl::KdlNode) -> Result<HashMap<String, UpstreamConfig>> {
@@ -27,37 +27,9 @@ pub fn parse_upstreams(node: &kdl::KdlNode) -> Result<HashMap<String, UpstreamCo
 
                 trace!(upstream_id = %id, "Parsing upstream");
 
-                // Parse targets
-                let mut targets = Vec::new();
-                if let Some(upstream_children) = child.children() {
-                    for target_node in upstream_children.nodes() {
-                        if target_node.name().value() == "target" {
-                            if let Some(address) = get_first_arg_string(target_node) {
-                                let weight = target_node
-                                    .entries()
-                                    .iter()
-                                    .find(|e| e.name().map(|n| n.value()) == Some("weight"))
-                                    .and_then(|e| e.value().as_integer())
-                                    .map(|v| v as u32)
-                                    .unwrap_or(1);
-
-                                trace!(
-                                    upstream_id = %id,
-                                    address = %address,
-                                    weight = weight,
-                                    "Parsed target"
-                                );
-
-                                targets.push(UpstreamTarget {
-                                    address,
-                                    weight,
-                                    max_requests: None,
-                                    metadata: HashMap::new(),
-                                });
-                            }
-                        }
-                    }
-                }
+                // Parse targets (accepts every supported syntax; see
+                // `parse_upstream_targets`).
+                let targets = parse_upstream_targets(child);
 
                 if targets.is_empty() {
                     return Err(anyhow::anyhow!(
@@ -724,6 +696,87 @@ mod tests {
         let doc: kdl::KdlDocument = input.parse().unwrap();
         let node = doc.nodes().first().unwrap();
         parse_upstreams(node)
+    }
+
+    fn targets_of(kdl: &str, id: &str) -> Vec<UpstreamTarget> {
+        parse_kdl_upstreams(kdl)
+            .unwrap()
+            .get(id)
+            .unwrap()
+            .targets
+            .clone()
+    }
+
+    #[test]
+    fn test_target_shorthand_first_arg() {
+        let t = targets_of(
+            r#"upstreams { upstream "b" { target "127.0.0.1:8081" weight=2 } }"#,
+            "b",
+        );
+        assert_eq!(t.len(), 1);
+        assert_eq!(t[0].address, "127.0.0.1:8081");
+        assert_eq!(t[0].weight, 2);
+    }
+
+    #[test]
+    fn test_target_block_form_inside_targets() {
+        // The form the quickstart docs showed — previously rejected by the
+        // single-file parser (zentinelproxy/zentinel#254).
+        let t = targets_of(
+            r#"
+            upstreams {
+                upstream "b" {
+                    targets {
+                        target { address "127.0.0.1:3000"; weight 3 }
+                        target { address "127.0.0.1:3001" }
+                    }
+                }
+            }
+            "#,
+            "b",
+        );
+        assert_eq!(t.len(), 2);
+        assert_eq!(t[0].address, "127.0.0.1:3000");
+        assert_eq!(t[0].weight, 3);
+        assert_eq!(t[1].address, "127.0.0.1:3001");
+        assert_eq!(t[1].weight, 1);
+    }
+
+    #[test]
+    fn test_target_block_form_without_wrapper() {
+        let t = targets_of(
+            r#"upstreams { upstream "b" { target { address "10.0.0.1:80" } } }"#,
+            "b",
+        );
+        assert_eq!(t.len(), 1);
+        assert_eq!(t[0].address, "10.0.0.1:80");
+    }
+
+    #[test]
+    fn test_target_address_property_form() {
+        let t = targets_of(
+            r#"upstreams { upstream "b" { target address="10.0.0.1:80" weight=5 } }"#,
+            "b",
+        );
+        assert_eq!(t.len(), 1);
+        assert_eq!(t[0].address, "10.0.0.1:80");
+        assert_eq!(t[0].weight, 5);
+    }
+
+    #[test]
+    fn test_upstream_address_shorthand() {
+        let t = targets_of(
+            r#"upstreams { upstream "b" { address "10.0.0.1:80" } }"#,
+            "b",
+        );
+        assert_eq!(t.len(), 1);
+        assert_eq!(t[0].address, "10.0.0.1:80");
+    }
+
+    #[test]
+    fn test_upstream_no_target_errors() {
+        let err = parse_kdl_upstreams(r#"upstreams { upstream "b" { } }"#).unwrap_err();
+        assert!(err.to_string().contains("at least one target"));
     }
 
     #[test]

--- a/crates/config/src/multi_file/parsers.rs
+++ b/crates/config/src/multi_file/parsers.rs
@@ -5,7 +5,6 @@
 
 use anyhow::{anyhow, Result};
 use kdl::KdlNode;
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 use zentinel_common::TraceIdFormat;
@@ -183,42 +182,8 @@ pub(super) fn parse_route(node: &KdlNode) -> Result<RouteConfig> {
 pub(super) fn parse_upstream(node: &KdlNode) -> Result<(String, UpstreamConfig)> {
     let name = get_first_arg_string(node).ok_or_else(|| anyhow!("Upstream requires a name"))?;
 
-    let mut targets = Vec::new();
-
-    // Parse targets from children
-    if let Some(children) = node.children() {
-        if let Some(targets_node) = children.get("targets") {
-            if let Some(target_children) = targets_node.children() {
-                for target_node in target_children.nodes() {
-                    if target_node.name().value() == "target" {
-                        let address = get_string_entry(target_node, "address")
-                            .unwrap_or_else(|| "127.0.0.1:8080".to_string());
-                        let weight = get_int_entry(target_node, "weight")
-                            .map(|v| v as u32)
-                            .unwrap_or(1);
-                        targets.push(crate::UpstreamTarget {
-                            address,
-                            weight,
-                            max_requests: None,
-                            metadata: HashMap::new(),
-                        });
-                    }
-                }
-            }
-        }
-    }
-
-    // If no targets defined, use address from node directly
-    if targets.is_empty() {
-        if let Some(address) = get_string_entry(node, "address") {
-            targets.push(crate::UpstreamTarget {
-                address,
-                weight: 1,
-                max_requests: None,
-                metadata: HashMap::new(),
-            });
-        }
-    }
+    // Shared with the single-file parser so both accept the same target syntax.
+    let targets = crate::kdl::parse_upstream_targets(node);
 
     Ok((
         name.clone(),
@@ -587,4 +552,44 @@ fn parse_exports(node: &KdlNode) -> Result<ExportConfig> {
     }
 
     Ok(exports)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn upstream_from(kdl: &str) -> UpstreamConfig {
+        let doc: kdl::KdlDocument = kdl.parse().unwrap();
+        let node = doc.nodes().first().unwrap();
+        parse_upstream(node).unwrap().1
+    }
+
+    #[test]
+    fn multi_file_accepts_target_shorthand() {
+        // Previously the multi-file parser only accepted the `targets { ... }`
+        // block form; the `target "addr"` shorthand now works too, matching the
+        // single-file parser (zentinelproxy/zentinel#254).
+        let u = upstream_from(r#"upstream "b" { target "127.0.0.1:8081" weight=2 }"#);
+        assert_eq!(u.targets.len(), 1);
+        assert_eq!(u.targets[0].address, "127.0.0.1:8081");
+        assert_eq!(u.targets[0].weight, 2);
+    }
+
+    #[test]
+    fn multi_file_accepts_targets_block() {
+        let u = upstream_from(
+            r#"
+            upstream "b" {
+                targets {
+                    target { address "127.0.0.1:3000"; weight 3 }
+                    target "127.0.0.1:3001"
+                }
+            }
+            "#,
+        );
+        assert_eq!(u.targets.len(), 2);
+        assert_eq!(u.targets[0].address, "127.0.0.1:3000");
+        assert_eq!(u.targets[0].weight, 3);
+        assert_eq!(u.targets[1].address, "127.0.0.1:3001");
+    }
 }

--- a/crates/config/src/validation.rs
+++ b/crates/config/src/validation.rs
@@ -1038,16 +1038,6 @@ fn validate_implementation_status(
         }
     }
 
-    // Metrics: address requires a dedicated HTTP server (not yet wired)
-    let metrics = &config.observability.metrics;
-    if metrics.address != "0.0.0.0:9090" {
-        warnings.push(format!(
-            "Metrics endpoint address='{}' is configured but a dedicated metrics HTTP server \
-             is not yet implemented. Use RUST_LOG and external scraping as a workaround.",
-            metrics.address
-        ));
-    }
-
     // Logging: level/format are controlled by RUST_LOG env var and --verbose flag,
     // not yet by the config file. File output also not yet wired.
     let logging = &config.observability.logging;

--- a/crates/config/src/validation.rs
+++ b/crates/config/src/validation.rs
@@ -1869,9 +1869,6 @@ mod tests {
         // max_concurrent_streams (unwired — Pingora H2 per-listener config)
         config.listeners[0].max_concurrent_streams = 200; // non-default → produces warning
 
-        // Metrics address (unwired — no dedicated HTTP server yet)
-        config.observability.metrics.address = "0.0.0.0:9191".to_string(); // non-default → warning
-
         // Logging file (unwired — goes to stdout/stderr)
         config.observability.logging.file = Some("/var/log/zentinel/app.log".into());
 
@@ -1894,7 +1891,6 @@ mod tests {
             "min_version",
             "max_version",
             "max_concurrent_streams",
-            "Metrics endpoint address",
             "logging.file",
             "Logging level",
         ];

--- a/crates/proxy/src/builtin_handlers.rs
+++ b/crates/proxy/src/builtin_handlers.rs
@@ -229,73 +229,87 @@ fn health_handler(request_id: &str) -> Response<Full<Bytes>> {
         .expect("static response builder with valid headers cannot fail")
 }
 
+/// Content type for the Prometheus text exposition format.
+pub(crate) const PROMETHEUS_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
+
+/// Render the Prometheus exposition body.
+///
+/// Shared by the builtin `/metrics` route handler and the standalone metrics
+/// server (see [`crate::metrics_server`]) so both expose identical output.
+///
+/// # Errors
+///
+/// Returns an error if the Prometheus encoder fails to serialize the gathered
+/// metric families (in practice this does not happen for the text encoder).
+pub(crate) fn render_prometheus_metrics(
+    cache_stats: Option<&Arc<HttpCacheStats>>,
+) -> Result<Vec<u8>, prometheus::Error> {
+    use prometheus::{Encoder, TextEncoder};
+
+    let encoder = TextEncoder::new();
+    let metric_families = prometheus::gather();
+
+    let mut buffer = Vec::new();
+    encoder.encode(&metric_families, &mut buffer)?;
+
+    // Add zentinel_up and build_info metrics
+    let extra_metrics = format!(
+        "# HELP zentinel_up Zentinel proxy is up and running\n\
+         # TYPE zentinel_up gauge\n\
+         zentinel_up 1\n\
+         # HELP zentinel_build_info Build information\n\
+         # TYPE zentinel_build_info gauge\n\
+         zentinel_build_info{{version=\"{}\"}} 1\n",
+        env!("CARGO_PKG_VERSION")
+    );
+    buffer.extend_from_slice(extra_metrics.as_bytes());
+
+    // Add HTTP cache metrics if available
+    if let Some(stats) = cache_stats {
+        let cache_metrics = format!(
+            "# HELP zentinel_cache_hits_total Total number of cache hits\n\
+             # TYPE zentinel_cache_hits_total counter\n\
+             zentinel_cache_hits_total {}\n\
+             # HELP zentinel_cache_misses_total Total number of cache misses\n\
+             # TYPE zentinel_cache_misses_total counter\n\
+             zentinel_cache_misses_total {}\n\
+             # HELP zentinel_cache_stores_total Total number of cache stores\n\
+             # TYPE zentinel_cache_stores_total counter\n\
+             zentinel_cache_stores_total {}\n\
+             # HELP zentinel_cache_hit_ratio Cache hit ratio (0.0 to 1.0)\n\
+             # TYPE zentinel_cache_hit_ratio gauge\n\
+             zentinel_cache_hit_ratio {:.4}\n\
+             # HELP zentinel_cache_memory_hits_total Cache hits from memory tier\n\
+             # TYPE zentinel_cache_memory_hits_total counter\n\
+             zentinel_cache_memory_hits_total {}\n\
+             # HELP zentinel_cache_disk_hits_total Cache hits from disk tier\n\
+             # TYPE zentinel_cache_disk_hits_total counter\n\
+             zentinel_cache_disk_hits_total {}\n",
+            stats.hits(),
+            stats.misses(),
+            stats.stores(),
+            stats.hit_ratio(),
+            stats.memory_hits(),
+            stats.disk_hits()
+        );
+        buffer.extend_from_slice(cache_metrics.as_bytes());
+    }
+
+    Ok(buffer)
+}
+
 /// Prometheus metrics handler
 fn metrics_handler(
     request_id: &str,
     cache_stats: Option<&Arc<HttpCacheStats>>,
 ) -> Response<Full<Bytes>> {
-    use prometheus::{Encoder, TextEncoder};
-
-    // Create encoder for Prometheus text format
-    let encoder = TextEncoder::new();
-
-    // Gather all metrics from the default registry
-    let metric_families = prometheus::gather();
-
-    // Encode metrics to text format
-    let mut buffer = Vec::new();
-    match encoder.encode(&metric_families, &mut buffer) {
-        Ok(()) => {
-            // Add zentinel_up and build_info metrics
-            let extra_metrics = format!(
-                "# HELP zentinel_up Zentinel proxy is up and running\n\
-                 # TYPE zentinel_up gauge\n\
-                 zentinel_up 1\n\
-                 # HELP zentinel_build_info Build information\n\
-                 # TYPE zentinel_build_info gauge\n\
-                 zentinel_build_info{{version=\"{}\"}} 1\n",
-                env!("CARGO_PKG_VERSION")
-            );
-            buffer.extend_from_slice(extra_metrics.as_bytes());
-
-            // Add HTTP cache metrics if available
-            if let Some(stats) = cache_stats {
-                let cache_metrics = format!(
-                    "# HELP zentinel_cache_hits_total Total number of cache hits\n\
-                     # TYPE zentinel_cache_hits_total counter\n\
-                     zentinel_cache_hits_total {}\n\
-                     # HELP zentinel_cache_misses_total Total number of cache misses\n\
-                     # TYPE zentinel_cache_misses_total counter\n\
-                     zentinel_cache_misses_total {}\n\
-                     # HELP zentinel_cache_stores_total Total number of cache stores\n\
-                     # TYPE zentinel_cache_stores_total counter\n\
-                     zentinel_cache_stores_total {}\n\
-                     # HELP zentinel_cache_hit_ratio Cache hit ratio (0.0 to 1.0)\n\
-                     # TYPE zentinel_cache_hit_ratio gauge\n\
-                     zentinel_cache_hit_ratio {:.4}\n\
-                     # HELP zentinel_cache_memory_hits_total Cache hits from memory tier\n\
-                     # TYPE zentinel_cache_memory_hits_total counter\n\
-                     zentinel_cache_memory_hits_total {}\n\
-                     # HELP zentinel_cache_disk_hits_total Cache hits from disk tier\n\
-                     # TYPE zentinel_cache_disk_hits_total counter\n\
-                     zentinel_cache_disk_hits_total {}\n",
-                    stats.hits(),
-                    stats.misses(),
-                    stats.stores(),
-                    stats.hit_ratio(),
-                    stats.memory_hits(),
-                    stats.disk_hits()
-                );
-                buffer.extend_from_slice(cache_metrics.as_bytes());
-            }
-
-            Response::builder()
-                .status(StatusCode::OK)
-                .header("Content-Type", encoder.format_type())
-                .header("X-Request-Id", request_id)
-                .body(Full::new(Bytes::from(buffer)))
-                .expect("static response builder with valid headers cannot fail")
-        }
+    match render_prometheus_metrics(cache_stats) {
+        Ok(buffer) => Response::builder()
+            .status(StatusCode::OK)
+            .header("Content-Type", PROMETHEUS_CONTENT_TYPE)
+            .header("X-Request-Id", request_id)
+            .body(Full::new(Bytes::from(buffer)))
+            .expect("static response builder with valid headers cannot fail"),
         Err(e) => {
             tracing::error!(error = %e, "Failed to encode Prometheus metrics");
             let error_body = format!("# ERROR: Failed to encode metrics: {}\n", e);

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -66,6 +66,7 @@ pub mod kubeconfig;
 pub mod logging;
 pub mod memory_cache;
 pub mod metrics;
+pub mod metrics_server;
 pub mod otel;
 pub mod proxy;
 pub mod rate_limit;

--- a/crates/proxy/src/main.rs
+++ b/crates/proxy/src/main.rs
@@ -600,6 +600,27 @@ fn run_server(
     // Get initial config for server setup
     let config = proxy.config_manager.current();
 
+    // Start the standalone Prometheus metrics server if enabled.
+    // `observability.metrics.address` is a dedicated listener, separate from the
+    // data-plane listeners, so the scrape endpoint is never exposed to client
+    // traffic by accident.
+    {
+        let metrics_cfg = config.observability.metrics.clone();
+        if metrics_cfg.enabled {
+            let cache_stats = Some(proxy.http_cache_stats());
+            runtime.spawn(async move {
+                zentinel_proxy::metrics_server::run_metrics_server(
+                    metrics_cfg.address,
+                    metrics_cfg.path,
+                    cache_stats,
+                )
+                .await;
+            });
+        } else {
+            info!("Metrics server disabled (observability.metrics.enabled = false)");
+        }
+    }
+
     // Setup signal handlers (runs in separate thread, needs config for shutdown timeout)
     setup_signal_handlers(
         signal_manager.sender(),

--- a/crates/proxy/src/metrics.rs
+++ b/crates/proxy/src/metrics.rs
@@ -54,9 +54,9 @@ impl MetricsManager {
 
     /// Create from metrics configuration.
     ///
-    /// Applies `enabled` and `path` from the config.
-    /// The `address` field determines which listener serves the metrics
-    /// endpoint but is handled at the listener level, not here.
+    /// Applies `enabled` and `path` from the config. The `address` field is
+    /// consumed separately by the standalone metrics server (see
+    /// [`crate::metrics_server`]), which binds the dedicated scrape listener.
     pub fn from_config(
         config: &zentinel_config::MetricsConfig,
         service_name: impl Into<String>,

--- a/crates/proxy/src/metrics_server.rs
+++ b/crates/proxy/src/metrics_server.rs
@@ -83,11 +83,7 @@ async fn handle_connection(
     let request = String::from_utf8_lossy(&buf[..n]);
 
     // Parse the request line: "GET /metrics?foo=bar HTTP/1.1"
-    let mut request_line = request
-        .lines()
-        .next()
-        .unwrap_or("")
-        .split_whitespace();
+    let mut request_line = request.lines().next().unwrap_or("").split_whitespace();
     let _method = request_line.next().unwrap_or("");
     let raw_target = request_line.next().unwrap_or("/");
     let req_path = raw_target.split('?').next().unwrap_or(raw_target);

--- a/crates/proxy/src/metrics_server.rs
+++ b/crates/proxy/src/metrics_server.rs
@@ -1,0 +1,247 @@
+//! Standalone HTTP server that exposes Prometheus metrics.
+//!
+//! When `observability.metrics.enabled` is set, the proxy binds a dedicated
+//! HTTP listener on `observability.metrics.address` and serves the Prometheus
+//! exposition format at `observability.metrics.path` (default `/metrics`).
+//!
+//! This is intentionally separate from the data-plane listeners so that the
+//! scrape endpoint can be bound to an internal address and is never exposed to
+//! client traffic by accident. The body is produced by the same renderer used
+//! by the builtin `/metrics` route handler, so both surfaces are identical.
+
+use std::sync::Arc;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tracing::{debug, error, info, warn};
+
+use crate::builtin_handlers::{render_prometheus_metrics, PROMETHEUS_CONTENT_TYPE};
+use crate::cache::HttpCacheStats;
+
+/// Maximum request size to read. Scrape requests are tiny; this bounds the
+/// per-connection buffer so a misbehaving client cannot force large allocations.
+const MAX_REQUEST_SIZE: usize = 8192;
+
+/// Run the standalone Prometheus metrics server.
+///
+/// Binds `addr` and serves the metrics body at `path`. A binding failure is
+/// logged loudly and the metrics endpoint is left disabled, but it never takes
+/// the proxy down — metrics are auxiliary and must not worsen an on-call.
+///
+/// This function runs until the process exits.
+pub async fn run_metrics_server(
+    addr: String,
+    path: String,
+    cache_stats: Option<Arc<HttpCacheStats>>,
+) {
+    let listener = match TcpListener::bind(&addr).await {
+        Ok(listener) => listener,
+        Err(e) => {
+            error!(
+                address = %addr,
+                error = %e,
+                "Failed to bind metrics server; metrics endpoint disabled"
+            );
+            return;
+        }
+    };
+
+    info!(address = %addr, path = %path, "Metrics server listening");
+
+    loop {
+        match listener.accept().await {
+            Ok((mut stream, peer)) => {
+                let path = path.clone();
+                let cache_stats = cache_stats.clone();
+                tokio::spawn(async move {
+                    if let Err(e) =
+                        handle_connection(&mut stream, &path, cache_stats.as_ref()).await
+                    {
+                        debug!(peer = %peer, error = %e, "Metrics server connection error");
+                    }
+                });
+            }
+            Err(e) => {
+                warn!(error = %e, "Metrics server accept error");
+            }
+        }
+    }
+}
+
+/// Handle a single HTTP connection on the metrics server.
+async fn handle_connection(
+    stream: &mut tokio::net::TcpStream,
+    metrics_path: &str,
+    cache_stats: Option<&Arc<HttpCacheStats>>,
+) -> std::io::Result<()> {
+    let mut buf = vec![0u8; MAX_REQUEST_SIZE];
+    let n = stream.read(&mut buf).await?;
+    if n == 0 {
+        return Ok(());
+    }
+
+    let request = String::from_utf8_lossy(&buf[..n]);
+
+    // Parse the request line: "GET /metrics?foo=bar HTTP/1.1"
+    let mut request_line = request
+        .lines()
+        .next()
+        .unwrap_or("")
+        .split_whitespace();
+    let _method = request_line.next().unwrap_or("");
+    let raw_target = request_line.next().unwrap_or("/");
+    let req_path = raw_target.split('?').next().unwrap_or(raw_target);
+
+    let response = if req_path == metrics_path {
+        match render_prometheus_metrics(cache_stats) {
+            Ok(body) => http_response("200 OK", PROMETHEUS_CONTENT_TYPE, &body),
+            Err(e) => {
+                error!(error = %e, "Failed to encode Prometheus metrics");
+                http_response(
+                    "500 Internal Server Error",
+                    "text/plain; charset=utf-8",
+                    format!("# ERROR: Failed to encode metrics: {}\n", e).as_bytes(),
+                )
+            }
+        }
+    } else if req_path == "/" {
+        // A tiny landing page so an operator hitting the address in a browser
+        // is pointed at the metrics path instead of getting a bare 404.
+        let body = format!(
+            "<html><head><title>Zentinel Metrics</title></head>\
+             <body><h1>Zentinel Metrics</h1>\
+             <p><a href=\"{path}\">{path}</a></p></body></html>",
+            path = metrics_path
+        );
+        http_response("200 OK", "text/html; charset=utf-8", body.as_bytes())
+    } else {
+        http_response("404 Not Found", "text/plain; charset=utf-8", b"Not Found\n")
+    };
+
+    stream.write_all(&response).await?;
+    stream.flush().await?;
+    Ok(())
+}
+
+/// Build a raw HTTP/1.1 response with `Connection: close`.
+fn http_response(status: &str, content_type: &str, body: &[u8]) -> Vec<u8> {
+    let mut response = format!(
+        "HTTP/1.1 {status}\r\n\
+         Content-Type: {content_type}\r\n\
+         Content-Length: {len}\r\n\
+         Connection: close\r\n\r\n",
+        status = status,
+        content_type = content_type,
+        len = body.len()
+    )
+    .into_bytes();
+    response.extend_from_slice(body);
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpStream;
+
+    async fn read_response(stream: &mut TcpStream) -> String {
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await.unwrap();
+        String::from_utf8_lossy(&buf).to_string()
+    }
+
+    #[tokio::test]
+    async fn serves_metrics_at_configured_path() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            handle_connection(&mut stream, "/metrics", None)
+                .await
+                .unwrap();
+        });
+
+        let mut client = TcpStream::connect(addr).await.unwrap();
+        client
+            .write_all(b"GET /metrics HTTP/1.1\r\nHost: x\r\n\r\n")
+            .await
+            .unwrap();
+        let response = read_response(&mut client).await;
+
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(response.contains("text/plain; version=0.0.4"));
+        assert!(response.contains("zentinel_up 1"));
+        assert!(response.contains("zentinel_build_info"));
+    }
+
+    #[tokio::test]
+    async fn unknown_path_returns_404() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            handle_connection(&mut stream, "/metrics", None)
+                .await
+                .unwrap();
+        });
+
+        let mut client = TcpStream::connect(addr).await.unwrap();
+        client
+            .write_all(b"GET /nope HTTP/1.1\r\nHost: x\r\n\r\n")
+            .await
+            .unwrap();
+        let response = read_response(&mut client).await;
+
+        assert!(response.starts_with("HTTP/1.1 404 Not Found"));
+    }
+
+    #[tokio::test]
+    async fn root_path_serves_landing_page() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            handle_connection(&mut stream, "/metrics", None)
+                .await
+                .unwrap();
+        });
+
+        let mut client = TcpStream::connect(addr).await.unwrap();
+        client
+            .write_all(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+            .await
+            .unwrap();
+        let response = read_response(&mut client).await;
+
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(response.contains("text/html"));
+        assert!(response.contains("/metrics"));
+    }
+
+    #[tokio::test]
+    async fn respects_custom_metrics_path() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            handle_connection(&mut stream, "/internal/metrics", None)
+                .await
+                .unwrap();
+        });
+
+        let mut client = TcpStream::connect(addr).await.unwrap();
+        client
+            .write_all(b"GET /internal/metrics?x=1 HTTP/1.1\r\nHost: x\r\n\r\n")
+            .await
+            .unwrap();
+        let response = read_response(&mut client).await;
+
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(response.contains("zentinel_up 1"));
+    }
+}

--- a/crates/proxy/src/proxy/mod.rs
+++ b/crates/proxy/src/proxy/mod.rs
@@ -368,6 +368,14 @@ impl ZentinelProxy {
         })
     }
 
+    /// Shared HTTP cache statistics.
+    ///
+    /// Exposed so the standalone metrics server can include cache counters in
+    /// its Prometheus output, matching the builtin `/metrics` route handler.
+    pub fn http_cache_stats(&self) -> Arc<crate::cache::HttpCacheStats> {
+        self.cache_manager.stats()
+    }
+
     /// Setup the configuration reload handler
     async fn setup_reload_handler(
         config_manager: Arc<ConfigManager>,


### PR DESCRIPTION
## Summary

Fixes the three out-of-the-box failures from #254 (the quickstart-doesn't-work report) and its spin-offs #255 / #256.

### #256 — metrics endpoint silently never binds
`observability.metrics.address` was parsed but never consumed, so nothing ever listened on the configured port. No listener, no log line, no error.

- New `crates/proxy/src/metrics_server.rs`: a dedicated HTTP server (same raw-tokio pattern as the ACME challenge server) that binds `metrics.address` and serves Prometheus text at `metrics.path`, a landing page at `/`, and 404 otherwise.
- Logs `Metrics server listening address=… path=…`; a bind failure logs loudly but does not take the proxy down.
- Body shared with the builtin `/metrics` route handler (`render_prometheus_metrics`) so both surfaces are identical.
- Removed the stale "not yet implemented" validation warning; corrected the misleading comment in `metrics.rs`.

### #255 — default Docker config fails to initialize file logging as non-root
The distroless image runs as `nonroot` (uid 65532) and `/var/log/zentinel` was neither created nor writable.

- `Dockerfile`: new `runtime-dirs` stage; `COPY --chown=65532:65532` of `/var/log/zentinel` and `/var/lib/zentinel` into the distroless `proxy` and `proxy-prebuilt` stages.
- `config/docker/default.kdl`: bundled container config now logs to stdout/stderr (`error-log { enabled #false }`), so it starts cleanly even on read-only or tmpfs mounts.

### #254 root cause — divergent KDL `target` syntax
The single-file and multi-file parsers accepted **disjoint** target syntaxes: single-file only `target "host:port"`, multi-file only `targets { target { address … } }`. That divergence is why the docs drifted and why the reporter hit "requires at least one target".

- Single shared `parse_upstream_targets` (in `kdl/helpers.rs`) used by both parsers, accepting the shorthand, block form, property form, the `targets { … }` wrapper, and the top-level `address` shorthand.
- Targets with no resolvable address are skipped rather than silently defaulted to a bogus address.

## Test plan

- [x] `cargo build -p zentinel-proxy -p zentinel-config`
- [x] `cargo clippy -p zentinel-proxy -p zentinel-config --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo test -p zentinel-proxy --lib metrics_server` (4 passed)
- [x] `cargo test -p zentinel-config --lib` (159 passed, incl. new single-file + multi-file target-syntax tests)
- [x] Live: ran `zentinel -c config/docker/default.kdl`; `:9090/metrics` → 200 with `zentinel_up 1` + build info + registry gauges; `/` → 200; `/nope` → 404; clean startup (no log-dir warning)
- [ ] CI build of the distroless image confirms `/var/log/zentinel` ownership (not buildable locally here)

Closes #256
Closes #255