### PR TITLE
fix(config): fail loudly on unsupported TLS config instead of ignoring it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,43 @@ for details.
 
 ## [Unreleased]
 
+> **Breaking release.** Includes a breaking listener TLS config-schema change
+> (below). The next release should bump the crate SemVer minor (0.6.x → 0.7.0).
+
+### Changed
+- **BREAKING — listener TLS config schema.** SNI certificates now use repeated
+  `sni { ... }` blocks instead of `additional-certs { cert ... }`, and cipher suites
+  use repeated `cipher-suite "NAME"` nodes instead of a `cipher-suites { ... }` list.
+  Unknown nodes inside `tls` and `sni` blocks are now **rejected at parse time**
+  (previously silently ignored) with descriptive errors and legacy-syntax hints, so
+  a config can no longer imply TLS behavior the proxy never applies. (#311)
+
+### Added
+- Loud startup warnings when TLS hardening settings — per-SNI certificate serving,
+  client-auth/mTLS, min/max TLS version, cipher suites, and session resumption — are
+  configured but not yet applied by the listener (issue #303); the listener uses
+  Pingora's built-in intermediate profile and serves the primary certificate to all
+  clients until #303 lands. Unenforced mTLS emits a `SECURITY:` warning. (#311)
+
+### Migration
+
+Update listener `tls` blocks to the new schema:
+
+```kdl
+// before                                  // after
+additional-certs {                         sni {
+    cert hostnames=["a.com"] {                 hostnames "a.com"
+        cert-file "a.crt"                      cert-file "a.crt"
+        key-file  "a.key"                      key-file  "a.key"
+    }                                      }
+}
+
+cipher-suites {                            cipher-suite "TLS_AES_128_GCM_SHA256"
+    - "TLS_AES_128_GCM_SHA256"             cipher-suite "TLS_AES_256_GCM_SHA384"
+    - "TLS_AES_256_GCM_SHA384"
+}
+```
+
 ---
 
 ## [26.07_3] - 2026-07-18

--- a/config/zentinel.kdl
+++ b/config/zentinel.kdl
@@ -33,11 +33,11 @@ listeners {
             min-version "TLS1.2"
             ocsp-stapling #true
             session-resumption #true
-            cipher-suites {
-                - "TLS_AES_128_GCM_SHA256"
-                - "TLS_AES_256_GCM_SHA384"
-                - "TLS_CHACHA20_POLY1305_SHA256"
-            }
+            // Custom cipher suites are configured as repeated nodes, e.g.:
+            //   cipher-suite "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+            // NOTE: cipher-suite, min-version, max-version and client-auth are
+            // parsed but not yet applied to the listener (issue #303); the
+            // listener currently uses the built-in intermediate TLS profile.
         }
     }
 }
@@ -138,12 +138,10 @@ routes {
             half-open-max-requests 3
         }
 
+        // retry-policy currently supports max-attempts only; per-attempt
+        // timeouts and backoff tuning are not yet implemented.
         retry-policy {
             max-attempts 3
-            timeout-ms 5000
-            backoff-base-ms 100
-            backoff-max-ms 2000
-            retryable-status-codes 502 503 504
         }
     }
 
@@ -361,7 +359,10 @@ waf {
         }
     }
 
-    mode "prevention"  // "detection" or "prevention"
+    // "off" until the WAF engine is wired into the proxy runtime; validation
+    // rejects "detection"/"prevention" so a config cannot imply inspection
+    // that is not happening.
+    mode "off"
     audit-log #true
 
     body-inspection {

--- a/crates/config/docs/examples.md
+++ b/crates/config/docs/examples.md
@@ -263,25 +263,29 @@ listeners {
             cert-file "/etc/ssl/certs/default.crt"
             key-file "/etc/ssl/private/default.key"
 
-            // Additional certificates for SNI
-            additional-certs {
-                // Explicit hostnames: only these are registered, SAN is ignored
-                cert hostnames=["api.example.com" "*.api.example.com"] {
-                    cert-file "/etc/ssl/certs/api.crt"
-                    key-file "/etc/ssl/private/api.key"
-                }
-                cert hostnames=["admin.example.com"] {
-                    cert-file "/etc/ssl/certs/admin.crt"
-                    key-file "/etc/ssl/private/admin.key"
-                }
+            // Additional certificates for SNI, one `sni` block per certificate.
+            // NOTE: `sni` blocks are parsed and used for ACME issuance, but
+            // per-SNI certificate *serving* is not wired in yet (issue #303);
+            // clients currently receive the default certificate.
 
-                // Priority hostnames: auto-extract all SANs, but this cert
-                // wins for "shared.example.com" if another cert also claims it
-                cert {
-                    priority-hostnames "shared.example.com"
-                    cert-file "/etc/ssl/certs/shared.crt"
-                    key-file "/etc/ssl/private/shared.key"
-                }
+            // Explicit hostnames: only these are registered, SAN is ignored
+            sni {
+                hostnames "api.example.com" "*.api.example.com"
+                cert-file "/etc/ssl/certs/api.crt"
+                key-file "/etc/ssl/private/api.key"
+            }
+            sni {
+                hostnames "admin.example.com"
+                cert-file "/etc/ssl/certs/admin.crt"
+                key-file "/etc/ssl/private/admin.key"
+            }
+
+            // Priority hostnames: auto-extract all SANs, but this cert
+            // wins for "shared.example.com" if another cert also claims it
+            sni {
+                priority-hostnames "shared.example.com"
+                cert-file "/etc/ssl/certs/shared.crt"
+                key-file "/etc/ssl/private/shared.key"
             }
         }
     }

--- a/crates/config/docs/kdl-format.md
+++ b/crates/config/docs/kdl-format.md
@@ -180,12 +180,13 @@ listeners {
             client-auth false
             ocsp-stapling true
 
-            // SNI support for multiple domains
-            additional-certs {
-                cert hostnames=["api.example.com"] {
-                    cert-file "/etc/ssl/certs/api.crt"
-                    key-file "/etc/ssl/private/api.key"
-                }
+            // SNI certificate for an additional domain.
+            // NOTE: parsed and used for ACME issuance, but per-SNI
+            // certificate *serving* is not wired in yet (issue #303).
+            sni {
+                hostnames "api.example.com"
+                cert-file "/etc/ssl/certs/api.crt"
+                key-file "/etc/ssl/private/api.key"
             }
         }
     }

--- a/crates/config/docs/schema.md
+++ b/crates/config/docs/schema.md
@@ -70,12 +70,18 @@ Port binding configuration.
 | `ca-file` | `string` | - | CA certificate for client verification |
 | `min-version` | `string` | `"tls1.2"` | Minimum TLS version |
 | `max-version` | `string` | - | Maximum TLS version |
-| `cipher-suites` | `[string]` | `[]` | Cipher suites (empty = defaults) |
+| `cipher-suite` | `string` (repeatable) | `[]` | Cipher suite, one node per suite (empty = defaults) |
 | `client-auth` | `bool` | `false` | Require client certificates (mTLS) |
 | `ocsp-stapling` | `bool` | `true` | Enable OCSP stapling |
 | `session-resumption` | `bool` | `true` | Enable session resumption |
-| `additional-certs` | `[SniCertificate]` | `[]` | Additional certs for SNI |
+| `sni` | `SniCertificate` (repeatable) | `[]` | Additional certs for SNI, one block per cert |
 | `acme` | `AcmeConfig` | - | ACME automatic certificate management |
+
+> **Note:** `min-version`, `max-version`, `cipher-suite`, `client-auth`, and
+> per-SNI certificate serving are parsed but not yet applied to the listener
+> (issue #303); the listener currently uses the built-in intermediate TLS
+> profile and serves the primary certificate to all clients. Unknown nodes
+> inside `tls` and `sni` blocks are rejected at parse time.
 
 ### AcmeConfig
 

--- a/crates/config/src/kdl/server.rs
+++ b/crates/config/src/kdl/server.rs
@@ -178,6 +178,8 @@ pub fn parse_listeners(node: &kdl::KdlNode) -> Result<Vec<ListenerConfig>> {
 pub fn parse_tls_config(node: &kdl::KdlNode, listener_id: &str) -> Result<TlsConfig> {
     debug!(listener_id = %listener_id, "Parsing TLS configuration");
 
+    reject_unknown_nodes(node, KNOWN_TLS_NODES, "tls", listener_id)?;
+
     // Parse ACME configuration if present
     let acme = if let Some(children) = node.children() {
         children
@@ -266,6 +268,75 @@ pub fn parse_tls_config(node: &kdl::KdlNode, listener_id: &str) -> Result<TlsCon
         session_resumption,
         acme,
     })
+}
+
+/// Child nodes recognized inside a listener `tls` block.
+const KNOWN_TLS_NODES: &[&str] = &[
+    "cert-file",
+    "key-file",
+    "ca-file",
+    "min-version",
+    "max-version",
+    "client-auth",
+    "ocsp-stapling",
+    "session-resumption",
+    "cipher-suite",
+    "sni",
+    "acme",
+];
+
+/// Child nodes recognized inside an `sni` block.
+const KNOWN_SNI_NODES: &[&str] = &[
+    "hostnames",
+    "priority-hostnames",
+    "cert-file",
+    "key-file",
+    "acme",
+];
+
+/// Reject child nodes the parser does not understand.
+///
+/// Unknown nodes in security-relevant blocks previously parsed as nothing,
+/// letting a config imply protections that were never active (issue #303).
+fn reject_unknown_nodes(
+    node: &kdl::KdlNode,
+    known: &[&str],
+    block: &str,
+    listener_id: &str,
+) -> Result<()> {
+    let Some(children) = node.children() else {
+        return Ok(());
+    };
+    for child in children.nodes() {
+        let name = child.name().value();
+        if known.contains(&name) {
+            continue;
+        }
+        let hint = match name {
+            "additional-certs" | "sni-cert" => {
+                "SNI certificates are configured with `sni { ... }` blocks placed directly \
+                 inside `tls { }`; the `additional-certs`/`sni-cert` syntax from older \
+                 documentation was never supported. "
+            }
+            "cipher-suites" => {
+                "Cipher suites are configured as repeated `cipher-suite \"NAME\"` nodes. "
+            }
+            "certificates" => {
+                "Certificates are configured with `cert-file`/`key-file` plus optional \
+                 `sni { ... }` blocks. "
+            }
+            _ => "",
+        };
+        return Err(anyhow::anyhow!(
+            "Unknown node '{}' in `{}` block of listener '{}'. {}Supported nodes: {}",
+            name,
+            block,
+            listener_id,
+            hint,
+            known.join(", ")
+        ));
+    }
+    Ok(())
 }
 
 /// Parse ACME configuration block
@@ -603,6 +674,8 @@ fn parse_propagation_config(node: &kdl::KdlNode) -> PropagationCheckConfig {
 /// }
 /// ```
 fn parse_sni_certificate(node: &kdl::KdlNode, listener_id: &str) -> Result<SniCertificate> {
+    reject_unknown_nodes(node, KNOWN_SNI_NODES, "sni", listener_id)?;
+
     let children = node.children();
 
     // Parse hostnames - explicit override, disables SAN auto-extraction.
@@ -762,5 +835,115 @@ mod tests {
         assert_eq!(public.namespace, None);
         assert_eq!(admin.namespace, Some("ops".to_string()));
         assert_eq!(admin.address, "127.0.0.1:9000");
+    }
+
+    fn parse_tls(input: &str) -> Result<TlsConfig> {
+        let doc: kdl::KdlDocument = input.parse().unwrap();
+        let node = doc.nodes().first().unwrap();
+        parse_tls_config(node, "test-listener")
+    }
+
+    #[test]
+    fn tls_block_parses_sni_certificates() {
+        let tls = parse_tls(
+            r#"
+            tls {
+                cert-file "/certs/default.crt"
+                key-file "/certs/default.key"
+                sni {
+                    hostnames "example.com"
+                    cert-file "/certs/example.crt"
+                    key-file "/certs/example.key"
+                }
+            }
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(tls.additional_certs.len(), 1);
+        assert_eq!(tls.additional_certs[0].hostnames, vec!["example.com"]);
+    }
+
+    #[test]
+    fn tls_block_rejects_unknown_node_with_documented_legacy_syntax_hint() {
+        let err = parse_tls(
+            r#"
+            tls {
+                cert-file "/certs/default.crt"
+                key-file "/certs/default.key"
+                additional-certs {
+                    sni-cert {
+                        hostname "example.com"
+                    }
+                }
+            }
+            "#,
+        )
+        .unwrap_err();
+
+        let message = err.to_string();
+        assert!(message.contains("Unknown node 'additional-certs'"));
+        assert!(message.contains("test-listener"));
+        assert!(message.contains("`sni { ... }`"));
+    }
+
+    #[test]
+    fn tls_block_rejects_plural_cipher_suites_node() {
+        let err = parse_tls(
+            r#"
+            tls {
+                cert-file "/certs/default.crt"
+                key-file "/certs/default.key"
+                cipher-suites {
+                    - "TLS_AES_128_GCM_SHA256"
+                }
+            }
+            "#,
+        )
+        .unwrap_err();
+
+        let message = err.to_string();
+        assert!(message.contains("Unknown node 'cipher-suites'"));
+        assert!(message.contains("repeated `cipher-suite \"NAME\"` nodes"));
+    }
+
+    #[test]
+    fn tls_block_rejects_arbitrary_unknown_node() {
+        let err = parse_tls(
+            r#"
+            tls {
+                cert-file "/certs/default.crt"
+                key-file "/certs/default.key"
+                tls13-cipher-suites "TLS_AES_128_GCM_SHA256"
+            }
+            "#,
+        )
+        .unwrap_err();
+
+        let message = err.to_string();
+        assert!(message.contains("Unknown node 'tls13-cipher-suites'"));
+        assert!(message.contains("Supported nodes:"));
+    }
+
+    #[test]
+    fn sni_block_rejects_unknown_node() {
+        let err = parse_tls(
+            r#"
+            tls {
+                cert-file "/certs/default.crt"
+                key-file "/certs/default.key"
+                sni {
+                    hostname "example.com"
+                    cert-file "/certs/example.crt"
+                    key-file "/certs/example.key"
+                }
+            }
+            "#,
+        )
+        .unwrap_err();
+
+        let message = err.to_string();
+        assert!(message.contains("Unknown node 'hostname'"));
+        assert!(message.contains("`sni` block"));
     }
 }

--- a/crates/proxy/docs/examples.md
+++ b/crates/proxy/docs/examples.md
@@ -253,15 +253,18 @@ listeners {
             cert-file "/etc/ssl/certs/default.crt"
             key-file "/etc/ssl/private/default.key"
 
-            additional-certs {
-                cert hostnames=["api.example.com", "*.api.example.com"] {
-                    cert-file "/etc/ssl/certs/api.crt"
-                    key-file "/etc/ssl/private/api.key"
-                }
-                cert hostnames=["admin.example.com"] {
-                    cert-file "/etc/ssl/certs/admin.crt"
-                    key-file "/etc/ssl/private/admin.key"
-                }
+            // One `sni` block per additional certificate.
+            // NOTE: parsed and used for ACME issuance, but per-SNI
+            // certificate *serving* is not wired in yet (issue #303).
+            sni {
+                hostnames "api.example.com" "*.api.example.com"
+                cert-file "/etc/ssl/certs/api.crt"
+                key-file "/etc/ssl/private/api.key"
+            }
+            sni {
+                hostnames "admin.example.com"
+                cert-file "/etc/ssl/certs/admin.crt"
+                key-file "/etc/ssl/private/admin.key"
             }
         }
     }

--- a/crates/proxy/src/main.rs
+++ b/crates/proxy/src/main.rs
@@ -829,13 +829,60 @@ fn run_server(
                                 }
                             };
                         tls_settings.enable_h2();
+
+                        // Until the Pingora fork accepts a pre-built rustls
+                        // ServerConfig (see TODO above and issue #303), settings
+                        // beyond the primary certificate are parsed but never
+                        // reach the listener. Say so loudly instead of letting
+                        // the config imply protections that are not active.
+                        if !tls_config.additional_certs.is_empty() {
+                            warn!(
+                                listener_id = %listener.id,
+                                sni_cert_count = tls_config.additional_certs.len(),
+                                "SNI certificates are configured but NOT served: \
+                                 per-SNI certificate selection is not wired into \
+                                 the TLS listener yet (issue #303). All clients \
+                                 receive the primary certificate."
+                            );
+                        }
+                        if tls_config.client_auth {
+                            warn!(
+                                listener_id = %listener.id,
+                                "SECURITY: client-auth (mTLS) is configured but \
+                                 NOT enforced: the listener does not request or \
+                                 verify client certificates (issue #303). Do not \
+                                 rely on mTLS for this listener."
+                            );
+                        }
+                        let mut unapplied: Vec<&str> = Vec::new();
+                        if tls_config.min_version != zentinel_common::types::TlsVersion::Tls12 {
+                            unapplied.push("min-version");
+                        }
+                        if tls_config.max_version.is_some() {
+                            unapplied.push("max-version");
+                        }
+                        if !tls_config.cipher_suites.is_empty() {
+                            unapplied.push("cipher-suite");
+                        }
+                        if !tls_config.session_resumption {
+                            unapplied.push("session-resumption");
+                        }
+                        if !unapplied.is_empty() {
+                            warn!(
+                                listener_id = %listener.id,
+                                settings = ?unapplied,
+                                "TLS hardening settings are configured but NOT \
+                                 applied: the listener uses Pingora's built-in \
+                                 intermediate profile (TLS 1.2+, default cipher \
+                                 suites) until issue #303 is resolved."
+                            );
+                        }
+
                         proxy_service.add_tls_with_settings(&listener.address, None, tls_settings);
                         info!(
                             listener_id = %listener.id,
                             address = %listener.address,
                             cert_file = %cert_path_str,
-                            min_tls_version = ?tls_config.min_version,
-                            client_auth = tls_config.client_auth,
                             acme_enabled = tls_config.acme.is_some(),
                             "HTTPS (h2+http/1.1) listening on: {}", listener.address
                         );


### PR DESCRIPTION
Stopgaps for #303 (per-SNI TLS listener support incomplete). The root fix — wiring `build_server_config()` into Pingora's `TlsSettings` — needs a Pingora fork change and stays tracked in #303; this PR stops the config layer from implying protections that are not active.

## Changes

**Parser (`crates/config/src/kdl/server.rs`)**
- Unknown child nodes in listener `tls` and `sni` blocks are now a parse error instead of silently ignored, matching the strict-key precedent in `retrypolicy_helper.rs`/`circuitbreaker_helper.rs`.
- Targeted hints for the syntax older docs showed: `additional-certs`/`sni-cert` → `sni { }`, `cipher-suites { }` → repeated `cipher-suite "NAME"` nodes, `certificates { }` → `cert-file`/`key-file` + `sni { }`.
- 5 new unit tests.

**Proxy startup (`crates/proxy/src/main.rs`)**
- `warn!` when SNI certificates are configured but not served (all clients receive the primary certificate).
- `warn!` (SECURITY) when `client-auth` is configured but not enforced.
- `warn!` when `min-version`/`max-version`/`cipher-suite`/`session-resumption` are set but the listener uses Pingora's built-in intermediate profile.
- The HTTPS startup `info!` no longer prints `min_tls_version`/`client_auth` as if applied.

**Shipped default config (`config/zentinel.kdl`)** — now actually passes `zentinel test` (it did not on `main`):
- Dead `cipher-suites { }` block replaced with a comment showing the supported syntax.
- `retry-policy` trimmed to `max-attempts` (the only key `RetryPolicy` implements; `timeout-ms`, `backoff-*`, `retryable-status-codes` were rejected by the strict parser).
- WAF `mode "prevention"` → `mode "off"`, as required by the existing validation rule for the unwired WAF engine.

**Crate docs** — `kdl-format.md`, `examples.md` (config + proxy), `schema.md` corrected to the real `sni { }` syntax, `cipher-suites` → `cipher-suite`, plus an explicit note that per-SNI serving and TLS hardening are pending #303.

## Verification

- `cargo test -p zentinel-config`: 207 passed (includes 5 new tests).
- `cargo clippy -p zentinel-config -p zentinel-proxy --all-targets -- -D warnings`: clean.
- `zentinel test --config config/zentinel.kdl`: passes (failed on `main` with `Got unknown key timeout-ms`).
- Old documented syntax now fails loudly:
  ```
  Unknown node 'additional-certs' in `tls` block of listener 'https'. SNI certificates are
  configured with `sni { ... }` blocks placed directly inside `tls { }`; the
  `additional-certs`/`sni-cert` syntax from older documentation was never supported. ...
  ```
- Swept all `config/examples/*.kdl`: 9 files fail `zentinel test` on pre-existing issues (retry-policy `timeout-ms`, missing `address`/`target`, one KDL include error) — none caused by this PR. Follow-up issue incoming.

## Compatibility note

Configs that contained unknown nodes inside `tls`/`sni` blocks (previously silently ignored) now fail at startup. This is deliberate: every such node implied inactive security. Reload paths reject the config and keep running the old one.

## Out of scope / follow-ups
- Pingora fork: accept a pre-built `rustls::ServerConfig`, then wire `build_server_config()` (root fix for #303).
- `config/example-multi-file/` uses square-bracket arrays that are not valid KDL and cannot ever have parsed; needs its own cleanup pass.
- `config/examples/*` pre-existing validation failures.
- Docs site (zentinelproxy.io-docs) multi-domain example still shows `additional-certs`.

Closes nothing on its own; #303 remains open for the root fix.
