### PR TITLE
chore: bump version to 0.6.18 for release 26.06_3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.17"
+version = "0.6.18"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Post-release version bump for **26.06_3** (crate version `0.6.18`, published to crates.io by the release workflow).

The release workflow pushed this branch but its direct push to `main` was blocked by branch protection and the PR-creation fallback did not run, leaving `main`'s `Cargo.toml` at `0.6.17` while crates.io is at `0.6.18`. Merging this re-syncs `main` so the next release computes the correct next version (mirrors #281 for the previous release).