### PR TITLE
chore: bump version to 0.6.23 for release 26.07_4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8207,7 +8207,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.22"
+version = "0.6.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8247,7 +8247,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.22"
+version = "0.6.23"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8269,7 +8269,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.22"
+version = "0.6.23"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8348,7 +8348,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.22"
+version = "0.6.23"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8379,7 +8379,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.22"
+version = "0.6.23"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8470,7 +8470,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.22"
+version = "0.6.23"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8487,7 +8487,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.22"
+version = "0.6.23"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.22"
+version = "0.6.23"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Post-release version bump following **26.07_4** (crate `0.6.23` published to crates.io).

The Release workflow auto-created `chore/bump-0.6.23` (Cargo.toml → 0.6.23) but its `gh pr create` didn't open a PR — opening it manually, same as the prior release cycles.

- `ffb6bea` (bot): bump workspace version `0.6.22` → `0.6.23` in `Cargo.toml`
- `dd20b1d`: `cargo update --workspace` to sync `Cargo.lock` (7 workspace crates 0.6.22 → 0.6.23; no external deps changed) — the bot commit is Cargo.toml-only and leaves the lockfile drifted otherwise.

Brings `main` in line with the published crate version. No functional changes.