### PR TITLE
chore: bump version to 0.6.24 for release 26.08_1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8259,7 +8259,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.23"
+version = "0.6.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8299,7 +8299,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.23"
+version = "0.6.24"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8321,7 +8321,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.23"
+version = "0.6.24"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8400,7 +8400,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.23"
+version = "0.6.24"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8431,7 +8431,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.23"
+version = "0.6.24"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8522,7 +8522,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.23"
+version = "0.6.24"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8539,7 +8539,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.23"
+version = "0.6.24"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.23"
+version = "0.6.24"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Post-release version bump for **26.08_1**, which published `zentinel-proxy 0.6.24` to crates.io on 2026-08-08.

The Release workflow pushed the bump commit to `chore/bump-0.6.24` but its `gh pr create` step failed, leaving the branch orphaned with no PR — the same failure as the last three releases (#296, #302, #324). Opening it by hand.

## Why this matters

`main` currently says `0.6.23` while crates.io has `0.6.24`. Left unmerged, the next release would compute `0.6.23 + 1 = 0.6.24` and collide with a version already published.

## Commits

| Commit | Change |
|--------|--------|
| `9a821dd` | Workflow's auto-bump — `Cargo.toml` workspace version 0.6.23 → 0.6.24 |
| `46fecbc` | `cargo update --workspace` to sync `Cargo.lock` |

The auto-bump is Cargo.toml-only and leaves `Cargo.lock` pinned at the old version, so the second commit is required to keep the two consistent. It updates exactly the 7 workspace crates (`zentinel-common`, `-config`, `-agent-protocol`, `-wasm-runtime`, `-proxy`, `-gateway`, `-stack`) and touches **no external dependencies**.