### PR TITLE
feat(proxy): enforce agent body limits and bound per-key limiter state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 # CI workflow - runs on every push and pull request
-# Validates code quality: formatting, linting, and documentation.
-# The full test suite is in tests.yml (manual / weekly / push-to-main only)
-# to keep PR-trigger Action minutes low.
+# Validates code quality: formatting, linting, documentation, and unit tests.
+# Unit (lib) tests run here so regressions are caught before merge; the full
+# test suite (integration, doc tests) is in tests.yml (manual / weekly /
+# push-to-main only) to keep PR-trigger Action minutes low.
 
 name: CI
 
@@ -119,3 +120,44 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
         run: cargo doc --workspace --no-deps
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo build
+        uses: actions/cache@v5
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-test-lib-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-test-lib-
+
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Run unit tests
+        run: cargo test --workspace --lib

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 # Tests workflow - runs the full workspace test suite.
 #
+# Unit (lib) tests run on every PR via ci.yml; this workflow covers the
+# rest (integration tests, doc tests, binaries).
+#
 # Not run on every PR (would burn through Action minutes — `cargo test
 # --workspace` takes 20+ minutes on this codebase). Instead:
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,38 @@ for details.
 
 ## [Unreleased]
 
+### Changed
+- **⚠️ Behavior change: oversized bodies no longer bypass agent inspection.**
+  Request/response bodies larger than an agent's `max-request-body-bytes` /
+  `max-response-body-bytes` (default 1 MiB; previously a hardcoded request-only
+  1 MB) now follow the agent's `failure-mode`: `closed` blocks the request with
+  **413**, `open` skips that agent loudly (warn log + `body_size_skips` metric)
+  while other agents still inspect. Previously oversized bodies were silently
+  allowed past all agents, and streaming bodies had no limit at all. Set
+  `failure-mode "open"` and/or raise the body limits on an agent to retain the
+  old (insecure) behavior explicitly.
+
+### Added
+- Per-agent `max-request-body-bytes` / `max-response-body-bytes` are now
+  enforced (the fields previously parsed but had no effect) and covered by the
+  multi-file config parser.
+- `max-keys` on rate-limit filters (default `100000`) bounds the in-memory
+  per-key limiter map with idle-aware eviction, replacing the unbounded growth
+  between periodic sweeps. New metrics: `zentinel_rate_limit_keys{scope}`,
+  `zentinel_rate_limit_key_evictions_total{scope}`.
+- `max-tenants` on inference token budgets (default `10000`) bounds per-tenant
+  budget state with expired-period-first eviction. New metrics:
+  `zentinel_inference_budget_tenants{route}`,
+  `zentinel_inference_budget_tenant_evictions_total{route}`.
+- `AgentDecision.decided_by` records which agent produced a block/redirect/
+  challenge (including synthetic fail-closed blocks from timeouts, circuit
+  breakers, and body-size limits); block logs carry `agent_id` and audit
+  entries gain an `agent:<id>` tag.
+- Config validation now rejects duplicate agent IDs, zero agent timeouts
+  (`timeout-ms`, `chunk-timeout-ms`), and zero body limits.
+- CI: workspace unit tests (`cargo test --workspace --lib`) now run on every
+  pull request; the full suite remains in the Tests workflow.
+
 ---
 
 ## [26.06_2] - 2026-06-09

--- a/crates/common/src/budget.rs
+++ b/crates/common/src/budget.rs
@@ -53,6 +53,14 @@ pub struct TokenBudgetConfig {
     /// E.g., 0.10 allows 10% burst above the limit
     #[serde(default)]
     pub burst_allowance: Option<f64>,
+
+    /// Maximum number of distinct tenants tracked in memory
+    ///
+    /// Bounds per-tenant budget state. When the cap is reached, tenants
+    /// whose period has expired are evicted first; if none are expired,
+    /// the tenants with the oldest periods are evicted.
+    #[serde(default = "default_max_tenants")]
+    pub max_tenants: usize,
 }
 
 fn default_alert_thresholds() -> Vec<f64> {
@@ -61,6 +69,11 @@ fn default_alert_thresholds() -> Vec<f64> {
 
 fn default_true() -> bool {
     true
+}
+
+/// Default bound on distinct tenants tracked per budget tracker.
+pub fn default_max_tenants() -> usize {
+    10_000
 }
 
 impl Default for TokenBudgetConfig {
@@ -72,6 +85,7 @@ impl Default for TokenBudgetConfig {
             enforce: true,
             rollover: false,
             burst_allowance: None,
+            max_tenants: default_max_tenants(),
         }
     }
 }

--- a/crates/config/docs/schema.md
+++ b/crates/config/docs/schema.md
@@ -244,6 +244,18 @@ Per-route cache configuration, nested under `policies.cache`.
 | `burst-tokens` | `u64` | `10000` | Burst token allowance |
 | `estimation-method` | `string` | `"chars"` | Token estimation: `chars`, `words`, `tiktoken` |
 
+### TokenBudgetConfig
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `period` | `string` | `"daily"` | Budget period: `hourly`, `daily`, `monthly`, or seconds |
+| `limit` | `u64` | **required** | Total tokens allowed in the period |
+| `alert-thresholds` | `[f64]` | `[0.80, 0.90, 0.95]` | Usage fractions that fire alerts |
+| `enforce` | `bool` | `true` | Block requests when exhausted |
+| `rollover` | `bool` | `false` | Carry unused tokens into the next period |
+| `burst-allowance` | `f64` | - | Soft-limit burst fraction above the limit |
+| `max-tenants` | `usize` | `10000` | Max distinct tenants tracked in memory; expired tenants are evicted at the cap (see `zentinel_inference_budget_tenants` / `zentinel_inference_budget_tenant_evictions_total` metrics) |
+
 ### GuardrailsConfig
 
 | Property | Type | Description |
@@ -352,6 +364,7 @@ Reusable filter definitions.
 | `on-limit` | `string` | `"reject"` | Action: `reject`, `delay`, `log-only` |
 | `status-code` | `u16` | `429` | Response status when limited |
 | `backend` | `string` | `"local"` | Storage: `local`, `redis`, `memcached` |
+| `max-keys` | `usize` | `100000` | Max distinct keys tracked in memory; idle keys are evicted at the cap (see `zentinel_rate_limit_keys` / `zentinel_rate_limit_key_evictions_total` metrics) |
 
 #### headers
 
@@ -418,11 +431,11 @@ External processing agent configuration.
 | `type` | `string` | **required** | Agent type: `waf`, `auth`, `rate-limit`, `custom` |
 | `transport` | `AgentTransport` | **required** | Transport configuration |
 | `events` | `[string]` | **required** | Events to handle |
-| `timeout-ms` | `u64` | `1000` | Call timeout |
-| `failure-mode` | `string` | `"closed"` | Failure mode |
+| `timeout-ms` | `u64` | `1000` | Call timeout (must be > 0) |
+| `failure-mode` | `string` | `"open"` | Failure mode (`open` allows on agent failure, `closed` blocks) |
 | `circuit-breaker` | `CircuitBreakerConfig` | - | Circuit breaker |
-| `max-request-body-bytes` | `u64` | - | Max request body to send |
-| `max-response-body-bytes` | `u64` | - | Max response body to send |
+| `max-request-body-bytes` | `u64` | `1048576` (1 MiB) | Max request body inspected by this agent. Larger bodies follow `failure-mode`: `closed` blocks with 413, `open` skips this agent with a warning and metric |
+| `max-response-body-bytes` | `u64` | `1048576` (1 MiB) | Max response body inspected by this agent (same failure-mode semantics) |
 | `request-body-mode` | `string` | `"buffer"` | Body mode: `buffer`, `stream`, `hybrid` |
 | `max-concurrent-calls` | `u32` | `100` | Max concurrent calls |
 

--- a/crates/config/docs/validation.md
+++ b/crates/config/docs/validation.md
@@ -89,6 +89,9 @@ Minimum supported: `1.0`
 |----------|------------|
 | `id` | Non-empty, unique |
 | `timeout-ms` | `> 0` |
+| `chunk-timeout-ms` | `> 0` |
+| `max-request-body-bytes` | `> 0` when set (omit for the 1 MiB default) |
+| `max-response-body-bytes` | `> 0` when set (omit for the 1 MiB default) |
 | `transport.unix-socket` | Parent directory must exist |
 | `transport.grpc.address` | Valid address format |
 | `events` | At least one event |

--- a/crates/config/src/filters.rs
+++ b/crates/config/src/filters.rs
@@ -253,10 +253,22 @@ pub struct RateLimitFilter {
     /// Maximum delay in milliseconds before rejecting (for Delay action)
     #[serde(default = "default_max_delay_ms", rename = "max-delay-ms")]
     pub max_delay_ms: u64,
+
+    /// Maximum number of distinct rate-limit keys tracked in memory
+    ///
+    /// Bounds per-key limiter state (e.g. one entry per client IP). When the
+    /// cap is reached, idle entries are evicted; if none are idle, the oldest
+    /// entries are evicted and an eviction metric is incremented.
+    #[serde(default = "default_max_keys", rename = "max-keys")]
+    pub max_keys: usize,
 }
 
 fn default_max_delay_ms() -> u64 {
     5000 // 5 seconds max delay
+}
+
+pub(crate) fn default_max_keys() -> usize {
+    100_000
 }
 
 // =============================================================================
@@ -857,6 +869,7 @@ mod tests {
                 limit_message: None,
                 backend: RateLimitBackend::Local,
                 max_delay_ms: 5000,
+                max_keys: 100_000,
             })
             .phase(),
             FilterPhase::Request
@@ -893,6 +906,7 @@ mod tests {
                 limit_message: None,
                 backend: RateLimitBackend::Local,
                 max_delay_ms: 5000,
+                max_keys: 100_000,
             }),
         );
 
@@ -955,6 +969,7 @@ mod tests {
             limit_message: None,
             backend: RateLimitBackend::Local,
             max_delay_ms: 3000,
+            max_keys: 100_000,
         };
 
         assert_eq!(filter.max_delay_ms, 3000);
@@ -973,6 +988,7 @@ mod tests {
             limit_message: None,
             backend: RateLimitBackend::Local,
             max_delay_ms: 5000, // default value
+            max_keys: 100_000,
         };
 
         assert_eq!(filter.max_delay_ms, 5000);

--- a/crates/config/src/kdl/filters.rs
+++ b/crates/config/src/kdl/filters.rs
@@ -112,6 +112,9 @@ fn parse_rate_limit_filter(node: &kdl::KdlNode) -> Result<Filter> {
         max_delay_ms: get_int_entry(node, "max-delay-ms")
             .map(|v| v as u64)
             .unwrap_or(5000),
+        max_keys: get_int_entry(node, "max-keys")
+            .map(|v| v as usize)
+            .unwrap_or_else(crate::filters::default_max_keys),
     }))
 }
 
@@ -426,5 +429,50 @@ fn parse_path_modifier(node: &kdl::KdlNode) -> Option<PathModifier> {
     } else {
         get_string_entry(node, "replace-prefix-match")
             .map(|prefix| PathModifier::ReplacePrefixMatch { value: prefix })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_filter(kdl: &str) -> Filter {
+        let doc: kdl::KdlDocument = kdl.parse().expect("kdl parses");
+        let node = doc.nodes().first().expect("one node");
+        parse_single_filter_definition(node).expect("filter parses")
+    }
+
+    #[test]
+    fn rate_limit_filter_parses_max_keys() {
+        let filter = parse_filter(
+            r#"filter "rl" {
+    type "rate-limit"
+    max-rps 50
+    max-keys 5000
+}"#,
+        );
+        match filter {
+            Filter::RateLimit(rl) => {
+                assert_eq!(rl.max_rps, 50);
+                assert_eq!(rl.max_keys, 5000);
+            }
+            other => panic!("expected rate-limit filter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rate_limit_filter_defaults_max_keys() {
+        let filter = parse_filter(
+            r#"filter "rl" {
+    type "rate-limit"
+    max-rps 50
+}"#,
+        );
+        match filter {
+            Filter::RateLimit(rl) => {
+                assert_eq!(rl.max_keys, crate::filters::default_max_keys());
+            }
+            other => panic!("expected rate-limit filter, got {other:?}"),
+        }
     }
 }

--- a/crates/config/src/kdl/routes.rs
+++ b/crates/config/src/kdl/routes.rs
@@ -1345,6 +1345,9 @@ fn parse_token_budget(node: &kdl::KdlNode) -> Result<TokenBudgetConfig> {
     let enforce = get_bool_entry(node, "enforce").unwrap_or(true);
     let rollover = get_bool_entry(node, "rollover").unwrap_or(false);
     let burst_allowance = get_float_entry(node, "burst-allowance");
+    let max_tenants = get_int_entry(node, "max-tenants")
+        .map(|v| v as usize)
+        .unwrap_or_else(zentinel_common::budget::default_max_tenants);
 
     trace!(
         period = ?period,
@@ -1353,6 +1356,7 @@ fn parse_token_budget(node: &kdl::KdlNode) -> Result<TokenBudgetConfig> {
         enforce = enforce,
         rollover = rollover,
         burst_allowance = ?burst_allowance,
+        max_tenants = max_tenants,
         "Parsed token budget configuration"
     );
 
@@ -1363,6 +1367,7 @@ fn parse_token_budget(node: &kdl::KdlNode) -> Result<TokenBudgetConfig> {
         enforce,
         rollover,
         burst_allowance,
+        max_tenants,
     })
 }
 

--- a/crates/config/src/multi_file/parsers.rs
+++ b/crates/config/src/multi_file/parsers.rs
@@ -242,7 +242,7 @@ pub(super) fn parse_agent(node: &KdlNode) -> Result<AgentConfig> {
             _ => crate::FailureMode::Open,
         },
         max_request_body_bytes: get_int_entry(node, "max-request-body-bytes").map(|v| v as usize),
-        max_response_body_bytes: None,
+        max_response_body_bytes: get_int_entry(node, "max-response-body-bytes").map(|v| v as usize),
         circuit_breaker: None,
         request_body_mode: Default::default(),
         response_body_mode: Default::default(),

--- a/crates/config/src/validation.rs
+++ b/crates/config/src/validation.rs
@@ -395,6 +395,10 @@ pub fn validate_config_semantics(config: &Config) -> Result<(), validator::Valid
     trace!("Validating upstreams");
     validate_upstreams(config, &mut errors);
 
+    // Validate agents
+    trace!("Validating agents");
+    validate_agents(config, &mut errors);
+
     // Validate duplicates
     trace!("Checking for duplicates");
     validate_duplicates(config, &mut errors);
@@ -723,6 +727,44 @@ fn validate_upstreams(config: &Config, errors: &mut Vec<String>) {
     }
 }
 
+fn validate_agents(config: &Config, errors: &mut Vec<String>) {
+    trace!(agent_count = config.agents.len(), "Validating agents");
+
+    for agent in &config.agents {
+        if agent.timeout_ms == 0 {
+            warn!(agent_id = %agent.id, "Agent has zero timeout");
+            errors.push(format!(
+                "Agent '{}' has timeout_ms 0. Timeouts must be greater than 0.",
+                agent.id
+            ));
+        }
+
+        if agent.chunk_timeout_ms == 0 {
+            warn!(agent_id = %agent.id, "Agent has zero chunk timeout");
+            errors.push(format!(
+                "Agent '{}' has chunk_timeout_ms 0. Timeouts must be greater than 0.",
+                agent.id
+            ));
+        }
+
+        if agent.max_request_body_bytes == Some(0) {
+            warn!(agent_id = %agent.id, "Agent has zero request body limit");
+            errors.push(format!(
+                "Agent '{}' has max_request_body_bytes 0. Use a positive limit, or omit the field for the default.",
+                agent.id
+            ));
+        }
+
+        if agent.max_response_body_bytes == Some(0) {
+            warn!(agent_id = %agent.id, "Agent has zero response body limit");
+            errors.push(format!(
+                "Agent '{}' has max_response_body_bytes 0. Use a positive limit, or omit the field for the default.",
+                agent.id
+            ));
+        }
+    }
+}
+
 fn validate_duplicates(config: &Config, errors: &mut Vec<String>) {
     trace!("Checking for duplicate identifiers");
 
@@ -734,6 +776,18 @@ fn validate_duplicates(config: &Config, errors: &mut Vec<String>) {
             errors.push(format!(
                 "Duplicate route ID '{}'. Each route must have a unique identifier.",
                 route.id
+            ));
+        }
+    }
+
+    // Duplicate agent IDs
+    let mut seen_agents = HashSet::new();
+    for agent in &config.agents {
+        if !seen_agents.insert(&agent.id) {
+            warn!(agent_id = %agent.id, "Duplicate agent ID found");
+            errors.push(format!(
+                "Duplicate agent ID '{}'. Each agent must have a unique identifier.",
+                agent.id
             ));
         }
     }
@@ -1238,6 +1292,134 @@ mod tests {
             shadow: None,
             fallback: None,
         }
+    }
+
+    fn config_with_agent_block(agent_block: &str) -> crate::Config {
+        let kdl = format!(
+            r#"
+            schema-version "1.0"
+            system {{ worker-threads 0 }}
+            listeners {{
+                listener "public" {{
+                    address "0.0.0.0:8080"
+                }}
+            }}
+            routes {{
+                route "api" {{
+                    matches {{ path-prefix "/" }}
+                    upstream "backend"
+                }}
+            }}
+            upstreams {{
+                upstream "backend" {{
+                    target "127.0.0.1:3000"
+                }}
+            }}
+            agents {{
+                {agent_block}
+            }}
+        "#
+        );
+        crate::Config::from_kdl(&kdl).expect("config parses")
+    }
+
+    fn validation_errors(config: &crate::Config) -> String {
+        match config.validate() {
+            Ok(()) => String::new(),
+            Err(e) => e.to_string(),
+        }
+    }
+
+    #[test]
+    fn duplicate_agent_ids_fail_validation() {
+        let config = config_with_agent_block(
+            r#"
+            agent "waf" type="waf" {
+                unix-socket path="/tmp/waf-a.sock"
+            }
+            agent "waf" type="waf" {
+                unix-socket path="/tmp/waf-b.sock"
+            }
+            "#,
+        );
+        let errors = validation_errors(&config);
+        assert!(
+            errors.contains("Duplicate agent ID 'waf'"),
+            "expected duplicate agent ID error, got: {errors}"
+        );
+    }
+
+    #[test]
+    fn agent_zero_timeout_fails_validation() {
+        let config = config_with_agent_block(
+            r#"
+            agent "waf" type="waf" {
+                unix-socket path="/tmp/waf.sock"
+                timeout-ms 0
+            }
+            "#,
+        );
+        let errors = validation_errors(&config);
+        assert!(
+            errors.contains("Agent 'waf' has timeout_ms 0"),
+            "expected zero timeout error, got: {errors}"
+        );
+    }
+
+    #[test]
+    fn agent_zero_chunk_timeout_fails_validation() {
+        let config = config_with_agent_block(
+            r#"
+            agent "waf" type="waf" {
+                unix-socket path="/tmp/waf.sock"
+                chunk-timeout-ms 0
+            }
+            "#,
+        );
+        let errors = validation_errors(&config);
+        assert!(
+            errors.contains("Agent 'waf' has chunk_timeout_ms 0"),
+            "expected zero chunk timeout error, got: {errors}"
+        );
+    }
+
+    #[test]
+    fn agent_zero_body_limits_fail_validation() {
+        let config = config_with_agent_block(
+            r#"
+            agent "waf" type="waf" {
+                unix-socket path="/tmp/waf.sock"
+                max-request-body-bytes 0
+                max-response-body-bytes 0
+            }
+            "#,
+        );
+        let errors = validation_errors(&config);
+        assert!(
+            errors.contains("Agent 'waf' has max_request_body_bytes 0"),
+            "expected zero request body limit error, got: {errors}"
+        );
+        assert!(
+            errors.contains("Agent 'waf' has max_response_body_bytes 0"),
+            "expected zero response body limit error, got: {errors}"
+        );
+    }
+
+    #[test]
+    fn valid_agent_passes_validation() {
+        let config = config_with_agent_block(
+            r#"
+            agent "waf" type="waf" {
+                unix-socket path="/tmp/waf.sock"
+                timeout-ms 500
+            }
+            "#,
+        );
+        let errors = validation_errors(&config);
+        assert!(
+            errors.is_empty(),
+            "valid agent config must pass validation, got: {errors}"
+        );
     }
 
     #[test]

--- a/crates/proxy/docs/agents.md
+++ b/crates/proxy/docs/agents.md
@@ -69,6 +69,11 @@ agents {
             recovery-timeout-secs 30
         }
     }
+    // Body inspection limits: bodies larger than max-request-body-bytes /
+    // max-response-body-bytes (default 1 MiB each) follow the agent's
+    // failure-mode — "closed" blocks the request with 413, "open" skips
+    // this agent's inspection with a warning and a body_size_skips metric.
+    // Agents whose limit accommodates the body still inspect it.
 
     // gRPC transport
     agent "auth-agent" {
@@ -435,6 +440,11 @@ Request
 - **First BLOCK wins** - Pipeline stops at first blocking decision
 - **Mutations merge** - Header mutations from all agents are combined
 - **Tags accumulate** - All agent tags are collected
+- **Attribution survives merging** - `AgentDecision.decided_by` records which
+  agent produced the deciding (non-allow) action, including synthetic blocks
+  from fail-closed timeouts, circuit breakers, and body-size limits. Block
+  logs carry it as `agent_id`, and audit log entries get an `agent:<id>` tag,
+  so every block can answer *which agent decided, and why*.
 
 ```rust
 pub fn merge_decisions(decisions: Vec<AgentDecision>) -> AgentDecision {

--- a/crates/proxy/docs/inference.md
+++ b/crates/proxy/docs/inference.md
@@ -167,6 +167,19 @@ route "/v1/chat/completions" {
 }
 ```
 
+### Tenant Bounds
+
+Per-tenant budget state is bounded by `max-tenants` (default `10000`).
+When a new tenant arrives at the cap, tenants whose period has expired are
+evicted first (with `rollover`, one extra period is kept); if all tenants
+are active, the oldest periods are evicted down to 90% of the cap with a
+warning log. Observability:
+
+```
+zentinel_inference_budget_tenants{route="chat"} 4210
+zentinel_inference_budget_tenant_evictions_total{route="chat"} 0
+```
+
 ### Budget Tracking
 
 ```rust

--- a/crates/proxy/docs/rate-limiting.md
+++ b/crates/proxy/docs/rate-limiting.md
@@ -39,6 +39,25 @@ routes {
 }
 ```
 
+### Key-Map Bounds
+
+Per-key limiter state is bounded by `max-keys` (default `100000`) on
+rate-limit filters. When a new key arrives at the cap, idle keys (not seen
+for 10s — stale for 1-second windows) are swept first; if all keys are
+active, the longest-idle entries are evicted down to 90% of the cap with a
+warning log and an eviction counter. The current key count is exported as
+`zentinel_rate_limit_keys{scope}`.
+
+```kdl
+filters {
+    filter "api-limit" {
+        type "rate-limit"
+        max-rps 100
+        max-keys 50000
+    }
+}
+```
+
 ### Rate Limit Keys
 
 | Key Type | Description | Example |
@@ -415,6 +434,10 @@ Content-Type: application/json
 # Request counts
 zentinel_rate_limit_allowed_total{route="api", key="client-ip"} 100000
 zentinel_rate_limit_limited_total{route="api", key="client-ip"} 500
+
+# Key-map bounds (scope is the route ID, or "global")
+zentinel_rate_limit_keys{scope="api"} 1532
+zentinel_rate_limit_key_evictions_total{scope="api"} 0
 
 # Current state
 zentinel_rate_limit_current_requests{route="api"} 75

--- a/crates/proxy/src/agents/agent_v2.rs
+++ b/crates/proxy/src/agents/agent_v2.rs
@@ -108,6 +108,20 @@ impl AgentV2 {
         self.config.timeout_ms
     }
 
+    /// Maximum request body size (bytes) this agent will inspect.
+    pub fn max_request_body_bytes(&self) -> usize {
+        self.config
+            .max_request_body_bytes
+            .unwrap_or(super::DEFAULT_AGENT_MAX_BODY_BYTES)
+    }
+
+    /// Maximum response body size (bytes) this agent will inspect.
+    pub fn max_response_body_bytes(&self) -> usize {
+        self.config
+            .max_response_body_bytes
+            .unwrap_or(super::DEFAULT_AGENT_MAX_BODY_BYTES)
+    }
+
     /// Get the agent's metrics.
     pub fn metrics(&self) -> &AgentMetrics {
         &self.metrics

--- a/crates/proxy/src/agents/decision.rs
+++ b/crates/proxy/src/agents/decision.rs
@@ -9,6 +9,12 @@ use zentinel_agent_protocol::{AgentResponse, AuditMetadata, BodyMutation, Decisi
 pub struct AgentDecision {
     /// Final decision action
     pub action: AgentAction,
+    /// ID of the agent that produced the deciding (non-allow) action
+    ///
+    /// `None` for allow decisions and for decisions not attributable to a
+    /// specific agent. Preserved through [`AgentDecision::merge`] so block
+    /// logs can always answer "which agent blocked this request".
+    pub decided_by: Option<String>,
     /// Header modifications for request
     pub request_headers: Vec<HeaderOp>,
     /// Header modifications for response
@@ -50,6 +56,7 @@ impl AgentDecision {
     pub fn default_allow() -> Self {
         Self {
             action: AgentAction::Allow,
+            decided_by: None,
             request_headers: Vec::new(),
             response_headers: Vec::new(),
             audit: Vec::new(),
@@ -68,6 +75,7 @@ impl AgentDecision {
                 body: Some(message.to_string()),
                 headers: None,
             },
+            decided_by: None,
             request_headers: Vec::new(),
             response_headers: Vec::new(),
             audit: Vec::new(),
@@ -76,6 +84,19 @@ impl AgentDecision {
             request_body_mutation: None,
             response_body_mutation: None,
         }
+    }
+
+    /// Attribute this decision to the agent that produced it.
+    pub fn with_decided_by(mut self, agent_id: impl Into<String>) -> Self {
+        self.decided_by = Some(agent_id.into());
+        self
+    }
+
+    /// Convert an agent response into a decision attributed to `agent_id`.
+    pub fn from_response(response: AgentResponse, agent_id: &str) -> Self {
+        let mut decision: Self = response.into();
+        decision.decided_by = Some(agent_id.to_string());
+        decision
     }
 
     /// Check if decision is to allow.
@@ -88,9 +109,10 @@ impl AgentDecision {
     /// If other decision is not allow, use it as the action.
     /// Header modifications, audit metadata, and routing metadata are merged.
     pub fn merge(&mut self, other: AgentDecision) {
-        // If other decision is not allow, use it
+        // If other decision is not allow, use it (and keep its attribution)
         if !other.is_allow() {
             self.action = other.action;
+            self.decided_by = other.decided_by;
         }
 
         // Merge header modifications
@@ -143,6 +165,7 @@ impl From<AgentResponse> for AgentDecision {
 
         Self {
             action,
+            decided_by: None,
             request_headers: response.request_headers,
             response_headers: response.response_headers,
             audit: vec![response.audit],
@@ -170,5 +193,34 @@ mod tests {
 
         decision1.merge(decision2);
         assert!(!decision1.is_allow());
+    }
+
+    #[test]
+    fn merge_preserves_blocking_agent_attribution() {
+        let mut combined = AgentDecision::default_allow().with_decided_by("auth");
+        // Allow decisions carry no attribution worth keeping
+        assert!(combined.is_allow());
+
+        let block = AgentDecision::block(403, "Forbidden").with_decided_by("waf");
+        combined.merge(block);
+
+        assert!(!combined.is_allow());
+        assert_eq!(combined.decided_by.as_deref(), Some("waf"));
+    }
+
+    #[test]
+    fn merge_with_allow_keeps_existing_attribution() {
+        let mut combined = AgentDecision::block(403, "Forbidden").with_decided_by("waf");
+        combined.merge(AgentDecision::default_allow());
+
+        assert_eq!(combined.decided_by.as_deref(), Some("waf"));
+    }
+
+    #[test]
+    fn from_response_sets_decided_by() {
+        let response = AgentResponse::block(403, None);
+        let decision = AgentDecision::from_response(response, "waf");
+        assert!(!decision.is_allow());
+        assert_eq!(decision.decided_by.as_deref(), Some("waf"));
     }
 }

--- a/crates/proxy/src/agents/manager.rs
+++ b/crates/proxy/src/agents/manager.rs
@@ -169,16 +169,14 @@ impl AgentManager {
         is_last: bool,
         route_agents: &[String],
     ) -> ZentinelResult<AgentDecision> {
-        // Check body size limits
-        let max_size = 1024 * 1024; // 1MB default
-        if data.len() > max_size {
-            warn!(
-                correlation_id = %ctx.correlation_id,
-                size = data.len(),
-                "Request body exceeds agent inspection limit"
-            );
-            return Ok(AgentDecision::default_allow());
-        }
+        // Enforce per-agent body inspection limits before dispatch
+        let inspecting_agents = match self
+            .apply_body_limits(ctx, route_agents, data.len(), EventType::RequestBodyChunk)
+            .await
+        {
+            BodyLimitsResult::Block(decision) => return Ok(*decision),
+            BodyLimitsResult::Proceed(agents) => agents,
+        };
 
         let event = RequestBodyChunkEvent {
             correlation_id: ctx.correlation_id.to_string(),
@@ -189,7 +187,7 @@ impl AgentManager {
             bytes_received: data.len(),
         };
 
-        self.process_event(EventType::RequestBodyChunk, &event, route_agents, ctx)
+        self.process_event(EventType::RequestBodyChunk, &event, &inspecting_agents, ctx)
             .await
     }
 
@@ -216,6 +214,20 @@ impl AgentManager {
             "Processing streaming request body chunk"
         );
 
+        // Enforce per-agent body inspection limits on the cumulative size
+        let inspecting_agents = match self
+            .apply_body_limits(
+                ctx,
+                route_agents,
+                bytes_received,
+                EventType::RequestBodyChunk,
+            )
+            .await
+        {
+            BodyLimitsResult::Block(decision) => return Ok(*decision),
+            BodyLimitsResult::Proceed(agents) => agents,
+        };
+
         let event = RequestBodyChunkEvent {
             correlation_id: ctx.correlation_id.to_string(),
             data: STANDARD.encode(data),
@@ -225,7 +237,7 @@ impl AgentManager {
             bytes_received,
         };
 
-        self.process_event(EventType::RequestBodyChunk, &event, route_agents, ctx)
+        self.process_event(EventType::RequestBodyChunk, &event, &inspecting_agents, ctx)
             .await
     }
 
@@ -249,6 +261,15 @@ impl AgentManager {
             "Processing streaming response body chunk"
         );
 
+        // Enforce per-agent body inspection limits on the cumulative size
+        let inspecting_agents = match self
+            .apply_body_limits(ctx, route_agents, bytes_sent, EventType::ResponseBodyChunk)
+            .await
+        {
+            BodyLimitsResult::Block(decision) => return Ok(*decision),
+            BodyLimitsResult::Proceed(agents) => agents,
+        };
+
         let event = ResponseBodyChunkEvent {
             correlation_id: ctx.correlation_id.to_string(),
             data: STANDARD.encode(data),
@@ -258,8 +279,13 @@ impl AgentManager {
             bytes_sent,
         };
 
-        self.process_event(EventType::ResponseBodyChunk, &event, route_agents, ctx)
-            .await
+        self.process_event(
+            EventType::ResponseBodyChunk,
+            &event,
+            &inspecting_agents,
+            ctx,
+        )
+        .await
     }
 
     /// Process response headers through agents.
@@ -528,7 +554,8 @@ impl AgentManager {
                         agent_id = %agent.id(),
                         "Blocking request due to circuit breaker (fail-closed mode)"
                     );
-                    return Ok(AgentDecision::block(503, "Service unavailable"));
+                    return Ok(AgentDecision::block(503, "Service unavailable")
+                        .with_decided_by(agent.id()));
                 }
                 continue;
             }
@@ -557,8 +584,8 @@ impl AgentManager {
                         "Agent call succeeded"
                     );
 
-                    // Merge response into combined decision
-                    combined_decision.merge(response.into());
+                    // Merge response into combined decision (attributed to this agent)
+                    combined_decision.merge(AgentDecision::from_response(response, agent.id()));
 
                     // If decision is to block/redirect/challenge, stop processing
                     if !combined_decision.is_allow() {
@@ -602,7 +629,8 @@ impl AgentManager {
                             agent_id = %agent.id(),
                             "Blocking request due to timeout (fail-closed mode)"
                         );
-                        return Ok(AgentDecision::block(504, "Gateway timeout"));
+                        return Ok(AgentDecision::block(504, "Gateway timeout")
+                            .with_decided_by(agent.id()));
                     }
                 }
             }
@@ -723,7 +751,8 @@ impl AgentManager {
                         agent_id = %agent.id(),
                         "Blocking request due to circuit breaker (filter fail-closed mode)"
                     );
-                    return Ok(AgentDecision::block(503, "Service unavailable"));
+                    return Ok(AgentDecision::block(503, "Service unavailable")
+                        .with_decided_by(agent.id()));
                 }
                 // Fail-open: continue to next agent
                 continue;
@@ -753,8 +782,8 @@ impl AgentManager {
                         "Agent call succeeded"
                     );
 
-                    // Merge response into combined decision
-                    combined_decision.merge(response.into());
+                    // Merge response into combined decision (attributed to this agent)
+                    combined_decision.merge(AgentDecision::from_response(response, agent.id()));
 
                     // If decision is to block/redirect/challenge, stop processing
                     if !combined_decision.is_allow() {
@@ -785,7 +814,8 @@ impl AgentManager {
                             agent_id = %agent.id(),
                             "Blocking request due to agent failure (filter fail-closed mode)"
                         );
-                        return Ok(AgentDecision::block(503, "Agent unavailable"));
+                        return Ok(AgentDecision::block(503, "Agent unavailable")
+                            .with_decided_by(agent.id()));
                     }
                     // Fail-open: continue to next agent (or proceed without this agent)
                     debug!(
@@ -811,7 +841,8 @@ impl AgentManager {
                             agent_id = %agent.id(),
                             "Blocking request due to timeout (filter fail-closed mode)"
                         );
-                        return Ok(AgentDecision::block(504, "Gateway timeout"));
+                        return Ok(AgentDecision::block(504, "Gateway timeout")
+                            .with_decided_by(agent.id()));
                     }
                     // Fail-open: continue to next agent
                     debug!(
@@ -1007,7 +1038,7 @@ impl AgentManager {
         for result in results {
             match result {
                 Ok((agent_id, response)) => {
-                    let decision: AgentDecision = response.into();
+                    let decision = AgentDecision::from_response(response, &agent_id);
 
                     // Check for blocking decision
                     if !decision.is_allow() {
@@ -1040,7 +1071,8 @@ impl AgentManager {
                         } else {
                             "Service unavailable"
                         };
-                        blocking_error = Some(AgentDecision::block(status, message));
+                        blocking_error =
+                            Some(AgentDecision::block(status, message).with_decided_by(&agent_id));
                     } else {
                         // Fail-open: log and continue
                         debug!(
@@ -1258,5 +1290,158 @@ impl AgentManager {
         agents
             .get(agent_id)
             .map(|agent| agent.pool_metrics_collector_arc())
+    }
+
+    /// Enforce per-agent body inspection limits for a body of `body_size` bytes.
+    ///
+    /// Agents whose limit is exceeded are handled according to their failure
+    /// mode: fail-closed produces a 413 Block decision, fail-open skips that
+    /// agent loudly (warn + metric) while agents within their limit still
+    /// inspect the body.
+    async fn apply_body_limits(
+        &self,
+        ctx: &AgentCallContext,
+        route_agents: &[String],
+        body_size: usize,
+        event_type: EventType,
+    ) -> BodyLimitsResult {
+        let agents = self.agents.read().await;
+        let limits: Vec<(String, FailureMode, usize)> = route_agents
+            .iter()
+            .filter_map(|id| agents.get(id))
+            .filter(|agent| agent.handles_event(event_type))
+            .map(|agent| {
+                let limit = if event_type == EventType::ResponseBodyChunk {
+                    agent.max_response_body_bytes()
+                } else {
+                    agent.max_request_body_bytes()
+                };
+                (agent.id().to_string(), agent.failure_mode(), limit)
+            })
+            .collect();
+
+        let outcome = evaluate_body_limits(&limits, body_size);
+
+        for (agent_id, limit) in &outcome.skipped {
+            warn!(
+                correlation_id = %ctx.correlation_id,
+                agent_id = %agent_id,
+                body_size = body_size,
+                limit = limit,
+                event_type = ?event_type,
+                "Body exceeds agent inspection limit, skipping agent (fail-open)"
+            );
+            if let Some(agent) = agents.get(agent_id) {
+                agent.metrics().record_body_size_skip();
+            }
+        }
+
+        if let Some((agent_id, limit)) = outcome.blocked_by {
+            warn!(
+                correlation_id = %ctx.correlation_id,
+                agent_id = %agent_id,
+                body_size = body_size,
+                limit = limit,
+                event_type = ?event_type,
+                "Body exceeds agent inspection limit, blocking request (fail-closed)"
+            );
+            return BodyLimitsResult::Block(Box::new(
+                AgentDecision::block(413, "Payload too large for security inspection")
+                    .with_decided_by(agent_id),
+            ));
+        }
+
+        BodyLimitsResult::Proceed(outcome.allowed)
+    }
+}
+
+/// Result of enforcing body inspection limits.
+enum BodyLimitsResult {
+    /// Agents (within their limits) that may inspect the body.
+    Proceed(Vec<String>),
+    /// A fail-closed agent's limit was exceeded; the request must be blocked.
+    Block(Box<AgentDecision>),
+}
+
+/// Outcome of evaluating a body size against per-agent inspection limits.
+#[derive(Debug)]
+struct BodyLimitOutcome {
+    /// Agents whose limit accommodates the body
+    allowed: Vec<String>,
+    /// Fail-open agents skipped because the body exceeds their limit (id, limit)
+    skipped: Vec<(String, usize)>,
+    /// First fail-closed agent whose limit was exceeded (id, limit)
+    blocked_by: Option<(String, usize)>,
+}
+
+/// Evaluate a body size against per-agent `(id, failure_mode, limit)` entries.
+fn evaluate_body_limits(
+    agents: &[(String, FailureMode, usize)],
+    body_size: usize,
+) -> BodyLimitOutcome {
+    let mut outcome = BodyLimitOutcome {
+        allowed: Vec::new(),
+        skipped: Vec::new(),
+        blocked_by: None,
+    };
+
+    for (id, failure_mode, limit) in agents {
+        if body_size <= *limit {
+            outcome.allowed.push(id.clone());
+        } else if *failure_mode == FailureMode::Closed {
+            outcome.blocked_by = Some((id.clone(), *limit));
+            break;
+        } else {
+            outcome.skipped.push((id.clone(), *limit));
+        }
+    }
+
+    outcome
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn limits() -> Vec<(String, FailureMode, usize)> {
+        vec![
+            ("waf".to_string(), FailureMode::Closed, 1024),
+            ("audit".to_string(), FailureMode::Open, 512),
+            ("dlp".to_string(), FailureMode::Open, 4096),
+        ]
+    }
+
+    #[test]
+    fn body_within_all_limits_allows_all_agents() {
+        let outcome = evaluate_body_limits(&limits(), 256);
+        assert_eq!(outcome.allowed, vec!["waf", "audit", "dlp"]);
+        assert!(outcome.skipped.is_empty());
+        assert!(outcome.blocked_by.is_none());
+    }
+
+    #[test]
+    fn oversized_body_blocks_on_fail_closed_agent() {
+        let outcome = evaluate_body_limits(&limits(), 2048);
+        assert_eq!(
+            outcome.blocked_by,
+            Some(("waf".to_string(), 1024)),
+            "fail-closed agent over its limit must block"
+        );
+    }
+
+    #[test]
+    fn oversized_body_skips_fail_open_agent_and_keeps_others() {
+        let outcome = evaluate_body_limits(&limits(), 600);
+        assert_eq!(outcome.allowed, vec!["waf", "dlp"]);
+        assert_eq!(outcome.skipped, vec![("audit".to_string(), 512)]);
+        assert!(outcome.blocked_by.is_none());
+    }
+
+    #[test]
+    fn no_agents_yields_empty_outcome() {
+        let outcome = evaluate_body_limits(&[], 1_000_000);
+        assert!(outcome.allowed.is_empty());
+        assert!(outcome.skipped.is_empty());
+        assert!(outcome.blocked_by.is_none());
     }
 }

--- a/crates/proxy/src/agents/metrics.rs
+++ b/crates/proxy/src/agents/metrics.rs
@@ -24,6 +24,8 @@ pub struct AgentMetrics {
     pub decisions_block: AtomicU64,
     pub decisions_redirect: AtomicU64,
     pub decisions_challenge: AtomicU64,
+    /// Bodies that exceeded an agent's inspection limit and skipped it (fail-open)
+    pub body_size_skips: AtomicU64,
 }
 
 impl AgentMetrics {
@@ -50,6 +52,11 @@ impl AgentMetrics {
     pub fn record_timeout(&self) {
         self.calls_total.fetch_add(1, Ordering::Relaxed);
         self.calls_timeout.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a body that exceeded an agent's inspection limit (fail-open skip).
+    pub fn record_body_size_skip(&self) {
+        self.body_size_skips.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Get average call duration in microseconds.

--- a/crates/proxy/src/agents/mod.rs
+++ b/crates/proxy/src/agents/mod.rs
@@ -39,6 +39,14 @@ mod decision;
 mod manager;
 mod metrics;
 
+/// Default maximum body size (in bytes) sent to an agent for inspection.
+///
+/// Applies when `max-request-body-bytes` / `max-response-body-bytes` are not
+/// set on the agent. Bodies larger than the effective limit are handled
+/// according to the agent's failure mode: fail-closed blocks the request,
+/// fail-open skips that agent's inspection (loudly).
+pub const DEFAULT_AGENT_MAX_BODY_BYTES: usize = 1024 * 1024;
+
 pub use agent_v2::AgentV2;
 pub use context::AgentCallContext;
 pub use decision::{AgentAction, AgentDecision};

--- a/crates/proxy/src/inference/budget.rs
+++ b/crates/proxy/src/inference/budget.rs
@@ -4,13 +4,39 @@
 //! over longer periods (hourly, daily, monthly) with optional enforcement.
 
 use dashmap::DashMap;
+use prometheus::{register_int_counter_vec, register_int_gauge_vec, IntCounterVec, IntGaugeVec};
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
+use std::sync::LazyLock;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tracing::{debug, info, trace, warn};
 
 use zentinel_common::budget::{
     BudgetAlert, BudgetCheckResult, BudgetPeriod, TenantBudgetStatus, TokenBudgetConfig,
 };
+
+/// Prometheus metrics for tenant budget maps.
+struct BudgetTrackerMetrics {
+    /// Distinct tenants currently tracked, per route
+    tenants: IntGaugeVec,
+    /// Tenants evicted to enforce the max-tenants bound, per route
+    evictions: IntCounterVec,
+}
+
+static TRACKER_METRICS: LazyLock<Option<BudgetTrackerMetrics>> = LazyLock::new(|| {
+    let tenants = register_int_gauge_vec!(
+        "zentinel_inference_budget_tenants",
+        "Distinct tenants currently tracked by token budget trackers",
+        &["route"]
+    )
+    .ok()?;
+    let evictions = register_int_counter_vec!(
+        "zentinel_inference_budget_tenant_evictions_total",
+        "Tenant budget states evicted to enforce the max-tenants bound",
+        &["route"]
+    )
+    .ok()?;
+    Some(BudgetTrackerMetrics { tenants, evictions })
+});
 
 /// Per-tenant budget state tracking
 struct TenantBudgetState {
@@ -325,10 +351,73 @@ impl TokenBudgetTracker {
         &self,
         tenant: &str,
     ) -> dashmap::mapref::one::Ref<'_, String, TenantBudgetState> {
+        if !self.tenants.contains_key(tenant) && self.tenants.len() >= self.config.max_tenants {
+            self.evict_tenants();
+        }
+
         self.tenants
             .entry(tenant.to_string())
             .or_insert_with(TenantBudgetState::new);
+
+        if let Some(metrics) = TRACKER_METRICS.as_ref() {
+            metrics
+                .tenants
+                .with_label_values(&[&self.route_id])
+                .set(self.tenants.len() as i64);
+        }
+
         self.tenants.get(tenant).expect("Just inserted")
+    }
+
+    /// Evict tenant state so a new tenant can be admitted without unbounded growth.
+    ///
+    /// Tenants whose period has expired are dropped first — their state is
+    /// equivalent to a fresh one (with rollover enabled, one extra period is
+    /// kept so unused tokens can still roll over on next access). If the map
+    /// is still at capacity, the tenants with the oldest periods are evicted
+    /// down to 90% of the bound.
+    fn evict_tenants(&self) {
+        let period_secs = self.config.period.as_secs();
+        let keep_secs = if self.config.rollover {
+            period_secs.saturating_mul(2)
+        } else {
+            period_secs
+        };
+
+        let before = self.tenants.len();
+        self.tenants
+            .retain(|_, state| state.elapsed().as_secs() < keep_secs);
+
+        if self.tenants.len() >= self.config.max_tenants {
+            let target = (self.config.max_tenants * 9).div_ceil(10);
+            let mut entries: Vec<(String, u64)> = self
+                .tenants
+                .iter()
+                .map(|e| (e.key().clone(), e.value().period_start_unix))
+                .collect();
+            entries.sort_by_key(|(_, start)| *start);
+            let excess = self.tenants.len().saturating_sub(target);
+            for (tenant, _) in entries.iter().take(excess) {
+                self.tenants.remove(tenant);
+            }
+        }
+
+        let evicted = before.saturating_sub(self.tenants.len());
+        if evicted > 0 {
+            warn!(
+                route_id = %self.route_id,
+                evicted = evicted,
+                remaining = self.tenants.len(),
+                max_tenants = self.config.max_tenants,
+                "Tenant budget map at capacity, evicted tenant state"
+            );
+            if let Some(metrics) = TRACKER_METRICS.as_ref() {
+                metrics
+                    .evictions
+                    .with_label_values(&[&self.route_id])
+                    .inc_by(evicted as u64);
+            }
+        }
     }
 }
 
@@ -348,6 +437,7 @@ mod tests {
             enforce: true,
             rollover: false,
             burst_allowance: None,
+            max_tenants: 10_000,
         }
     }
 
@@ -496,5 +586,42 @@ mod tests {
         assert_eq!(tracker.status("tenant-1").tokens_used, 500);
         assert_eq!(tracker.status("tenant-2").tokens_used, 200);
         assert_eq!(tracker.tenant_count(), 2);
+    }
+
+    #[test]
+    fn tenant_map_never_exceeds_max_tenants() {
+        let mut config = test_config();
+        config.max_tenants = 10;
+        let tracker = TokenBudgetTracker::new(config, "test-route");
+
+        for i in 0..100 {
+            tracker.record(&format!("tenant-{i}"), 1);
+        }
+
+        assert!(
+            tracker.tenant_count() <= 10,
+            "tenant map grew past max_tenants: {}",
+            tracker.tenant_count()
+        );
+    }
+
+    #[test]
+    fn tracker_still_enforces_budget_after_eviction() {
+        let mut config = test_config();
+        config.max_tenants = 5;
+        let tracker = TokenBudgetTracker::new(config, "test-route");
+
+        // Force evictions with many distinct tenants
+        for i in 0..50 {
+            tracker.record(&format!("tenant-{i}"), 1);
+        }
+
+        // A fresh tenant must still get correct budget accounting
+        tracker.record("fresh", 1000);
+        let result = tracker.check("fresh", 100);
+        assert!(
+            !result.is_allowed(),
+            "exhausted tenant must still be blocked after evictions"
+        );
     }
 }

--- a/crates/proxy/src/inference/manager.rs
+++ b/crates/proxy/src/inference/manager.rs
@@ -459,6 +459,7 @@ mod tests {
                 enforce: true,
                 rollover: false,
                 burst_allowance: None,
+                max_tenants: 10_000,
             }),
             cost_attribution: None,
             routing: None,

--- a/crates/proxy/src/proxy/handlers.rs
+++ b/crates/proxy/src/proxy/handlers.rs
@@ -527,6 +527,7 @@ impl ZentinelProxy {
                         AgentAction::Block { status, body, .. } => {
                             warn!(
                                 correlation_id = %ctx.trace_id,
+                                agent_id = decision.decided_by.as_deref().unwrap_or("unknown"),
                                 status = status,
                                 "Request blocked by agent"
                             );
@@ -534,11 +535,14 @@ impl ZentinelProxy {
 
                             // Audit log the block decision
                             // Collect tags and rule_ids from all audit metadata
-                            let all_tags: Vec<String> = decision
+                            let mut all_tags: Vec<String> = decision
                                 .audit
                                 .iter()
                                 .flat_map(|a| a.tags.iter().cloned())
                                 .collect();
+                            if let Some(ref agent_id) = decision.decided_by {
+                                all_tags.push(format!("agent:{agent_id}"));
+                            }
                             let all_rule_ids: Vec<String> = decision
                                 .audit
                                 .iter()

--- a/crates/proxy/src/proxy/http_trait.rs
+++ b/crates/proxy/src/proxy/http_trait.rs
@@ -3805,6 +3805,7 @@ impl ZentinelProxy {
                 if !decision.needs_more && !decision.is_allow() {
                     warn!(
                         correlation_id = %ctx.trace_id,
+                        agent_id = decision.decided_by.as_deref().unwrap_or("unknown"),
                         action = ?decision.action,
                         "Agent blocked request body"
                     );
@@ -4001,6 +4002,7 @@ impl ZentinelProxy {
                 if !decision.is_allow() {
                     warn!(
                         correlation_id = %ctx.trace_id,
+                        agent_id = decision.decided_by.as_deref().unwrap_or("unknown"),
                         action = ?decision.action,
                         "Agent blocked request body"
                     );

--- a/crates/proxy/src/proxy/mod.rs
+++ b/crates/proxy/src/proxy/mod.rs
@@ -715,6 +715,7 @@ impl ZentinelProxy {
                     message: None,
                     backend: zentinel_config::RateLimitBackend::Local,
                     max_delay_ms: 5000, // Default for policy-based rate limits
+                    max_keys: crate::rate_limit::DEFAULT_MAX_RATE_LIMIT_KEYS,
                 };
                 manager.register_route(&route.id, rl_config);
                 info!(
@@ -740,6 +741,7 @@ impl ZentinelProxy {
                             message: rl_filter.limit_message.clone(),
                             backend: rl_filter.backend.clone(),
                             max_delay_ms: rl_filter.max_delay_ms,
+                            max_keys: rl_filter.max_keys,
                         };
                         manager.register_route(&route.id, rl_config);
                         info!(

--- a/crates/proxy/src/rate_limit.rs
+++ b/crates/proxy/src/rate_limit.rs
@@ -17,7 +17,9 @@
 use dashmap::DashMap;
 use parking_lot::RwLock;
 use pingora_limits::rate::Rate;
-use std::sync::Arc;
+use prometheus::{register_int_counter_vec, register_int_gauge_vec, IntCounterVec, IntGaugeVec};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, LazyLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tracing::{debug, trace, warn};
 
@@ -69,7 +71,16 @@ pub struct RateLimitConfig {
     pub backend: RateLimitBackend,
     /// Maximum delay in milliseconds for Delay action
     pub max_delay_ms: u64,
+    /// Maximum number of distinct keys tracked in memory
+    pub max_keys: usize,
 }
+
+/// Default bound on distinct rate-limit keys tracked per pool.
+pub const DEFAULT_MAX_RATE_LIMIT_KEYS: usize = 100_000;
+
+/// Keys not seen within this many seconds are considered idle and evictable.
+/// Rate windows are 1 second, so any state older than this is meaningless.
+const IDLE_KEY_TTL_SECS: u64 = 10;
 
 impl Default for RateLimitConfig {
     fn default() -> Self {
@@ -82,6 +93,7 @@ impl Default for RateLimitConfig {
             message: None,
             backend: RateLimitBackend::Local,
             max_delay_ms: 5000,
+            max_keys: DEFAULT_MAX_RATE_LIMIT_KEYS,
         }
     }
 }
@@ -94,6 +106,8 @@ struct KeyRateLimiter {
     rate: Rate,
     /// Maximum requests per window
     max_requests: isize,
+    /// Unix timestamp (seconds) of the last check, for idle eviction
+    last_seen: AtomicU64,
 }
 
 impl KeyRateLimiter {
@@ -101,7 +115,17 @@ impl KeyRateLimiter {
         Self {
             rate: Rate::new(Duration::from_secs(1)),
             max_requests: max_rps as isize,
+            last_seen: AtomicU64::new(current_unix_timestamp()),
         }
+    }
+
+    fn touch(&self) {
+        self.last_seen
+            .store(current_unix_timestamp(), Ordering::Relaxed);
+    }
+
+    fn idle_secs(&self, now: u64) -> u64 {
+        now.saturating_sub(self.last_seen.load(Ordering::Relaxed))
     }
 
     /// Check if a request should be allowed
@@ -140,7 +164,35 @@ pub struct RateLimiterPool {
     backend: RateLimitBackendType,
     /// Configuration
     config: RwLock<RateLimitConfig>,
+    /// Scope label for metrics (route ID or "global")
+    scope: String,
+    /// Guard so only one task sweeps the key map at a time
+    sweeping: AtomicBool,
 }
+
+/// Prometheus metrics for rate limiter key maps.
+struct RateLimitPoolMetrics {
+    /// Distinct keys currently tracked, per scope
+    keys: IntGaugeVec,
+    /// Keys evicted to enforce the max-keys bound, per scope
+    evictions: IntCounterVec,
+}
+
+static POOL_METRICS: LazyLock<Option<RateLimitPoolMetrics>> = LazyLock::new(|| {
+    let keys = register_int_gauge_vec!(
+        "zentinel_rate_limit_keys",
+        "Distinct rate-limit keys currently tracked in memory",
+        &["scope"]
+    )
+    .ok()?;
+    let evictions = register_int_counter_vec!(
+        "zentinel_rate_limit_key_evictions_total",
+        "Rate-limit keys evicted to enforce the max-keys bound",
+        &["scope"]
+    )
+    .ok()?;
+    Some(RateLimitPoolMetrics { keys, evictions })
+});
 
 /// Get current unix timestamp in seconds
 fn current_unix_timestamp() -> u64 {
@@ -158,11 +210,18 @@ fn calculate_reset_timestamp() -> u64 {
 impl RateLimiterPool {
     /// Create a new rate limiter pool with the given configuration (local backend)
     pub fn new(config: RateLimitConfig) -> Self {
+        Self::with_scope(config, "default")
+    }
+
+    /// Create a new rate limiter pool with a metrics scope (route ID or "global")
+    pub fn with_scope(config: RateLimitConfig, scope: impl Into<String>) -> Self {
         Self {
             backend: RateLimitBackendType::Local {
                 limiters: DashMap::new(),
             },
             config: RwLock::new(config),
+            scope: scope.into(),
+            sweeping: AtomicBool::new(false),
         }
     }
 
@@ -175,6 +234,8 @@ impl RateLimiterPool {
                 local_fallback: DashMap::new(),
             },
             config: RwLock::new(config),
+            scope: "default".to_string(),
+            sweeping: AtomicBool::new(false),
         }
     }
 
@@ -185,6 +246,7 @@ impl RateLimiterPool {
     pub fn check(&self, key: &str) -> RateLimitCheckInfo {
         let config = self.config.read();
         let max_rps = config.max_rps;
+        let max_keys = config.max_keys;
         drop(config);
 
         let limiters = match &self.backend {
@@ -193,12 +255,10 @@ impl RateLimiterPool {
             RateLimitBackendType::Distributed { local_fallback, .. } => local_fallback,
         };
 
-        // Get or create limiter for this key
-        let limiter = limiters
-            .entry(key.to_string())
-            .or_insert_with(|| Arc::new(KeyRateLimiter::new(max_rps)))
-            .clone();
+        // Get or create limiter for this key, enforcing the key-map bound
+        let limiter = self.get_or_create_limiter(limiters, key, max_rps, max_keys);
 
+        limiter.touch();
         let outcome = limiter.check();
         let count = limiter.rate.observe(&(), 0); // Get current count without incrementing
         let remaining = if count >= max_rps as isize {
@@ -255,11 +315,11 @@ impl RateLimiterPool {
 
                         // Fallback to local
                         if redis.fallback_enabled() {
-                            let limiter = local_fallback
-                                .entry(key.to_string())
-                                .or_insert_with(|| Arc::new(KeyRateLimiter::new(max_rps)))
-                                .clone();
+                            let max_keys = self.config.read().max_keys;
+                            let limiter =
+                                self.get_or_create_limiter(local_fallback, key, max_rps, max_keys);
 
+                            limiter.touch();
                             let outcome = limiter.check();
                             let count = limiter.rate.observe(&(), 0);
                             let remaining = if count >= max_rps as isize {
@@ -364,34 +424,126 @@ impl RateLimiterPool {
         }
     }
 
-    /// Clean up expired entries (call periodically)
-    pub fn cleanup(&self) {
-        // Remove entries that haven't been accessed recently
-        // In practice, Rate handles its own window cleanup, so this is mainly
-        // for memory management when many unique keys are seen
-        let max_entries = 100_000; // Prevent unbounded growth
+    /// Get or create the limiter for a key, enforcing the `max_keys` bound.
+    ///
+    /// When the map is at capacity and a new key arrives, idle entries (not
+    /// seen within [`IDLE_KEY_TTL_SECS`]) are swept first; if the map is still
+    /// at capacity, the longest-idle entries are evicted down to 90% of the
+    /// bound and an eviction metric is incremented.
+    fn get_or_create_limiter(
+        &self,
+        limiters: &DashMap<String, Arc<KeyRateLimiter>>,
+        key: &str,
+        max_rps: u32,
+        max_keys: usize,
+    ) -> Arc<KeyRateLimiter> {
+        if let Some(limiter) = limiters.get(key) {
+            return limiter.clone();
+        }
 
+        if limiters.len() >= max_keys {
+            self.evict_keys(limiters, max_keys);
+        }
+
+        let limiter = limiters
+            .entry(key.to_string())
+            .or_insert_with(|| Arc::new(KeyRateLimiter::new(max_rps)))
+            .clone();
+
+        if let Some(metrics) = POOL_METRICS.as_ref() {
+            metrics
+                .keys
+                .with_label_values(&[&self.scope])
+                .set(limiters.len() as i64);
+        }
+
+        limiter
+    }
+
+    /// Evict entries so a new key can be admitted without exceeding `max_keys`.
+    fn evict_keys(&self, limiters: &DashMap<String, Arc<KeyRateLimiter>>, max_keys: usize) {
+        // Only one task sweeps at a time; concurrent inserts may briefly
+        // overshoot the bound by the number of racing requests.
+        if self
+            .sweeping
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            return;
+        }
+
+        let now = current_unix_timestamp();
+        let before = limiters.len();
+
+        // First pass: drop idle entries (their 1s window state is stale anyway)
+        limiters.retain(|_, limiter| limiter.idle_secs(now) <= IDLE_KEY_TTL_SECS);
+
+        // Second pass: still at capacity means all keys are active; evict the
+        // longest-idle entries down to 90% so inserts don't thrash the sweep.
+        if limiters.len() >= max_keys {
+            // Floor and stay below the cap so the pending insert never pushes
+            // the map past max_keys (div_ceil would leave target == max_keys
+            // for small caps and evict nothing).
+            let target = ((max_keys * 9) / 10).min(max_keys.saturating_sub(1));
+            let mut entries: Vec<(String, u64)> = limiters
+                .iter()
+                .map(|e| (e.key().clone(), e.value().idle_secs(now)))
+                .collect();
+            // Most idle first
+            entries.sort_by_key(|e| std::cmp::Reverse(e.1));
+            for (key, _) in entries.iter().take(limiters.len().saturating_sub(target)) {
+                limiters.remove(key);
+            }
+        }
+
+        let evicted = before.saturating_sub(limiters.len());
+        if evicted > 0 {
+            warn!(
+                scope = %self.scope,
+                evicted = evicted,
+                remaining = limiters.len(),
+                max_keys = max_keys,
+                "Rate limiter key map at capacity, evicted entries"
+            );
+            if let Some(metrics) = POOL_METRICS.as_ref() {
+                metrics
+                    .evictions
+                    .with_label_values(&[&self.scope])
+                    .inc_by(evicted as u64);
+                metrics
+                    .keys
+                    .with_label_values(&[&self.scope])
+                    .set(limiters.len() as i64);
+            }
+        }
+
+        self.sweeping.store(false, Ordering::Release);
+    }
+
+    /// Clean up idle entries (call periodically)
+    pub fn cleanup(&self) {
         let limiters = match &self.backend {
             RateLimitBackendType::Local { limiters } => limiters,
             #[cfg(feature = "distributed-rate-limit")]
             RateLimitBackendType::Distributed { local_fallback, .. } => local_fallback,
         };
 
-        if limiters.len() > max_entries {
-            // Simple eviction: clear half
-            let to_remove: Vec<_> = limiters
-                .iter()
-                .take(max_entries / 2)
-                .map(|e| e.key().clone())
-                .collect();
+        let now = current_unix_timestamp();
+        let before = limiters.len();
+        limiters.retain(|_, limiter| limiter.idle_secs(now) <= IDLE_KEY_TTL_SECS);
 
-            for key in to_remove {
-                limiters.remove(&key);
-            }
+        if let Some(metrics) = POOL_METRICS.as_ref() {
+            metrics
+                .keys
+                .with_label_values(&[&self.scope])
+                .set(limiters.len() as i64);
+        }
 
+        if before != limiters.len() {
             debug!(
-                entries_before = max_entries,
-                entries_after = limiters.len(),
+                scope = %self.scope,
+                removed = before - limiters.len(),
+                remaining = limiters.len(),
                 "Rate limiter pool cleanup completed"
             );
         }
@@ -431,10 +583,11 @@ impl RateLimitManager {
             message: None,
             backend: RateLimitBackend::Local,
             max_delay_ms: 5000,
+            max_keys: DEFAULT_MAX_RATE_LIMIT_KEYS,
         };
         Self {
             route_limiters: DashMap::new(),
-            global_limiter: Some(Arc::new(RateLimiterPool::new(config))),
+            global_limiter: Some(Arc::new(RateLimiterPool::with_scope(config, "global"))),
         }
     }
 
@@ -448,8 +601,10 @@ impl RateLimitManager {
             "Registering rate limiter for route"
         );
 
-        self.route_limiters
-            .insert(route_id.to_string(), Arc::new(RateLimiterPool::new(config)));
+        self.route_limiters.insert(
+            route_id.to_string(),
+            Arc::new(RateLimiterPool::with_scope(config, route_id)),
+        );
     }
 
     /// Check if a request should be rate limited
@@ -995,5 +1150,69 @@ mod tests {
             },
         );
         assert!(route_manager.is_enabled());
+    }
+
+    fn pool_key_count(pool: &RateLimiterPool) -> usize {
+        pool.local_limiter_count()
+    }
+
+    #[test]
+    fn key_map_never_exceeds_max_keys() {
+        let config = RateLimitConfig {
+            max_rps: 100,
+            max_keys: 10,
+            ..Default::default()
+        };
+        let pool = RateLimiterPool::new(config);
+
+        for i in 0..100 {
+            pool.check(&format!("client-{i}"));
+        }
+
+        // Active keys force second-pass eviction down to ~90% of the cap, so
+        // the map may hold at most max_keys entries (cap + the new insert - evictions)
+        assert!(
+            pool_key_count(&pool) <= 10,
+            "key map grew past max_keys: {}",
+            pool_key_count(&pool)
+        );
+    }
+
+    #[test]
+    fn eviction_keeps_recently_seen_keys_usable() {
+        let config = RateLimitConfig {
+            max_rps: 2,
+            max_keys: 5,
+            ..Default::default()
+        };
+        let pool = RateLimiterPool::new(config);
+
+        // Saturate one key to its limit
+        pool.check("hot");
+        pool.check("hot");
+        assert_eq!(pool.check("hot").outcome, RateLimitOutcome::Limited);
+
+        // Flood with new keys to force eviction; limiter must keep functioning
+        for i in 0..50 {
+            let info = pool.check(&format!("cold-{i}"));
+            assert_eq!(info.outcome, RateLimitOutcome::Allowed);
+        }
+        assert!(pool_key_count(&pool) <= 5);
+    }
+
+    #[test]
+    fn cleanup_retains_active_keys() {
+        let config = RateLimitConfig {
+            max_rps: 100,
+            max_keys: 100,
+            ..Default::default()
+        };
+        let pool = RateLimiterPool::new(config);
+
+        pool.check("active");
+        pool.cleanup();
+
+        // Key was just seen, so periodic cleanup must not remove it
+        assert_eq!(pool_key_count(&pool), 1);
     }
 }


### PR DESCRIPTION
> Stacked on #271 (release bump). Base is `chore/release-26.06_2`; retarget to `main` after #271 merges.

## Summary
- **Behavior change:** oversized request/response bodies no longer silently bypass agent inspection. Per-agent `max-request-body-bytes` / `max-response-body-bytes` (default 1 MiB) are now enforced and follow the agent's `failure-mode`: `closed` blocks with 413, `open` skips that agent loudly (warn log + `body_size_skips` metric). Previously the fields parsed but had no effect, and streaming bodies had no limit at all.
- Rate-limit filters gain `max-keys` (default 100k) bounding the per-key limiter map with idle-aware eviction; inference token budgets gain `max-tenants` (default 10k) with expired-period-first eviction. New gauges/counters: `zentinel_rate_limit_keys{scope}`, `zentinel_rate_limit_key_evictions_total{scope}`, `zentinel_inference_budget_tenants{route}`, `zentinel_inference_budget_tenant_evictions_total{route}`.
- `AgentDecision.decided_by` attributes every block/redirect/challenge to the responsible agent (including synthetic fail-closed blocks from timeouts, circuit breakers, and body-size limits); block logs carry `agent_id`, audit entries gain an `agent:<id>` tag.
- Config validation rejects duplicate agent IDs and zero timeouts/body limits.
- CI: workspace unit tests now run on every PR (full suite stays in the Tests workflow).

## Test plan
- [x] `cargo test --workspace --lib` (1k+ tests green)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `mise run pre-push`
- [ ] Soak/integration run with an agent configured `failure-mode "closed"` and oversized bodies (expect 413 + metric)