### PR TITLE
chore: bump version to 0.6.21 for release 26.07_2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8218,7 +8218,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8258,7 +8258,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8280,7 +8280,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8359,7 +8359,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8390,7 +8390,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8481,7 +8481,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8498,7 +8498,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.20"
+version = "0.6.21"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Post-release version bump from the 26.07_2 Release workflow (published 0.6.21 to crates.io), plus a Cargo.lock sync since the workflow's auto-bump only touches Cargo.toml. Same pattern as #296.