### PR TITLE
chore: bump version to 0.6.15 for release 26.06_1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ for details.
 
 | CalVer | Crate Version | Date | Highlights |
 |--------|---------------|------|------------|
+| [26.06_1](#26061---2026-06-07) | 0.6.15 | 2026-06-07 | Standalone Prometheus metrics server, per-listener route sets, quickstart fixes, dep maintenance (tikv-jemallocator 0.7, openssl 0.10.80, rust-minor batches) |
 | [26.05_4](#26054---2026-05-12) | 0.6.14 | 2026-05-12 | Dependency maintenance: OpenTelemetry 0.32, sysinfo 0.39, Rust toolchain 1.95 |
 | [26.05_3](#26053---2026-05-05) | 0.6.13 | 2026-05-05 | Embedded and bundled KDL configs use `system` block; ACME hickory-resolver 0.26 fix |
 | [26.05_2](#26052---2026-05-03) | 0.6.12 | 2026-05-03 | Install script provisions systemd unit, system user, and starter config |
@@ -49,13 +50,31 @@ for details.
 
 ## [Unreleased]
 
+---
+
+## [26.06_1] - 2026-06-07
+
+**Crate version:** 0.6.15
+
 ### Added
 - **Standalone Prometheus metrics server.** When `observability.metrics.enabled` is set, the proxy binds a dedicated HTTP listener on `observability.metrics.address` (default `0.0.0.0:9090`) and serves the Prometheus exposition format at `observability.metrics.path` (default `/metrics`), logging a `Metrics server listening` line at startup. Previously `address` was parsed but never consumed, so nothing bound the port — a silent failure that violated the "fail loudly" principle. (#256)
-- **Per-listener route sets.** A listener may now serve a distinct set of routes via a `namespace "<id>"` field. Requests arriving on that listener are matched **only** against the named namespace's routes — no fallback to the global set — so you can expose, e.g., an internal admin/metrics surface on a separate port. Listeners without a `namespace` field serve the global `routes` exactly as before. Modeled on Envoy's listener→route-configuration binding; the referenced namespace must exist or validation fails.
+- **Per-listener route sets.** A listener may now serve a distinct set of routes via a `namespace "<id>"` field. Requests arriving on that listener are matched **only** against the named namespace's routes — no fallback to the global set — so you can expose, e.g., an internal admin/metrics surface on a separate port. Listeners without a `namespace` field serve the global `routes` exactly as before. Modeled on Envoy's listener→route-configuration binding; the referenced namespace must exist or validation fails. (#258)
 
 ### Fixed
 - **Default Docker image starts cleanly as a non-root user.** The distroless `proxy` and `proxy-prebuilt` images now ship `/var/log/zentinel` and `/var/lib/zentinel` owned by uid/gid 65532, and the bundled container config logs to stdout/stderr rather than a file. Previously the default config failed to initialize file logging under `/var/log/zentinel` (not writable by the non-root user), and a `tmpfs` mount did not resolve it. (#255)
 - **Upstream `target` syntax is now identical across single-file and multi-file configs.** The two KDL parsers previously accepted *disjoint* target syntaxes — the single-file parser only took the `target "host:port"` shorthand while the multi-file parser only took the `targets { target { address … } }` block form — so a config copied between layouts (or from the docs) could fail with "requires at least one target". A single shared parser now accepts the shorthand, block form, property form, the `targets { … }` wrapper, and the top-level `address` shorthand in both. This was the root cause behind #254. (#254)
+
+### Changed
+- **Bump `tikv-jemallocator` 0.6.1 → 0.7.0.** (#265)
+- **Bump rust-minor group (10 updates).** (#264)
+- **Bump `busybox` Docker base 1.37 → 1.38.** (#263)
+- **Bump `openssl` 0.10.79 → 0.10.80.** (#252)
+- **Bump rust-minor group (5 updates).** (#251)
+- **Bump `wasmtime` group.** (#250)
+- **Bump `quick-xml` 0.39.4 → 0.40.1.** (#249)
+
+### Chores
+- Delete defunct `docs.yml` mdbook workflow. (#253)
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8229,7 +8229,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8269,7 +8269,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8291,7 +8291,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8370,7 +8370,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8401,7 +8401,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8492,7 +8492,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8509,7 +8509,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.14"
+version = "0.6.15"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bumps workspace version `0.6.14` → `0.6.15`.
- Promotes the `Unreleased` notes (#254, #255, #256, #258) into a new `26.06_1` section.
- Adds the dep/maint changes that landed since `26.05_4`: #249, #250, #251, #252, #253, #263, #264, #265.
- Updates `Cargo.lock` via `cargo update --workspace`.

## Test plan

- [ ] CI (Formatting, Clippy, Documentation) green.
- [ ] On merge, tag the merge commit as `26.06_1` to trigger the Release workflow.