### PR TITLE
chore: bump version to 0.6.22 for release 26.07_3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8228,7 +8228,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.21"
+version = "0.6.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8268,7 +8268,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.21"
+version = "0.6.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8290,7 +8290,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.21"
+version = "0.6.22"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8369,7 +8369,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.21"
+version = "0.6.22"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8400,7 +8400,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.21"
+version = "0.6.22"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8491,7 +8491,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.21"
+version = "0.6.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.21"
+version = "0.6.22"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.21"
+version = "0.6.22"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Post-release version bump from the 26.07_3 Release workflow (published 0.6.22 to crates.io), plus a Cargo.lock sync since the workflow's auto-bump only touches Cargo.toml. Same pattern as #302/#296.