### PR TITLE
fix(proxy): let upstream circuit breaker recover from open state (#261)

### DIFF
--- a/crates/proxy/src/upstream/mod.rs
+++ b/crates/proxy/src/upstream/mod.rs
@@ -1442,13 +1442,13 @@ impl UpstreamPool {
                     false
                 };
 
-            // Only mark the target unhealthy in the load balancer when the
-            // circuit breaker has actually opened (failure threshold reached).
-            // Individual failures are tracked by the circuit breaker; the
-            // upstream_peer selection loop already checks breaker state.
-            if breaker_opened {
-                self.load_balancer.report_health(target, false).await;
-            }
+            // Do NOT mark the target down in the load balancer when the breaker
+            // opens. The circuit breaker is the single availability gate — the
+            // upstream_peer selection loop checks `is_closed()`, which also runs
+            // the timed Open->HalfOpen transition and lets a probe through after
+            // `timeout_seconds`. Removing the target from the load balancer here
+            // would prevent it from ever being selected again, so that probe
+            // would never run and the target could not recover (#261).
 
             self.stats.failures.fetch_add(1, Ordering::Relaxed);
             warn!(
@@ -1491,23 +1491,15 @@ impl UpstreamPool {
                 .report_result_with_latency(target, true, latency)
                 .await;
         } else {
-            let breaker_opened =
-                if let Some(breaker) = self.circuit_breakers.read().await.get(target) {
-                    breaker.record_failure()
-                } else {
-                    false
-                };
-            self.stats.failures.fetch_add(1, Ordering::Relaxed);
-
-            // Only propagate failure to the load balancer when the circuit
-            // breaker has opened. This ensures adaptive LBs record the
-            // health change and individual failures don't prematurely
-            // remove targets from the healthy pool.
-            if breaker_opened {
-                self.load_balancer
-                    .report_result_with_latency(target, false, latency)
-                    .await;
+            // Record the failure in the circuit breaker (this may open it). We
+            // do NOT propagate a health-down to the load balancer on open: the
+            // selection loop's `is_closed()` check is the sole availability gate
+            // and runs the timed half-open recovery probe. Marking the target
+            // down here would remove it from selection and block recovery (#261).
+            if let Some(breaker) = self.circuit_breakers.read().await.get(target) {
+                breaker.record_failure();
             }
+            self.stats.failures.fetch_add(1, Ordering::Relaxed);
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes #261 — a tripped upstream circuit breaker never recovered, even after the backend came back healthy and `timeout-seconds` elapsed.

## Root cause
On failure, `UpstreamPool::report_result` (and `report_result_with_latency`) called `load_balancer.report_health(target, false)` once the breaker opened, removing the target from the load balancer's pool. The selection loop's `is_closed()` check (`upstream/mod.rs:1162`) is what performs the timed Open→HalfOpen transition and lets a probe through — but it only runs for a target the load balancer actually selects. With the target marked down, it was never selected, so the breaker was never probed, and the only path back to healthy (`report_health(true)` on a success) required a selection that could never happen. Deadlock.

This is the interaction flagged in #260 ("never goes half-open because the upstream is marked unhealthy").

## Fix
Stop marking the target down in the load balancer when the breaker opens. The circuit breaker is the single availability gate — the selection loop already checks it (the existing comments even said so). The half-open probe now runs after `timeout-seconds` and the breaker closes again on a successful probe.

## Verification
Reproduced the bug and confirmed the fix with a minimal config (no `health-check`, so the breaker is the only gate) and a backend that returns 503 then heals to 200:

**Before:** breaker opens, then every probe after the timeout returns 500 — no half-open transition is ever logged.

**After:**
```
Open timeout reached, transitioning to half-open
Circuit breaker half-open
Recorded success ... consecutive_successes=1 success_threshold=1
Circuit breaker closed
probe -> 200   # backend back in rotation
```

## Test plan
- [x] `cargo test -p zentinel-proxy upstream` / `-p zentinel-common circuit` — pass (no regressions)
- [x] `cargo fmt --check`, `cargo clippy -p zentinel-proxy` clean
- [x] End-to-end repro: open → half-open after timeout → closed on success
- [ ] Consider a pool-level regression test (no unit-test harness exists in `upstream/mod.rs` today; the CB timing is real-time, so this would need a clock seam — flagging as a possible follow-up)

Behavior-critical hot-path change — wanted review before merge.