### PR TITLE
chore: prepare release 26.08_1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ for details.
 
 | CalVer | Crate Version | Date | Highlights |
 |--------|---------------|------|------------|
+| [26.08_1](#26081---2026-08-08) | 0.6.24 | 2026-08-08 | Security: rustls 0.23.43 (ticket-age and binder arithmetic hardening); dependency maintenance: pem 4.0, base64 0.23, jsonschema 0.49, validator 0.21, async-memcached 0.7, http 1.5, redis 1.5 |
 | [26.07_4](#26074---2026-07-30) | 0.6.22 | 2026-07-30 | Dependency maintenance: wasmtime 47, quinn-proto 0.11.16, maxminddb 0.30, rust-minor batch (17 updates), actions/setup-go 7 |
 | [26.07_3](#26073---2026-07-18) | 0.6.21 | 2026-07-18 | Security: serde_with 3.21 (GHSA-7gcf-g7xr-8hxj); dependency maintenance: tokio-tungstenite 0.30, jsonschema 0.48, rust-minor batches (13 updates) |
 | [26.07_2](#26072---2026-07-06) | 0.6.20 | 2026-07-06 | Dependency maintenance: quick-xml 0.41, rust-minor batch (4 updates), cmov 0.5.4, conformance golang.org/x/net 0.55 |
@@ -55,6 +56,36 @@ for details.
 ---
 
 ## [Unreleased]
+
+---
+
+## [26.08_1] - 2026-08-08
+
+**Crate version:** 0.6.24
+
+Dependency-only release. No proxy behavior, configuration schema, or agent
+protocol changes.
+
+### Security
+- Bump `rustls` 0.23.42 → 0.23.43, part of the rust-minor group. Upstream
+  hardens session-ticket age arithmetic and the PSK binder suffix calculation
+  (`checked_sub` in `Rfc5077Ticketer::decrypt`), and tightens QUIC cipher-suite
+  and TLS-version checks. No CVE assigned and no Zentinel-specific exposure
+  identified; taken as defense in depth for the TLS listener path. (#326)
+
+### Changed
+- Bump the rust-minor group (4 updates): `rustls` 0.23.42 → 0.23.43,
+  `http` 1.4.2 → 1.5.0, `redis` 1.4.1 → 1.5.0, and
+  `toml` 1.1.3+spec-1.1.0 → 1.1.4+spec-1.1.0. (#326)
+- Bump `pem` 3.0.6 → 4.0.0. (#327)
+- Bump `jsonschema` 0.48.1 → 0.49.5. (#328)
+- Bump `base64` 0.22.1 → 0.23.1. (#329)
+- Bump `validator` 0.20.0 → 0.21.0. (#330)
+- Bump `async-memcached` 0.6.0 → 0.7.0. (#332)
+
+### Documentation
+- Correct the documented release process to match the Release workflow's
+  actual tag+1 versioning behavior. (#325)
 
 ---
 


### PR DESCRIPTION
Changelog entry for release `26.08_1`, covering everything merged since `26.07_4` (2026-07-30).

## Contents

Six dependency bumps plus one docs correction. **No proxy behavior, config schema, or agent protocol changes** — this is a dependency-only release.

| PR | Bump |
|----|------|
| #326 | rust-minor group: `rustls` 0.23.42→0.23.43, `http` 1.4.2→1.5.0, `redis` 1.4.1→1.5.0, `toml` 1.1.3→1.1.4 |
| #327 | `pem` 3.0.6 → 4.0.0 |
| #328 | `jsonschema` 0.48.1 → 0.49.5 |
| #329 | `base64` 0.22.1 → 0.23.1 |
| #330 | `validator` 0.20.0 → 0.21.0 |
| #332 | `async-memcached` 0.6.0 → 0.7.0 |
| #325 | docs: correct release process to match tag+1 behavior |

`pem`, `base64`, and `validator` are semver-major bumps that needed no source changes — only `Cargo.toml`/`Cargo.lock` moved, and CI was green on each.

The `rustls` bump is filed under **Security**: upstream hardens session-ticket age arithmetic and the PSK binder suffix calculation, and tightens QUIC cipher-suite/TLS-version checks. No CVE was assigned and no Zentinel-specific exposure was identified, so it is described as defense in depth rather than a fix for a known vulnerability here.

## Versioning

`Cargo.toml` is **intentionally not bumped** in this PR. The Release workflow reads the current workspace version at tag time, increments the patch, and publishes that — so tagging `26.08_1` against main at `0.6.23` publishes **`0.6.24`**.

## Note on the overview table

The new row records `0.6.24`, which is what will actually be published. Be aware the existing rows are systematically one behind: the table lists 26.07_4 as `0.6.22` but crates.io shows it published `0.6.23`, and it lists `0.6.19` for 26.07_1 although 0.6.19 was never published at all (crates.io jumps 0.6.18 → 0.6.20). Correcting that history is left out of this PR deliberately — happy to do it as a follow-up.