### PR TITLE
chore: bump version to 0.6.20 for release 26.07_1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8218,7 +8218,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8258,7 +8258,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8280,7 +8280,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8359,7 +8359,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8390,7 +8390,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8481,7 +8481,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8498,7 +8498,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.19"
+version = "0.6.20"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Automated post-release version bump for **26.07_1** (published crate version `0.6.20`). The release workflow's direct push to main was blocked by branch protection, so this lands it via PR (same as #288 for 26.06_3).

- `Cargo.toml`: workspace version 0.6.19 → 0.6.20 (from the release workflow)
- `Cargo.lock`: 7 workspace members synced to 0.6.20 (added so main stays consistent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)