### PR TITLE
chore: bump version to 0.6.16 for release 26.06_2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ for details.
 
 | CalVer | Crate Version | Date | Highlights |
 |--------|---------------|------|------------|
+| [26.06_2](#26062---2026-06-09) | 0.6.16 | 2026-06-09 | Security: Pingora 0.8.0 → 0.8.1 (HTTP/2 memory-exhaustion bound, rustls-webpki advisory fixes) |
 | [26.06_1](#26061---2026-06-07) | 0.6.15 | 2026-06-07 | Standalone Prometheus metrics server, per-listener route sets, quickstart fixes, dep maintenance (tikv-jemallocator 0.7, openssl 0.10.80, rust-minor batches) |
 | [26.05_4](#26054---2026-05-12) | 0.6.14 | 2026-05-12 | Dependency maintenance: OpenTelemetry 0.32, sysinfo 0.39, Rust toolchain 1.95 |
 | [26.05_3](#26053---2026-05-05) | 0.6.13 | 2026-05-05 | Embedded and bundled KDL configs use `system` block; ACME hickory-resolver 0.26 fix |
@@ -50,8 +51,14 @@ for details.
 
 ## [Unreleased]
 
+---
+
+## [26.06_2] - 2026-06-09
+
+**Crate version:** 0.6.16
+
 ### Security
-- **Bump Pingora 0.8.0 → 0.8.1** ([cloudflare/pingora release](https://github.com/cloudflare/pingora/releases/tag/0.8.1)). Brings in two security-relevant changes: bounded default HTTP/2 server limits to mitigate memory exhaustion, and the upstream dev-dep bumps that resolve `RUSTSEC-2026-0098` / `RUSTSEC-2026-0099` (`rustls-webpki`). Fork rev bumped to `b8d0c00` via [zentinelproxy/pingora#4](https://github.com/zentinelproxy/pingora/pull/4).
+- **Bump Pingora 0.8.0 → 0.8.1** ([cloudflare/pingora release](https://github.com/cloudflare/pingora/releases/tag/0.8.1)). Brings in two security-relevant changes: bounded default HTTP/2 server limits to mitigate memory exhaustion, and the upstream dev-dep bumps that resolve `RUSTSEC-2026-0098` / `RUSTSEC-2026-0099` (`rustls-webpki`). Fork rev bumped to `b8d0c00` via [zentinelproxy/pingora#4](https://github.com/zentinelproxy/pingora/pull/4). (#270)
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8261,7 +8261,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8301,7 +8301,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8323,7 +8323,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8402,7 +8402,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8433,7 +8433,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8524,7 +8524,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8541,7 +8541,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.15"
+version = "0.6.16"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bumps workspace version `0.6.15` → `0.6.16`.
- Promotes the Pingora 0.8.1 entry (#270) from `Unreleased` into a new `26.06_2` section.
- Updates `Cargo.lock` via `cargo update --workspace`.

Highlight: the 26.06_2 release is driven by the Pingora 0.8.1 security bump (HTTP/2 memory-exhaustion bound + rustls-webpki advisory fixes).

## Test plan

- [ ] CI (Formatting / Clippy / Documentation) green.
- [ ] On merge, tag the merge commit as `26.06_2` to trigger the Release workflow.