### PR TITLE
chore: bump version to 0.6.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8259,7 +8259,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8299,7 +8299,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8321,7 +8321,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8400,7 +8400,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8431,7 +8431,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8522,7 +8522,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8539,7 +8539,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.16"
+version = "0.6.17"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
Post-release dev bump from `0.6.16` (released as **26.06_2**) to `0.6.17`, so `main` is no longer sitting on an already-published crate version and the next release prep starts cleanly.

The Release workflow already created this branch and pushed the bot bump commit (`chore: bump version to 0.6.17 for release 26.06_2`), but it only touched root `Cargo.toml` — `Cargo.lock` still pinned the workspace crates at `0.6.16`. This PR adds the missing `cargo update --workspace` lockfile sync on top of the bot commit so the bump is complete and `--locked` builds stay green.

Merging this gets `main` to `0.6.17`. No CHANGELOG entry — that's added when the next CalVer release is prepped.