### PR TITLE
fix: bound hidden unbounded state, run pool maintenance, align docs with reality

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -322,12 +322,18 @@ rust-lldb target/debug/deps/zentinel_proxy-xxx specific_test
 ### Validate Config
 
 ```bash
-# Check config syntax
-cargo run --bin zentinel -- --config config/zentinel.kdl --check
+# Check config syntax and schema (parse + validate, don't start)
+cargo run --bin zentinel -- test --config config/zentinel.kdl
 
-# Dry run (parse and validate, don't start)
-cargo run --bin zentinel -- --config config/zentinel.kdl --dry-run
+# Validate with connectivity checks (network, agents, certificates)
+cargo run --bin zentinel -- validate --config config/zentinel.kdl
+
+# Lint for best practices
+cargo run --bin zentinel -- lint --config config/zentinel.kdl
 ```
+
+> There are no `--check`/`--dry-run` flags; use the `test`/`validate`/`lint`
+> subcommands (or the `-t/--test` flag, equivalent to `test`).
 
 ### Config Examples
 
@@ -336,7 +342,7 @@ Test against example configs:
 ```bash
 for config in config/examples/*.kdl; do
     echo "Testing $config"
-    cargo run --bin zentinel -- --config "$config" --check
+    cargo run --bin zentinel -- test --config "$config"
 done
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,42 @@ for details.
   (`timeout-ms`, `chunk-timeout-ms`), and zero body limits.
 - CI: workspace unit tests (`cargo test --workspace --lib`) now run on every
   pull request; the full suite remains in the Tests workflow.
+- `system { route-cache-size N }` (default `1000`) exposes the previously
+  hardcoded route-match cache size; evictions are now visible via
+  `zentinel_route_cache_evictions_total` and a debug log.
+- Agent pool correlation affinities are bounded (`max_correlation_affinities`,
+  default `100000`) with idle-TTL reclamation (default 5 min) and explicit
+  release at request completion. New metrics: `correlation_affinities` gauge,
+  `affinity_evictions_total`, `affinity_rejections_total`.
+
+### Fixed
+- **Agent pool maintenance now actually runs.** `AgentPool::run_maintenance`
+  (connection health re-checks, reconnection, sticky-session cleanup) existed
+  but was never spawned: a crashed-and-restarted agent stayed permanently
+  unhealthy until proxy restart. It is now spawned per agent on initialize.
+- Correlation affinity entries leaked once per request (inserted on every
+  request-headers call, never cleared anywhere).
+- Reverse-connection clients leaked pending-response entries on
+  serialization/send failure and on timeout under lock contention; the
+  `in_flight` gauge also drifted upward on every error.
+- Agent metrics collector: `max_series` was configured but never enforced and
+  `expire_old_metrics` was never called, so agent-reported series accumulated
+  without bound. New series are dropped at the limit (warn + counter) and
+  stale series expire via pool maintenance.
+- Consistent-hash lookup cache grew without bound on request-derived key
+  hashes (`with_capacity(1000)` was only an allocation hint); now hard-bounded
+  at 10k entries.
+- Active health checks now bound the WHOLE probe (connect + write + read) with
+  `timeout-secs`; previously only the connect was bounded, so a backend that
+  accepted then hung froze that target's check loop forever.
+- Disk-cache in-flight write tracking could silently skip cleanup when a
+  handler was dropped under lock contention; moved to a lock-free map. Startup
+  now probes cache-dir writability once with an actionable error.
+- Hot reload warns explicitly when listener or `system` settings changed in
+  the new config (they are not hot-reloadable and were previously ignored
+  silently).
+- README no longer claims S3-FIFO/TinyLFU cache eviction (it is LRU) or
+  WebSocket traffic mirroring (frame inspection + session affinity).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ More examples: [`config/examples/`](config/examples/) covers API gateways, load 
 | **Load Balancing** | 14 algorithms: round-robin, weighted, least connections, Maglev, Peak EWMA, and more |
 | **Security** | TLS/mTLS, rate limiting, GeoIP filtering, WAF, zip bomb protection |
 | **Agent Protocol** | External agents for WAF, auth, and custom logic — crash-isolated, any language |
-| **HTTP Caching** | Pingora-based response caching with stampede prevention and S3-FIFO + TinyLFU eviction |
-| **WebSocket Proxying** | RFC 6455 compliant with frame inspection and traffic mirroring |
+| **HTTP Caching** | Pingora-based response caching with stampede prevention and LRU eviction (memory, disk, or hybrid backends) |
+| **WebSocket Proxying** | RFC 6455 compliant with per-frame agent inspection and session affinity |
 | **Observability** | Prometheus metrics, structured logging, OpenTelemetry tracing |
-| **Hot Reload** | Zero-downtime config updates via SIGHUP with validation and atomic swap |
+| **Hot Reload** | Zero-downtime config updates via SIGHUP with validation and atomic swap (routes, upstreams, agents; listener changes require a restart) |
 
 See the full feature breakdown at [zentinelproxy.io/features](https://zentinelproxy.io/features/).
 

--- a/crates/agent-protocol/docs/v2/pooling.md
+++ b/crates/agent-protocol/docs/v2/pooling.md
@@ -816,6 +816,24 @@ let config = AgentPoolConfig {
 
 The maintenance task (`run_maintenance()`) automatically cleans up expired sessions.
 
+### Correlation Affinity Bounds
+
+Connection affinity (headers → body chunk routing, keyed by correlation ID) is
+bounded and self-cleaning:
+
+- `max_correlation_affinities` (default `100_000`): when the map is full, new
+  affinities are dropped (`affinity_rejections_total` counter) and body chunks
+  for those requests fall back to normal connection selection.
+- `correlation_affinity_ttl` (default 5 minutes): idle entries are reclaimed by
+  the maintenance task (`affinity_evictions_total` counter) as a backstop for
+  requests that never complete. The proxy releases affinities explicitly at
+  request completion.
+- Current entry count is exported as the `correlation_affinities` gauge.
+
+> `run_maintenance()` must be running for TTL cleanup, health re-checks, and
+> reconnection. The proxy spawns it per agent in `AgentV2::initialize` and
+> aborts it on shutdown.
+
 ### When to Use Sticky Sessions
 
 | Scenario | Use Sticky Sessions? |

--- a/crates/agent-protocol/src/buffer_pool.rs
+++ b/crates/agent-protocol/src/buffer_pool.rs
@@ -92,6 +92,9 @@ impl BufferPool {
 
 /// A pooled buffer that returns to the pool on drop.
 pub struct PooledBuffer {
+    /// Invariant: always `Some` while the wrapper is accessible. The only
+    /// `take()`s are in `Self::take` (consumes `self`) and `Drop`, so the
+    /// `expect`s in the accessors below cannot fire.
     buffer: Option<BytesMut>,
 }
 

--- a/crates/agent-protocol/src/mmap_buffer.rs
+++ b/crates/agent-protocol/src/mmap_buffer.rs
@@ -249,10 +249,13 @@ impl LargeBodyBuffer {
         // If in mmap mode, convert to memory first
         self.convert_mmap_to_memory()?;
 
-        if let BufferStorage::Memory(ref mut vec) = self.storage {
-            Ok(vec.as_mut_slice())
-        } else {
-            unreachable!("convert_mmap_to_memory should have converted to Memory")
+        match self.storage {
+            BufferStorage::Memory(ref mut vec) => Ok(vec.as_mut_slice()),
+            // convert_mmap_to_memory guarantees Memory on Ok; return an error
+            // rather than panicking in the dataplane if that ever regresses
+            BufferStorage::Mmap { .. } => Err(io::Error::other(
+                "mmap buffer was not converted to memory storage",
+            )),
         }
     }
 

--- a/crates/agent-protocol/src/v2/observability.rs
+++ b/crates/agent-protocol/src/v2/observability.rs
@@ -10,7 +10,9 @@ use crate::v2::control::{ConfigUpdateRequest, ConfigUpdateResponse, ConfigUpdate
 use crate::v2::metrics::{HistogramBucket, MetricsReport};
 use parking_lot::RwLock;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
+use tracing::warn;
 
 /// Metrics collector that receives and aggregates metrics from agents.
 #[derive(Debug)]
@@ -23,6 +25,10 @@ pub struct MetricsCollector {
     histograms: RwLock<HashMap<MetricKey, AggregatedHistogram>>,
     /// Last report time per agent
     last_report: RwLock<HashMap<String, Instant>>,
+    /// Series dropped because `max_series` was reached
+    dropped_series: AtomicU64,
+    /// Whether the collector is currently at capacity (for one-shot warn)
+    at_capacity: AtomicBool,
     /// Configuration
     config: MetricsCollectorConfig,
 }
@@ -122,7 +128,30 @@ impl MetricsCollector {
             gauges: RwLock::new(HashMap::new()),
             histograms: RwLock::new(HashMap::new()),
             last_report: RwLock::new(HashMap::new()),
+            dropped_series: AtomicU64::new(0),
+            at_capacity: AtomicBool::new(false),
             config,
+        }
+    }
+
+    /// Number of series dropped because `max_series` was reached.
+    pub fn dropped_series(&self) -> u64 {
+        self.dropped_series.load(Ordering::Relaxed)
+    }
+
+    /// Record that a new series was dropped due to `max_series`, warning once
+    /// per at-capacity episode.
+    fn record_series_drop(&self, agent_id: &str, name: &str) {
+        self.dropped_series.fetch_add(1, Ordering::Relaxed);
+        if !self.at_capacity.swap(true, Ordering::Relaxed) {
+            warn!(
+                agent_id = %agent_id,
+                metric = %name,
+                max_series = self.config.max_series,
+                "Agent metrics collector at max_series; dropping new series \
+                 (existing series still update). Check agents for \
+                 high-cardinality labels."
+            );
         }
     }
 
@@ -144,7 +173,15 @@ impl MetricsCollector {
 
             let key = MetricKey::new(&report.agent_id, &counter.name, &labels);
 
+            let gauges_len = self.gauges.read().len();
+            let histograms_len = self.histograms.read().len();
             let mut counters = self.counters.write();
+            if !counters.contains_key(&key)
+                && counters.len() + gauges_len + histograms_len >= self.config.max_series
+            {
+                self.record_series_drop(&report.agent_id, &counter.name);
+                continue;
+            }
             counters.insert(
                 key,
                 AggregatedCounter {
@@ -166,7 +203,15 @@ impl MetricsCollector {
 
             let key = MetricKey::new(&report.agent_id, &gauge.name, &labels);
 
+            let counters_len = self.counters.read().len();
+            let histograms_len = self.histograms.read().len();
             let mut gauges = self.gauges.write();
+            if !gauges.contains_key(&key)
+                && counters_len + gauges.len() + histograms_len >= self.config.max_series
+            {
+                self.record_series_drop(&report.agent_id, &gauge.name);
+                continue;
+            }
             gauges.insert(
                 key,
                 AggregatedGauge {
@@ -188,7 +233,15 @@ impl MetricsCollector {
 
             let key = MetricKey::new(&report.agent_id, &histogram.name, &labels);
 
+            let counters_len = self.counters.read().len();
+            let gauges_len = self.gauges.read().len();
             let mut histograms = self.histograms.write();
+            if !histograms.contains_key(&key)
+                && counters_len + gauges_len + histograms.len() >= self.config.max_series
+            {
+                self.record_series_drop(&report.agent_id, &histogram.name);
+                continue;
+            }
             histograms.insert(
                 key,
                 AggregatedHistogram {
@@ -218,6 +271,12 @@ impl MetricsCollector {
         self.histograms
             .write()
             .retain(|_, v| now.duration_since(v.last_updated) < max_age);
+
+        // Expiry may have freed capacity; allow the at-capacity warn to fire
+        // again on the next saturation episode.
+        if self.series_count() < self.config.max_series {
+            self.at_capacity.store(false, Ordering::Relaxed);
+        }
     }
 
     /// Get the number of active metric series.

--- a/crates/agent-protocol/src/v2/observability.rs
+++ b/crates/agent-protocol/src/v2/observability.rs
@@ -1263,6 +1263,58 @@ mod tests {
     }
 
     #[test]
+    fn max_series_drops_new_series_but_updates_existing() {
+        let collector = MetricsCollector::with_config(MetricsCollectorConfig {
+            max_age: Duration::from_secs(300),
+            max_series: 2,
+            include_agent_id_label: true,
+        });
+
+        let mut report = MetricsReport::new("agent-1", 10_000);
+        report.counters.push(CounterMetric::new("a_total", 1));
+        report.counters.push(CounterMetric::new("b_total", 1));
+        report.counters.push(CounterMetric::new("c_total", 1)); // over limit
+        collector.record(&report);
+
+        assert_eq!(collector.series_count(), 2);
+        assert_eq!(collector.dropped_series(), 1);
+
+        // Existing series still update at capacity
+        let mut update = MetricsReport::new("agent-1", 10_000);
+        update.counters.push(CounterMetric::new("a_total", 42));
+        collector.record(&update);
+
+        assert_eq!(collector.series_count(), 2);
+        assert_eq!(collector.dropped_series(), 1);
+        let prometheus = collector.export_prometheus();
+        assert!(prometheus.contains("42"));
+    }
+
+    #[test]
+    fn expired_series_free_capacity_for_new_ones() {
+        let collector = MetricsCollector::with_config(MetricsCollectorConfig {
+            max_age: Duration::ZERO,
+            max_series: 1,
+            include_agent_id_label: false,
+        });
+
+        let mut report = MetricsReport::new("agent-1", 10_000);
+        report.counters.push(CounterMetric::new("a_total", 1));
+        collector.record(&report);
+        assert_eq!(collector.series_count(), 1);
+
+        // max_age == 0 expires everything
+        collector.expire_old_metrics();
+        assert_eq!(collector.series_count(), 0);
+
+        let mut report2 = MetricsReport::new("agent-1", 10_000);
+        report2.counters.push(CounterMetric::new("b_total", 1));
+        collector.record(&report2);
+        assert_eq!(collector.series_count(), 1);
+        assert_eq!(collector.dropped_series(), 0);
+    }
+
+    #[test]
     fn test_metrics_collector_with_labels() {
         let collector = MetricsCollector::new();
 

--- a/crates/agent-protocol/src/v2/pool.rs
+++ b/crates/agent-protocol/src/v2/pool.rs
@@ -1789,9 +1789,11 @@ impl AgentPool {
         loop {
             interval.tick().await;
 
-            // Clean up expired sticky sessions and correlation affinities
+            // Clean up expired sticky sessions, correlation affinities, and
+            // stale agent-reported metric series
             self.cleanup_expired_sessions();
             self.cleanup_expired_affinities();
+            self.metrics_collector.expire_old_metrics();
 
             // Iterate without holding a long-lived lock
             let agent_ids: Vec<String> = self.agents.iter().map(|e| e.key().clone()).collect();

--- a/crates/agent-protocol/src/v2/pool.rs
+++ b/crates/agent-protocol/src/v2/pool.rs
@@ -155,6 +155,22 @@ pub struct AgentPoolConfig {
     ///
     /// Default: 5 minutes
     pub sticky_session_timeout: Option<Duration>,
+    /// Idle TTL for correlation affinity entries (headers → body chunk routing).
+    ///
+    /// Affinities are cleared explicitly when a request completes; this TTL is
+    /// the backstop that reclaims entries for requests that never complete
+    /// (client disconnects, cancellations, proxy-side errors).
+    ///
+    /// Default: 5 minutes
+    pub correlation_affinity_ttl: Duration,
+    /// Maximum number of correlation affinity entries.
+    ///
+    /// When the map is full, new affinities are dropped (counted in
+    /// `affinity_rejections_total`); body chunks for those requests fall back
+    /// to normal connection selection instead of pinned routing.
+    ///
+    /// Default: 100_000
+    pub max_correlation_affinities: usize,
 }
 
 impl Default for AgentPoolConfig {
@@ -173,7 +189,39 @@ impl Default for AgentPoolConfig {
             flow_control_mode: FlowControlMode::FailClosed,
             flow_control_wait_timeout: Duration::from_millis(100),
             sticky_session_timeout: Some(Duration::from_secs(5 * 60)), // 5 minutes
+            correlation_affinity_ttl: Duration::from_secs(5 * 60),
+            max_correlation_affinities: 100_000,
         }
+    }
+}
+
+/// Connection affinity entry: pins body chunks of a request to the same
+/// connection that received its headers.
+struct AffinityEntry {
+    connection: Arc<PooledConnection>,
+    created_at: Instant,
+    /// Milliseconds since `created_at` of the last access.
+    last_accessed: AtomicU64,
+}
+
+impl AffinityEntry {
+    fn new(connection: Arc<PooledConnection>) -> Self {
+        Self {
+            connection,
+            created_at: Instant::now(),
+            last_accessed: AtomicU64::new(0),
+        }
+    }
+
+    fn touch(&self) {
+        let offset = self.created_at.elapsed().as_millis() as u64;
+        self.last_accessed.store(offset, Ordering::Relaxed);
+    }
+
+    fn is_expired(&self, ttl: Duration) -> bool {
+        let last =
+            self.created_at + Duration::from_millis(self.last_accessed.load(Ordering::Relaxed));
+        last.elapsed() > ttl
     }
 }
 
@@ -583,7 +631,11 @@ pub struct AgentPool {
     protocol_metrics: Arc<ProtocolMetrics>,
     /// Connection affinity: correlation_id → connection used for headers.
     /// Ensures body chunks go to the same connection as headers for streaming.
-    correlation_affinity: DashMap<String, Arc<PooledConnection>>,
+    /// Bounded by `max_correlation_affinities`; idle entries reclaimed by the
+    /// maintenance task after `correlation_affinity_ttl`.
+    correlation_affinity: DashMap<String, AffinityEntry>,
+    /// Whether the affinity map is currently at capacity (for one-shot warn).
+    affinity_at_capacity: AtomicBool,
     /// Sticky sessions: session_id → session info for long-lived streams.
     /// Used for WebSocket, SSE, and long-polling connections.
     sticky_sessions: DashMap<String, StickySession>,
@@ -632,6 +684,7 @@ impl AgentPool {
             config_update_callback,
             protocol_metrics: Arc::new(ProtocolMetrics::new()),
             correlation_affinity: DashMap::new(),
+            affinity_at_capacity: AtomicBool::new(false),
             sticky_sessions: DashMap::new(),
         }
     }
@@ -666,10 +719,70 @@ impl AgentPool {
     /// Clear connection affinity for a correlation ID.
     ///
     /// Call this when a request is complete (after receiving final response)
-    /// to free the affinity mapping. Not strictly necessary (affinities are
-    /// cheap), but good practice for long-running proxies.
+    /// to free the affinity mapping. Entries that are never cleared are
+    /// reclaimed by the maintenance task after `correlation_affinity_ttl`.
     pub fn clear_correlation_affinity(&self, correlation_id: &str) {
-        self.correlation_affinity.remove(correlation_id);
+        if self.correlation_affinity.remove(correlation_id).is_some() {
+            self.protocol_metrics
+                .set_correlation_affinities(self.correlation_affinity.len() as u64);
+        }
+    }
+
+    /// Store connection affinity for a correlation ID, enforcing the
+    /// `max_correlation_affinities` bound.
+    ///
+    /// When the map is at capacity the affinity is dropped (body chunks fall
+    /// back to normal connection selection) and the rejection is counted.
+    fn store_correlation_affinity(&self, correlation_id: &str, conn: &Arc<PooledConnection>) {
+        let at_capacity = self.correlation_affinity.len() >= self.config.max_correlation_affinities
+            && !self.correlation_affinity.contains_key(correlation_id);
+
+        if at_capacity {
+            self.protocol_metrics.inc_affinity_rejections();
+            if !self.affinity_at_capacity.swap(true, Ordering::Relaxed) {
+                warn!(
+                    max = self.config.max_correlation_affinities,
+                    "Correlation affinity map at capacity; new requests fall back to \
+                     normal connection selection for body chunks (counted in \
+                     zentinel_agent_affinity_rejections_total)"
+                );
+            }
+            return;
+        }
+        self.affinity_at_capacity.store(false, Ordering::Relaxed);
+
+        self.correlation_affinity.insert(
+            correlation_id.to_string(),
+            AffinityEntry::new(Arc::clone(conn)),
+        );
+        self.protocol_metrics
+            .set_correlation_affinities(self.correlation_affinity.len() as u64);
+    }
+
+    /// Remove correlation affinities idle longer than `correlation_affinity_ttl`.
+    ///
+    /// Returns the number of entries removed. Called by the maintenance task;
+    /// removals indicate requests that ended without explicit cleanup.
+    pub fn cleanup_expired_affinities(&self) -> usize {
+        let ttl = self.config.correlation_affinity_ttl;
+        let before = self.correlation_affinity.len();
+        self.correlation_affinity
+            .retain(|_, entry| !entry.is_expired(ttl));
+        let removed = before - self.correlation_affinity.len();
+
+        if removed > 0 {
+            debug!(
+                removed = removed,
+                remaining = self.correlation_affinity.len(),
+                ttl_secs = ttl.as_secs(),
+                "Reclaimed expired correlation affinities"
+            );
+            self.protocol_metrics.inc_affinity_evictions(removed as u64);
+            self.protocol_metrics
+                .set_correlation_affinities(self.correlation_affinity.len() as u64);
+        }
+
+        removed
     }
 
     /// Get the number of active correlation affinities.
@@ -845,8 +958,7 @@ impl AgentPool {
         conn.touch();
 
         // Store correlation affinity
-        self.correlation_affinity
-            .insert(correlation_id.to_string(), Arc::clone(&conn));
+        self.store_correlation_affinity(correlation_id, &conn);
 
         let result = conn
             .client
@@ -1222,8 +1334,7 @@ impl AgentPool {
         conn.touch(); // Atomic, no lock
 
         // Store connection affinity for body chunk routing
-        self.correlation_affinity
-            .insert(correlation_id.to_string(), Arc::clone(&conn));
+        self.store_correlation_affinity(correlation_id, &conn);
 
         let result = conn
             .client
@@ -1283,8 +1394,9 @@ impl AgentPool {
         self.total_requests.fetch_add(1, Ordering::Relaxed);
 
         // Try to use affinity (same connection as headers), fall back to selection
-        let conn = if let Some(affinity_conn) = self.correlation_affinity.get(correlation_id) {
-            Arc::clone(&affinity_conn)
+        let conn = if let Some(entry) = self.correlation_affinity.get(correlation_id) {
+            entry.touch();
+            Arc::clone(&entry.connection)
         } else {
             // No affinity found, use normal selection (shouldn't happen in normal flow)
             trace!(correlation_id = %correlation_id, "No affinity found for body chunk, using selection");
@@ -1677,8 +1789,9 @@ impl AgentPool {
         loop {
             interval.tick().await;
 
-            // Clean up expired sticky sessions
+            // Clean up expired sticky sessions and correlation affinities
             self.cleanup_expired_sessions();
+            self.cleanup_expired_affinities();
 
             // Iterate without holding a long-lived lock
             let agent_ids: Vec<String> = self.agents.iter().map(|e| e.key().clone()).collect();
@@ -1991,6 +2104,103 @@ mod tests {
         assert!(!is_uds_endpoint("http://localhost:8080"));
         assert!(!is_uds_endpoint("localhost:50051"));
         assert!(!is_uds_endpoint("127.0.0.1:8080"));
+    }
+
+    async fn test_conn() -> Arc<PooledConnection> {
+        // AgentClientV2Uds::new performs no I/O, so the socket need not exist
+        let client = AgentClientV2Uds::new(
+            "test-agent",
+            "/tmp/zentinel-test-nonexistent.sock",
+            Duration::from_secs(1),
+        )
+        .await
+        .expect("client created");
+        Arc::new(PooledConnection::new(V2Transport::Uds(client), 4))
+    }
+
+    #[tokio::test]
+    async fn affinity_map_enforces_capacity_bound() {
+        let config = AgentPoolConfig {
+            max_correlation_affinities: 3,
+            ..Default::default()
+        };
+        let pool = AgentPool::with_config(config);
+        let conn = test_conn().await;
+
+        for i in 0..10 {
+            pool.store_correlation_affinity(&format!("corr-{i}"), &conn);
+        }
+
+        assert_eq!(pool.correlation_affinity_count(), 3);
+        assert_eq!(
+            pool.protocol_metrics()
+                .affinity_rejections_total
+                .load(Ordering::Relaxed),
+            7
+        );
+    }
+
+    #[tokio::test]
+    async fn affinity_reinsert_for_existing_key_allowed_at_capacity() {
+        let config = AgentPoolConfig {
+            max_correlation_affinities: 1,
+            ..Default::default()
+        };
+        let pool = AgentPool::with_config(config);
+        let conn = test_conn().await;
+
+        pool.store_correlation_affinity("corr-a", &conn);
+        // Same key again: not a rejection, map stays at 1
+        pool.store_correlation_affinity("corr-a", &conn);
+
+        assert_eq!(pool.correlation_affinity_count(), 1);
+        assert_eq!(
+            pool.protocol_metrics()
+                .affinity_rejections_total
+                .load(Ordering::Relaxed),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn affinity_cleared_on_request_end() {
+        let pool = AgentPool::new();
+        let conn = test_conn().await;
+
+        pool.store_correlation_affinity("corr-1", &conn);
+        assert_eq!(pool.correlation_affinity_count(), 1);
+
+        pool.clear_correlation_affinity("corr-1");
+        assert_eq!(pool.correlation_affinity_count(), 0);
+        assert_eq!(
+            pool.protocol_metrics()
+                .correlation_affinities
+                .load(Ordering::Relaxed),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn expired_affinities_are_reclaimed() {
+        let config = AgentPoolConfig {
+            correlation_affinity_ttl: Duration::ZERO,
+            ..Default::default()
+        };
+        let pool = AgentPool::with_config(config);
+        let conn = test_conn().await;
+
+        pool.store_correlation_affinity("corr-1", &conn);
+        pool.store_correlation_affinity("corr-2", &conn);
+
+        let removed = pool.cleanup_expired_affinities();
+        assert_eq!(removed, 2);
+        assert_eq!(pool.correlation_affinity_count(), 0);
+        assert_eq!(
+            pool.protocol_metrics()
+                .affinity_evictions_total
+                .load(Ordering::Relaxed),
+            2
+        );
     }
 
     #[test]

--- a/crates/agent-protocol/src/v2/protocol_metrics.rs
+++ b/crates/agent-protocol/src/v2/protocol_metrics.rs
@@ -31,10 +31,17 @@ pub struct ProtocolMetrics {
     pub flow_control_resumes_total: AtomicU64,
     /// Requests rejected due to flow control
     pub flow_control_rejections_total: AtomicU64,
+    /// Correlation affinities reclaimed by TTL sweep (requests that ended
+    /// without explicit cleanup)
+    pub affinity_evictions_total: AtomicU64,
+    /// Affinities dropped because the affinity map was at capacity
+    pub affinity_rejections_total: AtomicU64,
 
     // Gauges
     /// Current in-flight requests
     pub in_flight_requests: AtomicU64,
+    /// Current correlation affinity entries
+    pub correlation_affinities: AtomicU64,
     /// Current buffer utilization (0-100)
     pub buffer_utilization_percent: AtomicU64,
     /// Number of healthy connections
@@ -107,6 +114,26 @@ impl ProtocolMetrics {
             .fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Increment affinity TTL evictions.
+    #[inline]
+    pub fn inc_affinity_evictions(&self, count: u64) {
+        self.affinity_evictions_total
+            .fetch_add(count, Ordering::Relaxed);
+    }
+
+    /// Increment affinity at-capacity rejections.
+    #[inline]
+    pub fn inc_affinity_rejections(&self) {
+        self.affinity_rejections_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Set correlation affinities gauge.
+    #[inline]
+    pub fn set_correlation_affinities(&self, count: u64) {
+        self.correlation_affinities.store(count, Ordering::Relaxed);
+    }
+
     /// Set in-flight requests gauge.
     #[inline]
     pub fn set_in_flight(&self, count: u64) {
@@ -169,7 +196,10 @@ impl ProtocolMetrics {
             flow_control_rejections_total: self
                 .flow_control_rejections_total
                 .load(Ordering::Relaxed),
+            affinity_evictions_total: self.affinity_evictions_total.load(Ordering::Relaxed),
+            affinity_rejections_total: self.affinity_rejections_total.load(Ordering::Relaxed),
             in_flight_requests: self.in_flight_requests.load(Ordering::Relaxed),
+            correlation_affinities: self.correlation_affinities.load(Ordering::Relaxed),
             buffer_utilization_percent: self.buffer_utilization_percent.load(Ordering::Relaxed),
             healthy_connections: self.healthy_connections.load(Ordering::Relaxed),
             paused_connections: self.paused_connections.load(Ordering::Relaxed),
@@ -226,12 +256,33 @@ impl ProtocolMetrics {
             snap.flow_control_rejections_total
         ));
 
+        output.push_str(&format!(
+            "# HELP {prefix}_affinity_evictions_total Correlation affinities reclaimed by TTL sweep\n\
+             # TYPE {prefix}_affinity_evictions_total counter\n\
+             {prefix}_affinity_evictions_total {}\n\n",
+            snap.affinity_evictions_total
+        ));
+
+        output.push_str(&format!(
+            "# HELP {prefix}_affinity_rejections_total Affinities dropped because the map was at capacity\n\
+             # TYPE {prefix}_affinity_rejections_total counter\n\
+             {prefix}_affinity_rejections_total {}\n\n",
+            snap.affinity_rejections_total
+        ));
+
         // Gauges
         output.push_str(&format!(
             "# HELP {prefix}_in_flight_requests Current in-flight requests\n\
              # TYPE {prefix}_in_flight_requests gauge\n\
              {prefix}_in_flight_requests {}\n\n",
             snap.in_flight_requests
+        ));
+
+        output.push_str(&format!(
+            "# HELP {prefix}_correlation_affinities Current correlation affinity entries\n\
+             # TYPE {prefix}_correlation_affinities gauge\n\
+             {prefix}_correlation_affinities {}\n\n",
+            snap.correlation_affinities
         ));
 
         output.push_str(&format!(
@@ -431,9 +482,12 @@ pub struct ProtocolMetricsSnapshot {
     pub flow_control_pauses_total: u64,
     pub flow_control_resumes_total: u64,
     pub flow_control_rejections_total: u64,
+    pub affinity_evictions_total: u64,
+    pub affinity_rejections_total: u64,
 
     // Gauges
     pub in_flight_requests: u64,
+    pub correlation_affinities: u64,
     pub buffer_utilization_percent: u64,
     pub healthy_connections: u64,
     pub paused_connections: u64,

--- a/crates/agent-protocol/src/v2/reverse.rs
+++ b/crates/agent-protocol/src/v2/reverse.rs
@@ -549,13 +549,8 @@ impl ReverseConnectionClient {
         correlation_id: &str,
         event: &T,
     ) -> Result<AgentResponse, AgentProtocolError> {
-        let (tx, rx) = oneshot::channel();
-        self.pending
-            .lock()
-            .await
-            .insert(correlation_id.to_string(), tx);
-
-        // Serialize event with correlation ID
+        // Serialize event with correlation ID (before registering the pending
+        // entry, so serialization failures cannot leak it)
         let mut payload = serde_json::to_value(event)
             .map_err(|e| AgentProtocolError::Serialization(e.to_string()))?;
 
@@ -569,37 +564,49 @@ impl ReverseConnectionClient {
         let payload_bytes = serde_json::to_vec(&payload)
             .map_err(|e| AgentProtocolError::Serialization(e.to_string()))?;
 
-        // Send message
+        let (tx, rx) = oneshot::channel();
+        self.pending
+            .lock()
+            .await
+            .insert(correlation_id.to_string(), tx);
+
+        // Send message; on failure remove the pending entry we just registered
         {
             let outbound = self.outbound_tx.lock().await;
-            if let Some(tx) = outbound.as_ref() {
-                tx.send((msg_type, payload_bytes))
+            let send_result = match outbound.as_ref() {
+                Some(tx) => tx
+                    .send((msg_type, payload_bytes))
                     .await
-                    .map_err(|_| AgentProtocolError::ConnectionClosed)?;
-            } else {
-                return Err(AgentProtocolError::ConnectionClosed);
+                    .map_err(|_| AgentProtocolError::ConnectionClosed),
+                None => Err(AgentProtocolError::ConnectionClosed),
+            };
+            drop(outbound);
+            if let Err(e) = send_result {
+                self.pending.lock().await.remove(correlation_id);
+                return Err(e);
             }
         }
 
         self.in_flight
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-        // Wait for response with timeout
-        let response = tokio::time::timeout(self.timeout, rx)
-            .await
-            .map_err(|_| {
-                self.pending
-                    .try_lock()
-                    .ok()
-                    .map(|mut p| p.remove(correlation_id));
-                AgentProtocolError::Timeout(self.timeout)
-            })?
-            .map_err(|_| AgentProtocolError::ConnectionClosed)?;
+        // Wait for response with timeout. Every exit path below must remove
+        // the pending entry and decrement in_flight, or the map leaks and the
+        // gauge drifts.
+        let result = match tokio::time::timeout(self.timeout, rx).await {
+            Ok(Ok(response)) => Ok(response),
+            Ok(Err(_)) => Err(AgentProtocolError::ConnectionClosed),
+            Err(_) => Err(AgentProtocolError::Timeout(self.timeout)),
+        };
 
         self.in_flight
             .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
 
-        Ok(response)
+        if result.is_err() {
+            self.pending.lock().await.remove(correlation_id);
+        }
+
+        result
     }
 
     /// Cancel a specific request.

--- a/crates/config/docs/schema.md
+++ b/crates/config/docs/schema.md
@@ -35,6 +35,12 @@ Global server configuration.
 | `working-directory` | `string` | - | Working directory |
 | `trace-id-format` | `string` | `"tinyflake"` | Trace ID format (`tinyflake` or `uuid`) |
 | `auto-reload` | `bool` | `false` | Auto-reload config on file changes |
+| `route-cache-size` | `u32` | `1000` | Max entries in the route-match cache (per route set); must be > 0. Evictions counted in `zentinel_route_cache_evictions_total` |
+
+> **Hot reload caveat:** routes, upstreams, filters, and agents are applied by
+> hot reload (SIGHUP / auto-reload). Listener bindings and `system` settings
+> are **not** — the proxy logs a warning if they changed and keeps the running
+> values until restart.
 
 ---
 

--- a/crates/config/src/defaults.rs
+++ b/crates/config/src/defaults.rs
@@ -170,6 +170,7 @@ pub fn create_default_config() -> Config {
             working_directory: None,
             trace_id_format: Default::default(),
             auto_reload: false,
+            route_cache_size: 1000,
         },
         listeners: vec![
             ListenerConfig {

--- a/crates/config/src/kdl/server.rs
+++ b/crates/config/src/kdl/server.rs
@@ -41,6 +41,9 @@ pub fn parse_server_config(node: &kdl::KdlNode) -> Result<ServerConfig> {
         working_directory: get_string_entry(node, "working-directory").map(PathBuf::from),
         trace_id_format,
         auto_reload: get_bool_entry(node, "auto-reload").unwrap_or(false),
+        route_cache_size: get_int_entry(node, "route-cache-size")
+            .map(|v| v as usize)
+            .unwrap_or_else(crate::server::default_route_cache_size),
     };
 
     trace!(

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -819,6 +819,7 @@ impl Config {
                 working_directory: None,
                 trace_id_format: Default::default(),
                 auto_reload: false,
+                route_cache_size: 1000,
             },
             listeners: vec![ListenerConfig {
                 id: "http".to_string(),

--- a/crates/config/src/multi_file/parsers.rs
+++ b/crates/config/src/multi_file/parsers.rs
@@ -113,6 +113,9 @@ pub(super) fn parse_server(node: &KdlNode) -> Result<ServerConfig> {
             .map(|s| TraceIdFormat::from_str_loose(&s))
             .unwrap_or_default(),
         auto_reload: get_bool_entry(node, "auto-reload").unwrap_or(false),
+        route_cache_size: get_int_entry(node, "route-cache-size")
+            .map(|v| v as usize)
+            .unwrap_or_else(crate::server::default_route_cache_size),
     })
 }
 

--- a/crates/config/src/server.rs
+++ b/crates/config/src/server.rs
@@ -57,6 +57,13 @@ pub struct ServerConfig {
     /// and automatically reload when modifications are detected.
     #[serde(default)]
     pub auto_reload: bool,
+
+    /// Maximum entries in the route-match cache (per route set).
+    ///
+    /// When full, ~10% of entries are evicted (counted in
+    /// `zentinel_route_cache_evictions_total`). Default: 1000.
+    #[serde(default = "default_route_cache_size")]
+    pub route_cache_size: usize,
 }
 
 // ============================================================================
@@ -425,6 +432,10 @@ pub(crate) fn default_worker_threads() -> usize {
 
 pub(crate) fn default_max_connections() -> usize {
     10000
+}
+
+pub(crate) fn default_route_cache_size() -> usize {
+    1000
 }
 
 pub(crate) fn default_graceful_shutdown_timeout() -> u64 {

--- a/crates/config/src/validation.rs
+++ b/crates/config/src/validation.rs
@@ -375,6 +375,15 @@ pub fn validate_config_semantics(config: &Config) -> Result<(), validator::Valid
         "Collected IDs for cross-reference validation"
     );
 
+    // Validate server-wide settings
+    if config.server.route_cache_size == 0 {
+        errors.push(
+            "server.route-cache-size must be greater than 0 (the route cache cannot be disabled \
+             by setting it to zero)"
+                .to_string(),
+        );
+    }
+
     // Validate routes
     trace!("Validating routes");
     validate_routes(config, &route_ids, &upstream_ids, &filter_ids, &mut errors);
@@ -1902,6 +1911,7 @@ mod tests {
             working_directory: None,
             trace_id_format: Default::default(),
             auto_reload: false,
+            route_cache_size: 1000,
         };
 
         // --- ListenerConfig ---

--- a/crates/gateway/src/config_writer.rs
+++ b/crates/gateway/src/config_writer.rs
@@ -570,6 +570,7 @@ mod tests {
                 working_directory: None,
                 trace_id_format: Default::default(),
                 auto_reload: true,
+                route_cache_size: 1000,
             },
             listeners: vec![ListenerConfig {
                 id: "http".to_string(),

--- a/crates/gateway/src/translator.rs
+++ b/crates/gateway/src/translator.rs
@@ -295,6 +295,7 @@ impl ConfigTranslator {
                 working_directory: None,
                 trace_id_format: Default::default(),
                 auto_reload: true,
+                route_cache_size: 1000,
             },
             listeners,
             routes,

--- a/crates/proxy/src/agents/agent_v2.rs
+++ b/crates/proxy/src/agents/agent_v2.rs
@@ -44,6 +44,9 @@ pub struct AgentV2 {
     last_success_ns: AtomicU64,
     /// Consecutive failures
     consecutive_failures: AtomicU32,
+    /// Background pool maintenance task (health checks, reconnection,
+    /// affinity/session cleanup). Spawned by `initialize`, aborted by `shutdown`.
+    maintenance_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 impl AgentV2 {
@@ -85,6 +88,7 @@ impl AgentV2 {
             base_instant: Instant::now(),
             last_success_ns: AtomicU64::new(NO_TIMESTAMP),
             consecutive_failures: AtomicU32::new(0),
+            maintenance_handle: std::sync::Mutex::new(None),
         }
     }
 
@@ -179,12 +183,33 @@ impl AgentV2 {
             "V2 agent pool initialized"
         );
 
+        // Spawn pool maintenance: periodic health checks (with recovery of
+        // connections marked unhealthy), reconnection of failed connections,
+        // and cleanup of expired sticky sessions / correlation affinities.
+        // Without this, a crashed-and-restarted agent would stay unreachable.
+        {
+            let pool = Arc::clone(&self.pool);
+            let handle = tokio::spawn(async move { pool.run_maintenance().await });
+            let mut guard = self
+                .maintenance_handle
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some(old) = guard.replace(handle) {
+                old.abort();
+            }
+        }
+
         // Send configuration if present
         if let Some(config_value) = &self.config.config {
             self.send_configure(config_value.clone()).await?;
         }
 
         Ok(())
+    }
+
+    /// Clear the connection affinity for a completed request.
+    pub fn clear_correlation_affinity(&self, correlation_id: &str) {
+        self.pool.clear_correlation_affinity(correlation_id);
     }
 
     /// Get endpoint from transport config.
@@ -674,6 +699,16 @@ impl AgentV2 {
             agent_id = %self.config.id,
             "Shutting down v2 agent"
         );
+
+        // Stop background pool maintenance
+        if let Some(handle) = self
+            .maintenance_handle
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+        {
+            handle.abort();
+        }
 
         // Remove from pool - this gracefully closes connections
         if let Err(e) = self.pool.remove_agent(&self.config.id).await {

--- a/crates/proxy/src/agents/manager.rs
+++ b/crates/proxy/src/agents/manager.rs
@@ -1228,6 +1228,18 @@ impl AgentManager {
         info!("Agent manager shutdown complete");
     }
 
+    /// Release per-request agent state after a request completes.
+    ///
+    /// Clears the correlation affinity (headers → body chunk connection
+    /// pinning) on every agent pool. Affinities that are never released here
+    /// are reclaimed by the pool maintenance TTL sweep.
+    pub async fn end_request(&self, correlation_id: &str) {
+        let agents = self.agents.read().await;
+        for agent in agents.values() {
+            agent.clear_correlation_affinity(correlation_id);
+        }
+    }
+
     /// Get agent metrics.
     pub fn metrics(&self) -> &AgentMetrics {
         &self.metrics

--- a/crates/proxy/src/disk_cache.rs
+++ b/crates/proxy/src/disk_cache.rs
@@ -28,11 +28,11 @@ use pingora_cache::storage::{
 use pingora_cache::trace::SpanHandle;
 use pingora_core::{Error, ErrorType, Result};
 use std::any::Any;
-use std::collections::{HashMap, HashSet};
+use dashmap::DashMap;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
 
 // ============================================================================
@@ -48,8 +48,10 @@ pub struct DiskCacheStorage {
     num_shards: u32,
     #[allow(dead_code)]
     max_size_bytes: usize,
-    /// Tracks in-flight writes: combined_hash -> set of temp_ids
-    inflight: Arc<RwLock<HashMap<String, HashSet<u64>>>>,
+    /// Tracks in-flight writes: combined_hash -> set of temp_ids.
+    /// Lock-free so `DiskMissHandler::drop` can always clean up its entry
+    /// (an async lock's `try_write` could silently leak under contention).
+    inflight: Arc<DashMap<String, HashSet<u64>>>,
     next_temp_id: AtomicU64,
 }
 
@@ -60,6 +62,23 @@ impl DiskCacheStorage {
     /// files left behind by interrupted writes.
     pub fn new(path: &Path, shards: u32, max_size: usize) -> Self {
         let base = path.to_path_buf();
+
+        // Probe writability once up front so a misconfigured cache directory
+        // produces a single actionable error instead of one per subdirectory
+        // (and later, one per failed cache write).
+        if let Err(e) = std::fs::create_dir_all(&base).and_then(|()| {
+            let probe = base.join(".zentinel-write-probe");
+            std::fs::write(&probe, b"probe")?;
+            std::fs::remove_file(&probe)
+        }) {
+            error!(
+                path = %base.display(),
+                error = %e,
+                "Disk cache directory is not writable; cache writes WILL fail \
+                 (requests still proxied, uncached). Fix permissions or change \
+                 cache disk-path."
+            );
+        }
 
         // Create shard dirs, hex-prefix subdirs, and tmp dirs
         for shard in 0..shards {
@@ -93,7 +112,7 @@ impl DiskCacheStorage {
             base_path: base,
             num_shards: shards,
             max_size_bytes: max_size,
-            inflight: Arc::new(RwLock::new(HashMap::new())),
+            inflight: Arc::new(DashMap::new()),
             next_temp_id: AtomicU64::new(1),
         }
     }
@@ -281,8 +300,22 @@ pub struct DiskMissHandler {
     body_path: PathBuf,
     tmp_dir: PathBuf,
     temp_id: u64,
-    inflight: Arc<RwLock<HashMap<String, HashSet<u64>>>>,
+    inflight: Arc<DashMap<String, HashSet<u64>>>,
     finished: bool,
+}
+
+impl DiskMissHandler {
+    /// Remove this handler's temp_id from inflight tracking.
+    fn release_inflight(&self) {
+        if let Some(mut set) = self.inflight.get_mut(&self.combined) {
+            set.remove(&self.temp_id);
+            if set.is_empty() {
+                drop(set);
+                self.inflight
+                    .remove_if(&self.combined, |_, s| s.is_empty());
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -362,15 +395,7 @@ impl HandleMiss for DiskMissHandler {
         })??;
 
         // Remove from inflight tracking
-        {
-            let mut inflight = self.inflight.write().await;
-            if let Some(set) = inflight.get_mut(&self.combined) {
-                set.remove(&self.temp_id);
-                if set.is_empty() {
-                    inflight.remove(&self.combined);
-                }
-            }
-        }
+        self.release_inflight();
 
         debug!(combined = %self.combined, size, "Disk cache entry written");
         Ok(MissFinishType::Created(size))
@@ -380,16 +405,10 @@ impl HandleMiss for DiskMissHandler {
 impl Drop for DiskMissHandler {
     fn drop(&mut self) {
         if !self.finished {
-            // Clean up inflight tracking if finish() was never called.
-            // We can't do async in Drop, so use try_write.
-            if let Ok(mut inflight) = self.inflight.try_write() {
-                if let Some(set) = inflight.get_mut(&self.combined) {
-                    set.remove(&self.temp_id);
-                    if set.is_empty() {
-                        inflight.remove(&self.combined);
-                    }
-                }
-            }
+            // Clean up inflight tracking if finish() was never called
+            // (aborted/cancelled write). DashMap removal is lock-free, so
+            // unlike an async lock this can never silently skip cleanup.
+            self.release_inflight();
         }
     }
 }
@@ -475,13 +494,10 @@ impl Storage for DiskCacheStorage {
         let temp_id = self.next_temp_id.fetch_add(1, Ordering::Relaxed);
 
         // Register in inflight tracking
-        {
-            let mut inflight = self.inflight.write().await;
-            inflight
-                .entry(combined.clone())
-                .or_default()
-                .insert(temp_id);
-        }
+        self.inflight
+            .entry(combined.clone())
+            .or_default()
+            .insert(temp_id);
 
         Ok(Box::new(DiskMissHandler {
             body_buffer: Vec::new(),
@@ -520,10 +536,7 @@ impl Storage for DiskCacheStorage {
         })?;
 
         // Also remove from inflight tracking
-        {
-            let mut inflight = self.inflight.write().await;
-            inflight.remove(&combined);
-        }
+        self.inflight.remove(&combined);
 
         Ok(removed)
     }
@@ -909,7 +922,7 @@ mod tests {
         assert!(STORAGE.lookup(&key, trace).await.unwrap().is_none());
 
         // Verify inflight tracking was cleaned up
-        assert!(STORAGE.inflight.read().await.is_empty());
+        assert!(STORAGE.inflight.is_empty());
 
         // Cleanup
         let _ = std::fs::remove_dir_all(

--- a/crates/proxy/src/disk_cache.rs
+++ b/crates/proxy/src/disk_cache.rs
@@ -19,6 +19,7 @@
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use dashmap::DashMap;
 use pingora_cache::eviction::EvictionManager;
 use pingora_cache::key::{CacheHashKey, CacheKey, CompactCacheKey};
 use pingora_cache::meta::CacheMeta;
@@ -28,7 +29,6 @@ use pingora_cache::storage::{
 use pingora_cache::trace::SpanHandle;
 use pingora_core::{Error, ErrorType, Result};
 use std::any::Any;
-use dashmap::DashMap;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -311,8 +311,7 @@ impl DiskMissHandler {
             set.remove(&self.temp_id);
             if set.is_empty() {
                 drop(set);
-                self.inflight
-                    .remove_if(&self.combined, |_, s| s.is_empty());
+                self.inflight.remove_if(&self.combined, |_, s| s.is_empty());
             }
         }
     }

--- a/crates/proxy/src/health.rs
+++ b/crates/proxy/src/health.rs
@@ -317,6 +317,7 @@ impl ActiveHealthChecker {
     /// Spawn health check task for a target
     fn spawn_check_task(&self, target: String) -> tokio::task::JoinHandle<()> {
         let interval = Duration::from_secs(self.config.interval_secs);
+        let check_timeout = Duration::from_secs(self.config.timeout_secs);
         let checker = Arc::clone(&self.checker);
         let health_status = Arc::clone(&self.health_status);
         let healthy_threshold = self.config.healthy_threshold;
@@ -345,7 +346,17 @@ impl ActiveHealthChecker {
                             "Performing health check"
                         );
                         let start = Instant::now();
-                        let result = checker.check(&target).await;
+                        // Outer timeout bounds the WHOLE check (connect + write
+                        // + read). Checker impls bound the connect themselves,
+                        // but a backend that accepts then hangs would otherwise
+                        // stall this target's check loop forever.
+                        let result = match time::timeout(check_timeout, checker.check(&target)).await {
+                            Ok(r) => r,
+                            Err(_) => Err(format!(
+                                "Health check timed out after {:?} (timeout-secs)",
+                                check_timeout
+                            )),
+                        };
                         let check_duration = start.elapsed();
 
                         // Update health status

--- a/crates/proxy/src/proxy/http_trait.rs
+++ b/crates/proxy/src/proxy/http_trait.rs
@@ -3346,6 +3346,15 @@ impl ProxyHttp for ZentinelProxy {
         // Decrement active requests
         self.reload_coordinator.dec_requests();
 
+        // Release per-request agent state (correlation affinity) now that the
+        // request is complete; the pool TTL sweep is only the backstop.
+        if !ctx.route_agent_ids.is_empty()
+            || !ctx.body_inspection_agents.is_empty()
+            || !ctx.websocket_inspection_agents.is_empty()
+        {
+            self.agent_manager.end_request(&ctx.trace_id).await;
+        }
+
         // === Fire pending shadow request (if body buffering was enabled) ===
         if !ctx.shadow_sent {
             if let Some(shadow_pending) = ctx.shadow_pending.take() {

--- a/crates/proxy/src/proxy/mod.rs
+++ b/crates/proxy/src/proxy/mod.rs
@@ -172,7 +172,11 @@ impl ZentinelProxy {
             .await;
 
         // Create route matcher (global routes only)
-        let route_matcher = Arc::new(RwLock::new(RouteMatcher::new(config.routes.clone(), None)?));
+        let route_matcher = Arc::new(RwLock::new(RouteMatcher::with_cache_size(
+            config.routes.clone(),
+            None,
+            config.server.route_cache_size,
+        )?));
 
         // Build per-listener route matchers for listeners bound to a namespace
         // route set (empty unless any listener references a namespace).
@@ -410,7 +414,11 @@ impl ZentinelProxy {
                 );
                 continue;
             };
-            match RouteMatcher::new(ns.routes.clone(), None) {
+            match RouteMatcher::with_cache_size(
+                ns.routes.clone(),
+                None,
+                config.server.route_cache_size,
+            ) {
                 Ok(matcher) => {
                     info!(
                         listener_id = %listener.id,

--- a/crates/proxy/src/reload/mod.rs
+++ b/crates/proxy/src/reload/mod.rs
@@ -451,6 +451,28 @@ impl ConfigManager {
             "Preparing configuration swap"
         );
 
+        // Listeners are bound at startup and are NOT hot-reloadable. Say so
+        // loudly instead of silently ignoring the change.
+        let old_listeners = serde_json::to_value(&old_config.listeners).ok();
+        let new_listeners = serde_json::to_value(&new_config.listeners).ok();
+        if old_listeners != new_listeners {
+            warn!(
+                "Listener configuration changed in the new config, but listeners \
+                 (addresses, ports, TLS bindings) are NOT applied by hot reload. \
+                 The proxy continues serving on the previously bound listeners; \
+                 restart zentinel to apply listener changes."
+            );
+        }
+        if serde_json::to_value(&old_config.server).ok()
+            != serde_json::to_value(&new_config.server).ok()
+        {
+            warn!(
+                "system/server configuration changed in the new config, but \
+                 worker threads and process-level settings are NOT applied by \
+                 hot reload; restart zentinel to apply them."
+            );
+        }
+
         // Run pre-reload hooks
         let hooks = self.reload_hooks.read().await;
         for hook in hooks.iter() {

--- a/crates/proxy/src/routing.rs
+++ b/crates/proxy/src/routing.rs
@@ -5,11 +5,21 @@
 //! with support for priority-based evaluation.
 
 use dashmap::DashMap;
+use prometheus::{register_int_counter, IntCounter};
 use regex::Regex;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use tracing::{debug, info, trace, warn};
+
+/// Entries evicted from the route-match cache to enforce `route-cache-size`.
+static ROUTE_CACHE_EVICTIONS: LazyLock<Option<IntCounter>> = LazyLock::new(|| {
+    register_int_counter!(
+        "zentinel_route_cache_evictions_total",
+        "Route-match cache entries evicted to enforce route-cache-size"
+    )
+    .ok()
+});
 
 use zentinel_common::types::Priority;
 use zentinel_common::RouteId;
@@ -84,10 +94,21 @@ struct RouteCache {
 }
 
 impl RouteMatcher {
-    /// Create a new route matcher from configuration
+    /// Create a new route matcher from configuration with the default
+    /// route-cache size (1000 entries).
     pub fn new(
         routes: Vec<RouteConfig>,
         default_route: Option<String>,
+    ) -> Result<Self, RouteError> {
+        Self::with_cache_size(routes, default_route, 1000)
+    }
+
+    /// Create a new route matcher with an explicit route-cache size
+    /// (`system { route-cache-size N }`).
+    pub fn with_cache_size(
+        routes: Vec<RouteConfig>,
+        default_route: Option<String>,
+        cache_size: usize,
     ) -> Result<Self, RouteError> {
         info!(
             route_count = routes.len(),
@@ -146,7 +167,7 @@ impl RouteMatcher {
         Ok(Self {
             routes: compiled_routes,
             default_route: default_route.map(RouteId::new),
-            cache: Arc::new(RouteCache::new(1000)),
+            cache: Arc::new(RouteCache::new(cache_size)),
             needs_headers,
             needs_query_params,
         })
@@ -557,7 +578,7 @@ impl RouteCache {
 
     /// Evict random entries when cache is full
     fn evict_random(&self) {
-        let to_evict = self.max_size / 10; // Evict ~10%
+        let to_evict = (self.max_size / 10).max(1); // Evict ~10%
         let mut evicted = 0;
 
         // Iterate and remove some entries
@@ -573,6 +594,16 @@ impl RouteCache {
         // Update count (approximate)
         self.entry_count
             .store(self.entries.len(), Ordering::Relaxed);
+
+        debug!(
+            evicted = evicted,
+            remaining = self.entries.len(),
+            max_size = self.max_size,
+            "Route cache at capacity; evicted entries"
+        );
+        if let Some(counter) = ROUTE_CACHE_EVICTIONS.as_ref() {
+            counter.inc_by(evicted as u64);
+        }
     }
 
     /// Get current cache size

--- a/crates/proxy/src/routing.rs
+++ b/crates/proxy/src/routing.rs
@@ -806,6 +806,19 @@ mod tests {
     use zentinel_common::types::Priority;
     use zentinel_config::{MatchCondition, RouteConfig};
 
+    #[test]
+    fn route_cache_never_exceeds_max_size() {
+        let cache = RouteCache::new(10);
+        for i in 0..100 {
+            cache.insert(format!("key-{i}"), RouteId::new(format!("route-{i}")));
+            assert!(
+                cache.len() <= 10,
+                "route cache grew past max_size: {}",
+                cache.len()
+            );
+        }
+    }
+
     fn create_test_route(id: &str, matches: Vec<MatchCondition>) -> RouteConfig {
         RouteConfig {
             id: id.to_string(),

--- a/crates/proxy/src/scoped_circuit_breaker.rs
+++ b/crates/proxy/src/scoped_circuit_breaker.rs
@@ -18,7 +18,7 @@
 
 use dashmap::DashMap;
 use std::sync::Arc;
-use tracing::{debug, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 use zentinel_common::ids::Scope;
 use zentinel_common::types::{CircuitBreakerConfig, CircuitBreakerState};
@@ -150,17 +150,30 @@ impl ScopedCircuitBreakerManager {
             .map(|entry| entry.key().clone())
             .collect();
 
+        let reset_count = keys_to_reset.len();
         for key in keys_to_reset {
             if let Some(breaker) = self.breakers.get(&key) {
                 breaker.reset(); // Lock-free, no await needed
             }
         }
+        info!(
+            scope = ?scope,
+            reset = reset_count,
+            "Reset all circuit breakers in scope"
+        );
     }
 
     /// Clear all circuit breakers (for reload).
     pub fn clear(&self) {
+        let breakers = self.breakers.len();
+        let scopes = self.scope_configs.len();
         self.breakers.clear();
         self.scope_configs.clear();
+        info!(
+            breakers = breakers,
+            scope_configs = scopes,
+            "Cleared all scoped circuit breakers (config reload); failure history reset"
+        );
     }
 
     /// Get the number of circuit breakers currently tracked.

--- a/crates/proxy/src/upstream/consistent_hash.rs
+++ b/crates/proxy/src/upstream/consistent_hash.rs
@@ -12,6 +12,25 @@ use async_trait::async_trait;
 use tracing::{debug, info, trace, warn};
 use zentinel_common::errors::{ZentinelError, ZentinelResult};
 
+/// Hard bound for the lookup cache. Key hashes come from request data, so the
+/// cache must not grow with attacker-controlled cardinality. When full it is
+/// cleared (cheap: entries are rebuilt from the ring on demand).
+const LOOKUP_CACHE_MAX: usize = 10_000;
+
+/// Insert into the bounded lookup cache, clearing it first if at capacity.
+async fn bounded_cache_insert(cache: &RwLock<HashMap<u64, usize>>, key_hash: u64, idx: usize) {
+    let mut cache = cache.write().await;
+    if cache.len() >= LOOKUP_CACHE_MAX {
+        debug!(
+            size = cache.len(),
+            max = LOOKUP_CACHE_MAX,
+            "Consistent-hash lookup cache full; clearing"
+        );
+        cache.clear();
+    }
+    cache.insert(key_hash, idx);
+}
+
 /// Hash function types supported by the consistent hash balancer
 #[derive(Debug, Clone, Copy)]
 pub enum HashFunction {
@@ -92,7 +111,9 @@ pub struct ConsistentHashBalancer {
     connection_counts: Vec<Arc<AtomicU64>>,
     /// Total active connections
     total_connections: Arc<AtomicU64>,
-    /// Cache for recent hash lookups (hash -> target_index)
+    /// Cache for recent hash lookups (hash -> target_index).
+    /// Bounded at [`LOOKUP_CACHE_MAX`]: key hashes are request-derived
+    /// (client IP, headers), so unbounded growth would be attacker-steerable.
     lookup_cache: Arc<RwLock<HashMap<u64, usize>>>,
     /// Generation counter for detecting ring changes
     generation: Arc<AtomicUsize>,
@@ -302,7 +323,7 @@ impl ConsistentHashBalancer {
 
             // Update cache
             if let Some(idx) = target_index {
-                self.lookup_cache.write().await.insert(key_hash, idx);
+                bounded_cache_insert(&self.lookup_cache, key_hash, idx).await;
                 trace!(
                     hash_key = %hash_key,
                     target_index = idx,
@@ -337,10 +358,7 @@ impl ConsistentHashBalancer {
 
             if current_load <= max_load {
                 // Update cache
-                self.lookup_cache
-                    .write()
-                    .await
-                    .insert(key_hash, vnode.target_index);
+                bounded_cache_insert(&self.lookup_cache, key_hash, vnode.target_index).await;
                 debug!(
                     hash_key = %hash_key,
                     target_index = vnode.target_index,

--- a/crates/proxy/src/upstream/consistent_hash.rs
+++ b/crates/proxy/src/upstream/consistent_hash.rs
@@ -626,6 +626,15 @@ impl LoadBalancer for ConsistentHashBalancer {
 mod tests {
     use super::*;
 
+    #[tokio::test]
+    async fn lookup_cache_never_exceeds_bound() {
+        let cache = RwLock::new(HashMap::new());
+        for i in 0..(LOOKUP_CACHE_MAX as u64 + 500) {
+            bounded_cache_insert(&cache, i, 0).await;
+            assert!(cache.read().await.len() <= LOOKUP_CACHE_MAX);
+        }
+    }
+
     fn create_test_targets(count: usize) -> Vec<UpstreamTarget> {
         (0..count)
             .map(|i| UpstreamTarget {


### PR DESCRIPTION
> Stacked on #273. Base is `feature/enforce-body-limits-and-bounded-state`; retarget after #273 merges.

Assessment-driven hardening: a full audit of the codebase against the MANIFESTO promises (bounded resources, loud failure, observable decisions) found several latent production bugs.

## Summary
- **Agent pool maintenance now actually runs.** `AgentPool::run_maintenance` (health re-checks, reconnection, sticky-session cleanup) existed but was never spawned — a crashed-and-restarted agent stayed permanently unhealthy until proxy restart. Spawned per agent in `AgentV2::initialize`, aborted on shutdown.
- **Correlation affinity leak plugged.** The headers→body-chunk affinity map was inserted into on every request and `clear_correlation_affinity` had zero callers. Now bounded (`max_correlation_affinities`, default 100k, fallback to normal selection when full), idle-TTL swept (default 5 min), and released explicitly in the request logging phase. New metrics: `correlation_affinities` gauge, `affinity_evictions_total`, `affinity_rejections_total`.
- **Agent metrics collector bounded.** `max_series` was configured but never enforced and `expire_old_metrics` was never called — agent-reported series accumulated forever. New series are dropped at the limit (one-shot warn + `dropped_series` counter); expiry runs in pool maintenance.
- **Consistent-hash lookup cache bounded** (was unbounded on request-derived key hashes; `with_capacity(1000)` is only an allocation hint).
- **Health probes bounded end-to-end.** `timeout-secs` now wraps the whole check (connect + write + read); previously only the connect was bounded, so a backend that accepted then hung froze that target's check loop forever.
- Reverse-connection clients: pending-response entries no longer leak on serialization/send failure or timeout-under-contention; `in_flight` gauge no longer drifts on errors.
- Disk cache: in-flight write tracking moved to a lock-free map so handler `Drop` cleanup can never silently skip; startup probes cache-dir writability once with an actionable error.
- Hot reload warns when listener or `system` settings changed (they are not hot-reloadable and were previously ignored silently); circuit-breaker scope reset/clear now logged.
- `system { route-cache-size N }` exposes the previously hardcoded route cache size; evictions visible via `zentinel_route_cache_evictions_total`.
- `unreachable!()` in the mmap buffer replaced with an error return.
- **Docs honesty:** README no longer claims S3-FIFO/TinyLFU eviction (it is LRU) or WebSocket traffic mirroring; hot-reload feature row notes the listener caveat; workflow docs use the real `test`/`validate`/`lint` subcommands instead of nonexistent `--check`/`--dry-run` flags.

## Test plan
- [x] 8 new unit tests (affinity bound/TTL/clear, max_series enforcement + expiry, route cache bound, consistent-hash cache bound)
- [x] `cargo test --workspace --lib`, `cargo clippy --workspace --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `mise run pre-push`
- [ ] Kill-and-restart an agent under load; verify the proxy reconnects within `health_check_interval` (previously never)
- [ ] Watch `correlation_affinities` gauge stay flat under sustained traffic