### PR TITLE
feat(config): actionable errors for route match conditions

### DIFF
--- a/crates/config/src/kdl/helpers.rs
+++ b/crates/config/src/kdl/helpers.rs
@@ -238,3 +238,85 @@ pub fn extract_u64_with_limits(node: &kdl::KdlNode) -> Result<u64> {
 
     Ok(u64_val)
 }
+
+/// Suggest the closest candidate for a (probably misspelled) input.
+///
+/// Returns `Some(candidate)` when a candidate is within a small edit distance
+/// of the input (scaled with input length), so error messages can offer a
+/// "did you mean" hint. Returns `None` when nothing is plausibly close.
+pub fn did_you_mean<'a>(input: &str, candidates: &[&'a str]) -> Option<&'a str> {
+    // Allow more typo distance for longer inputs; at least 1, at most 3.
+    let max_distance = (input.len() / 4).clamp(1, 3);
+
+    candidates
+        .iter()
+        .map(|c| (edit_distance(input, c), *c))
+        .filter(|(d, _)| *d <= max_distance)
+        .min_by_key(|(d, _)| *d)
+        .map(|(_, c)| c)
+}
+
+/// Edit distance between two strings (over `char`s).
+///
+/// Optimal-string-alignment variant of Levenshtein: insertions, deletions,
+/// and substitutions cost 1, and an adjacent transposition ("hots" → "host")
+/// also costs 1, which matches how config keys are typically mistyped.
+fn edit_distance(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+
+    // rows[i][j] = distance between a[..i] and b[..j]
+    let mut rows: Vec<Vec<usize>> = vec![(0..=b.len()).collect()];
+
+    for (i, ca) in a.iter().enumerate() {
+        let mut row = vec![0usize; b.len() + 1];
+        row[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            let substitution_cost = if ca == cb { 0 } else { 1 };
+            let mut d = (rows[i][j] + substitution_cost) // substitute
+                .min(rows[i][j + 1] + 1) // delete
+                .min(row[j] + 1); // insert
+            if i > 0 && j > 0 && *ca == b[j - 1] && a[i - 1] == *cb {
+                d = d.min(rows[i - 1][j - 1] + 1); // transpose
+            }
+            row[j + 1] = d;
+        }
+        rows.push(row);
+    }
+
+    rows[a.len()][b.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn edit_distance_basics() {
+        assert_eq!(edit_distance("", ""), 0);
+        assert_eq!(edit_distance("abc", "abc"), 0);
+        assert_eq!(edit_distance("abc", "abd"), 1);
+        assert_eq!(edit_distance("abc", ""), 3);
+        assert_eq!(edit_distance("path_prefix", "path-prefix"), 1);
+        // Adjacent transposition costs 1 (OSA variant)
+        assert_eq!(edit_distance("hots", "host"), 1);
+    }
+
+    #[test]
+    fn did_you_mean_suggests_close_candidates() {
+        let candidates = ["path", "path-prefix", "path-regex", "host", "method"];
+        assert_eq!(
+            did_you_mean("path_prefix", &candidates),
+            Some("path-prefix")
+        );
+        assert_eq!(did_you_mean("hots", &candidates), Some("host"));
+        assert_eq!(did_you_mean("pth", &candidates), Some("path"));
+    }
+
+    #[test]
+    fn did_you_mean_rejects_distant_candidates() {
+        let candidates = ["path", "host", "method"];
+        assert_eq!(did_you_mean("upstream", &candidates), None);
+        assert_eq!(did_you_mean("zzzzzz", &candidates), None);
+    }
+}

--- a/crates/config/src/kdl/mod.rs
+++ b/crates/config/src/kdl/mod.rs
@@ -205,11 +205,31 @@ pub fn parse_kdl_document(doc: kdl::KdlDocument) -> Result<Config> {
                 ));
             }
             other => {
+                const VALID_BLOCKS: &[&str] = &[
+                    "schema-version",
+                    "system",
+                    "listeners",
+                    "routes",
+                    "upstreams",
+                    "filters",
+                    "agents",
+                    "waf",
+                    "namespace",
+                    "limits",
+                    "observability",
+                    "rate-limits",
+                    "cache",
+                    "include",
+                ];
+                let suggestion = helpers::did_you_mean(other, VALID_BLOCKS)
+                    .map(|s| format!(" Did you mean '{}'?", s))
+                    .unwrap_or_default();
                 return Err(anyhow::anyhow!(
-                    "Unknown top-level configuration block: '{}'\n\
-                     Valid blocks are: schema-version, system, listeners, routes, upstreams, \
-                     filters, agents, waf, namespace, limits, observability, rate-limits, cache",
-                    other
+                    "Unknown top-level configuration block: '{}'.{}\n\
+                     Valid blocks are: {}",
+                    other,
+                    suggestion,
+                    VALID_BLOCKS.join(", ")
                 ));
             }
         }

--- a/crates/config/src/kdl/routes.rs
+++ b/crates/config/src/kdl/routes.rs
@@ -180,68 +180,145 @@ pub fn parse_routes(node: &kdl::KdlNode) -> Result<Vec<RouteConfig>> {
     Ok(routes)
 }
 
+/// Match condition node names recognized inside a `matches` block, paired
+/// with a usage example for error messages.
+const VALID_MATCH_CONDITIONS: &[(&str, &str)] = &[
+    ("path", "path \"/api/v1/users\""),
+    ("path-prefix", "path-prefix \"/api\""),
+    ("path-regex", "path-regex \"^/api/v[0-9]+/\""),
+    ("host", "host \"example.com\" (or \"*.example.com\")"),
+    (
+        "header",
+        "header \"x-version\" (or header \"x-version\" \"2\")",
+    ),
+    ("method", "method \"GET\""),
+    (
+        "query-param",
+        "query-param \"debug\" (or query-param \"debug\" \"true\")",
+    ),
+];
+
+/// Build the error for a match condition whose first argument is missing or
+/// not a string (e.g. `path-prefix` with no value, or `method 42`).
+fn match_condition_value_error(route_id: &str, match_node: &kdl::KdlNode) -> anyhow::Error {
+    let name = match_node.name().value();
+    let example = VALID_MATCH_CONDITIONS
+        .iter()
+        .find(|(n, _)| *n == name)
+        .map(|(_, ex)| *ex)
+        .unwrap_or("path-prefix \"/api\"");
+    match match_node.entries().first() {
+        Some(entry) => anyhow::anyhow!(
+            "Route '{}': match condition '{}' has a non-string value {}.\n\
+             Expected a quoted string, e.g., {}",
+            route_id,
+            name,
+            entry.value(),
+            example
+        ),
+        None => anyhow::anyhow!(
+            "Route '{}': match condition '{}' is missing its value.\n\
+             Expected a quoted string, e.g., {}",
+            route_id,
+            name,
+            example
+        ),
+    }
+}
+
 fn parse_match_conditions(node: &kdl::KdlNode) -> Result<Vec<MatchCondition>> {
     let mut matches = Vec::new();
+    // Route ID for error context; parse_routes has already required it.
+    let route_id = get_first_arg_string(node).unwrap_or_else(|| "<unnamed>".to_string());
 
     if let Some(route_children) = node.children() {
         if let Some(matches_node) = route_children.get("matches") {
             if let Some(match_children) = matches_node.children() {
                 for match_node in match_children.nodes() {
-                    match match_node.name().value() {
+                    let name = match_node.name().value();
+                    match name {
                         "path-prefix" => {
-                            if let Some(prefix) = get_first_arg_string(match_node) {
-                                matches.push(MatchCondition::PathPrefix(prefix));
-                            }
+                            let prefix = get_first_arg_string(match_node).ok_or_else(|| {
+                                match_condition_value_error(&route_id, match_node)
+                            })?;
+                            matches.push(MatchCondition::PathPrefix(prefix));
                         }
                         "path" => {
-                            if let Some(path) = get_first_arg_string(match_node) {
-                                matches.push(MatchCondition::Path(path));
-                            }
+                            let path = get_first_arg_string(match_node).ok_or_else(|| {
+                                match_condition_value_error(&route_id, match_node)
+                            })?;
+                            matches.push(MatchCondition::Path(path));
                         }
                         "path-regex" => {
-                            if let Some(regex) = get_first_arg_string(match_node) {
-                                matches.push(MatchCondition::PathRegex(regex));
-                            }
+                            let regex = get_first_arg_string(match_node).ok_or_else(|| {
+                                match_condition_value_error(&route_id, match_node)
+                            })?;
+                            matches.push(MatchCondition::PathRegex(regex));
                         }
                         "host" => {
-                            if let Some(host) = get_first_arg_string(match_node) {
-                                matches.push(MatchCondition::Host(host));
-                            }
+                            let host = get_first_arg_string(match_node).ok_or_else(|| {
+                                match_condition_value_error(&route_id, match_node)
+                            })?;
+                            matches.push(MatchCondition::Host(host));
                         }
                         "header" => {
                             let entries: Vec<_> = match_node.entries().iter().collect();
-                            if let Some(name) = entries.first().and_then(|e| e.value().as_string())
-                            {
-                                let value = entries
-                                    .get(1)
-                                    .and_then(|e| e.value().as_string())
-                                    .map(|s| s.to_string());
-                                matches.push(MatchCondition::Header {
-                                    name: name.to_string(),
-                                    value,
-                                });
-                            }
+                            let name = entries
+                                .first()
+                                .and_then(|e| e.value().as_string())
+                                .ok_or_else(|| {
+                                    match_condition_value_error(&route_id, match_node)
+                                })?;
+                            let value = entries
+                                .get(1)
+                                .and_then(|e| e.value().as_string())
+                                .map(|s| s.to_string());
+                            matches.push(MatchCondition::Header {
+                                name: name.to_string(),
+                                value,
+                            });
                         }
                         "method" => {
-                            if let Some(method) = get_first_arg_string(match_node) {
-                                matches.push(MatchCondition::Method(vec![method]));
-                            }
+                            let method = get_first_arg_string(match_node).ok_or_else(|| {
+                                match_condition_value_error(&route_id, match_node)
+                            })?;
+                            matches.push(MatchCondition::Method(vec![method]));
                         }
                         "query-param" => {
                             let entries: Vec<_> = match_node.entries().iter().collect();
-                            if let Some(name) = entries.first().and_then(|e| e.value().as_string())
-                            {
-                                let value = entries
-                                    .get(1)
-                                    .and_then(|e| e.value().as_string())
-                                    .map(|s| s.to_string());
-                                matches.push(MatchCondition::QueryParam {
-                                    name: name.to_string(),
-                                    value,
-                                });
-                            }
+                            let name = entries
+                                .first()
+                                .and_then(|e| e.value().as_string())
+                                .ok_or_else(|| {
+                                    match_condition_value_error(&route_id, match_node)
+                                })?;
+                            let value = entries
+                                .get(1)
+                                .and_then(|e| e.value().as_string())
+                                .map(|s| s.to_string());
+                            matches.push(MatchCondition::QueryParam {
+                                name: name.to_string(),
+                                value,
+                            });
                         }
-                        _ => {}
+                        other => {
+                            // A silently dropped match condition would make the
+                            // route match MORE requests than intended, so a typo
+                            // here must be a hard error, not a warning.
+                            let valid_names: Vec<&str> =
+                                VALID_MATCH_CONDITIONS.iter().map(|(n, _)| *n).collect();
+                            let suggestion = super::helpers::did_you_mean(other, &valid_names)
+                                .map(|s| format!(" Did you mean '{}'?", s))
+                                .unwrap_or_default();
+                            return Err(anyhow::anyhow!(
+                                "Route '{}': unknown match condition '{}'.{}\n\
+                                 Valid match conditions are: {}",
+                                route_id,
+                                other,
+                                suggestion,
+                                valid_names.join(", ")
+                            ));
+                        }
                     }
                 }
             }
@@ -744,13 +821,27 @@ fn parse_shadow_config(node: &kdl::KdlNode) -> Result<ShadowConfig> {
         )
     })?;
 
+    // Percentage: accepts a number (`percentage 50` / `percentage 12.5`) or a
+    // numeric string (`percentage "50"`). Invalid values are hard errors —
+    // silently falling back to the 100% default would mirror far more traffic
+    // than intended.
     let percentage = if let Some(pct_str) = get_string_entry(node, "percentage") {
-        pct_str.parse::<f64>().unwrap_or(100.0)
+        pct_str.parse::<f64>().map_err(|_| {
+            anyhow::anyhow!(
+                "Shadow 'percentage' has invalid value \"{}\". \
+                 Expected a number between 0 and 100, e.g., percentage 50",
+                pct_str
+            )
+        })?
     } else {
-        get_int_entry(node, "percentage")
-            .map(|v| v as f64)
-            .unwrap_or(100.0)
+        get_float_entry(node, "percentage").unwrap_or(100.0)
     };
+    if !(0.0..=100.0).contains(&percentage) {
+        return Err(anyhow::anyhow!(
+            "Shadow 'percentage' is {} but must be between 0 and 100.",
+            percentage
+        ));
+    }
 
     let timeout_ms = get_int_entry(node, "timeout-ms").unwrap_or(5000) as u64;
     let buffer_body = get_bool_entry(node, "buffer-body").unwrap_or(false);
@@ -1813,5 +1904,250 @@ mod tests {
         let rp = routes.first().unwrap().retry_policy.as_ref();
 
         assert!(rp.is_none());
+    }
+
+    /// Parse a `routes { ... }` KDL fragment through `parse_routes`.
+    fn parse_routes_from(kdl: &str) -> Result<Vec<RouteConfig>> {
+        let doc: kdl::KdlDocument = kdl.parse().expect("KDL parses");
+        let routes_node = doc.get("routes").expect("routes node present");
+        parse_routes(routes_node)
+    }
+
+    #[test]
+    fn match_condition_unknown_name_is_an_error_with_suggestion() {
+        // `path_prefix` (underscore) is the classic typo for `path-prefix`.
+        // Silently dropping it would make the route match everything.
+        let err = parse_routes_from(
+            r#"
+            routes {
+                route "assets" {
+                    matches { path_prefix "/assets" }
+                    upstream "backend"
+                }
+            }
+            "#,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("Route 'assets'"), "missing route id: {err}");
+        assert!(
+            err.contains("unknown match condition 'path_prefix'"),
+            "missing offending name: {err}"
+        );
+        assert!(
+            err.contains("Did you mean 'path-prefix'?"),
+            "missing suggestion: {err}"
+        );
+        assert!(
+            err.contains("path, path-prefix, path-regex, host, header, method, query-param"),
+            "missing valid condition list: {err}"
+        );
+    }
+
+    #[test]
+    fn match_condition_unknown_name_without_close_candidate_lists_valid_names() {
+        let err = parse_routes_from(
+            r#"
+            routes {
+                route "api" {
+                    matches { banana "/api" }
+                    upstream "backend"
+                }
+            }
+            "#,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("unknown match condition 'banana'"), "{err}");
+        assert!(!err.contains("Did you mean"), "{err}");
+        assert!(err.contains("Valid match conditions are:"), "{err}");
+    }
+
+    #[test]
+    fn match_condition_missing_value_is_an_error() {
+        let err = parse_routes_from(
+            r#"
+            routes {
+                route "api" {
+                    matches { path-prefix }
+                    upstream "backend"
+                }
+            }
+            "#,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("Route 'api'"), "{err}");
+        assert!(
+            err.contains("match condition 'path-prefix' is missing its value"),
+            "{err}"
+        );
+        assert!(
+            err.contains("path-prefix \"/api\""),
+            "missing example: {err}"
+        );
+    }
+
+    #[test]
+    fn match_condition_non_string_value_is_an_error() {
+        let err = parse_routes_from(
+            r#"
+            routes {
+                route "api" {
+                    matches { method 42 }
+                    upstream "backend"
+                }
+            }
+            "#,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(
+            err.contains("match condition 'method' has a non-string value 42"),
+            "{err}"
+        );
+        assert!(err.contains("method \"GET\""), "missing example: {err}");
+    }
+
+    #[test]
+    fn match_condition_valid_forms_still_parse() {
+        let routes = parse_routes_from(
+            r#"
+            routes {
+                route "kitchen-sink" {
+                    matches {
+                        path "/exact"
+                        path-prefix "/api"
+                        path-regex "^/v[0-9]+/"
+                        host "*.example.com"
+                        header "x-version" "2"
+                        header "x-flag"
+                        method "GET"
+                        query-param "debug" "true"
+                        query-param "trace"
+                    }
+                    upstream "backend"
+                }
+            }
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].matches.len(), 9);
+        assert!(matches!(
+            routes[0].matches[4],
+            MatchCondition::Header { ref name, ref value } if name == "x-version" && value.as_deref() == Some("2")
+        ));
+        assert!(matches!(
+            routes[0].matches[5],
+            MatchCondition::Header { ref name, ref value } if name == "x-flag" && value.is_none()
+        ));
+        assert!(matches!(
+            routes[0].matches[8],
+            MatchCondition::QueryParam { ref name, ref value } if name == "trace" && value.is_none()
+        ));
+    }
+
+    #[test]
+    fn shadow_percentage_rejects_non_numeric_string() {
+        // Previously `percentage "lots"` silently became 100% mirroring.
+        let err = parse_routes_from(
+            r#"
+            routes {
+                route "api" {
+                    matches { path-prefix "/" }
+                    upstream "backend"
+                    shadow {
+                        upstream "canary"
+                        percentage "lots"
+                    }
+                }
+            }
+            "#,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(
+            err.contains("Shadow 'percentage' has invalid value \"lots\""),
+            "{err}"
+        );
+        assert!(err.contains("between 0 and 100"), "{err}");
+    }
+
+    #[test]
+    fn shadow_percentage_rejects_out_of_range_values() {
+        let err = parse_routes_from(
+            r#"
+            routes {
+                route "api" {
+                    matches { path-prefix "/" }
+                    upstream "backend"
+                    shadow {
+                        upstream "canary"
+                        percentage 150
+                    }
+                }
+            }
+            "#,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(
+            err.contains("Shadow 'percentage' is 150 but must be between 0 and 100"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn shadow_percentage_accepts_numeric_forms() {
+        let routes = parse_routes_from(
+            r#"
+            routes {
+                route "int-pct" {
+                    matches { path-prefix "/" }
+                    upstream "backend"
+                    shadow { upstream "canary"; percentage 50 }
+                }
+            }
+            "#,
+        )
+        .unwrap();
+        assert_eq!(routes[0].shadow.as_ref().unwrap().percentage, 50.0);
+
+        // Float form was previously (silently) ignored and became 100.0.
+        let routes = parse_routes_from(
+            r#"
+            routes {
+                route "float-pct" {
+                    matches { path-prefix "/" }
+                    upstream "backend"
+                    shadow { upstream "canary"; percentage 12.5 }
+                }
+            }
+            "#,
+        )
+        .unwrap();
+        assert_eq!(routes[0].shadow.as_ref().unwrap().percentage, 12.5);
+
+        let routes = parse_routes_from(
+            r#"
+            routes {
+                route "string-pct" {
+                    matches { path-prefix "/" }
+                    upstream "backend"
+                    shadow { upstream "canary"; percentage "75" }
+                }
+            }
+            "#,
+        )
+        .unwrap();
+        assert_eq!(routes[0].shadow.as_ref().unwrap().percentage, 75.0);
     }
 }


### PR DESCRIPTION
Addresses #112, and part of #113.

## Before

Route match conditions failed unhelpfully in three ways:

- A **missing value** (`path-prefix` with no argument) fell through to a generic parse failure with no indication of which route or condition was at fault.
- A **non-string value** (`method 8080`) did the same.
- An **unknown condition name** (`path_prefix` instead of `path-prefix`) was reported without naming the route or listing valid names.

## After

```
Route 'api': match condition 'path-prefix' is missing its value.
Expected a quoted string, e.g., path-prefix "/api"

Route 'api': unknown match condition 'path_prefix'. Did you mean 'path-prefix'?
Valid match conditions are: path, path-prefix, path-regex, host, header, method, query-param
```

The suggestion uses an optimal-string-alignment edit distance, so an adjacent transposition (`hots` → `host`) counts as a single edit — the way config keys are actually mistyped. The tolerance scales with input length (1–3 edits) so short names don't collect nonsense suggestions. The same helper now backs the unknown-top-level-block error, which also gained `include` in its valid list (it is accepted at the top level but was missing from the message).

Also: `shadow` percentages are validated rather than silently coerced — a non-numeric string or an out-of-range value is rejected instead of quietly becoming something else.

## Behaviour change

Match conditions with a missing or non-string value are now a **hard error** rather than being skipped. That is deliberate and matches the direction set by #311: a route silently dropping a match condition is a route that matches more traffic than its author intended. It could reject a config that previously loaded — but any such config was not doing what it looked like it was doing.

## Tests

Covers each new error path, the valid forms that must keep parsing (including the two-argument `header`/`query-param` forms), the shadow-percentage cases, and the edit-distance helper itself. 213 tests pass in `zentinel-config`.

## Note on #113

This carries the validation half (#112). #113 asks for route-matching edge-case tests — prefix/exact/wildcard collisions, trailing slashes, percent-encoding, precedence ordering — which belong next to the matcher in `crates/proxy`, not the parser. Not covered here; #113 should stay open.