### PR TITLE
chore: bump version to 0.6.19 for release 26.07_1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ for details.
 
 | CalVer | Crate Version | Date | Highlights |
 |--------|---------------|------|------------|
+| [26.07_1](#26071---2026-07-01) | 0.6.19 | 2026-07-01 | Dependency maintenance: maxminddb 0.29, wasmtime 46, rust-minor batch (12 updates), actions/cache 6 |
 | [26.06_3](#26063---2026-06-23) | 0.6.17 | 2026-06-23 | Multi-file KDL block merging, upstream circuit-breaker recovery fix, counter underflow guard, dependency maintenance |
 | [26.06_2](#26062---2026-06-16) | 0.6.16 | 2026-06-16 | Manifesto hardening (agent body limits, bounded limiter/pool state, pool maintenance), route-level retry-policy parsing, Pingora 0.8.1 security bump, dependency maintenance |
 | [26.06_1](#26061---2026-06-07) | 0.6.15 | 2026-06-07 | Standalone Prometheus metrics server, per-listener route sets, quickstart fixes, dep maintenance (tikv-jemallocator 0.7, openssl 0.10.80, rust-minor batches) |
@@ -51,6 +52,18 @@ for details.
 ---
 
 ## [Unreleased]
+
+---
+
+## [26.07_1] - 2026-07-01
+
+**Crate version:** 0.6.19
+
+### Changed
+- Bump `maxminddb` 0.28 → 0.29. (#293)
+- Bump the `wasmtime` group (`wasmtime`, `wasmtime-wasi`) 45.0 → 46.0. (#292)
+- Bump the rust-minor group (12 updates). (#291)
+- CI: bump `actions/cache` 5 → 6. (#290)
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8218,7 +8218,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8258,7 +8258,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8280,7 +8280,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8359,7 +8359,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8390,7 +8390,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8481,7 +8481,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8498,7 +8498,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.18"
+version = "0.6.19"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Release 26.07_1 (crate 0.6.19)

Dependency-maintenance release — the changes since 26.06_3 are the four dependency PRs merged on 2026-06-30.

### Version note
`main` was already at `0.6.18`, but **`0.6.18` is already published to crates.io** (from the 26.06_3 cycle). Republishing it would fail, so this release ships the next free crate version, **`0.6.19`**.

### Included changes
- Bump `maxminddb` 0.28 → 0.29 (#293)
- Bump the `wasmtime` group (`wasmtime`, `wasmtime-wasi`) 45.0 → 46.0 (#292)
- Bump the rust-minor group, 12 updates (#291)
- CI: bump `actions/cache` 5 → 6 (#290)

### Contents
- `Cargo.toml`: workspace version 0.6.18 → 0.6.19
- `Cargo.lock`: 7 workspace members synced to 0.6.19 (no other dependency changes)
- `CHANGELOG.md`: overview row + `[26.07_1]` section

### Release steps after merge
Tag `26.07_1` on the merge commit to trigger the Release workflow (builds/signs binaries, publishes crates to crates.io, creates the GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
