### PR TITLE
fix(acme): retry transient ACME errors with backoff and scope keep-ready to renewals

### DIFF
--- a/crates/proxy/src/acme/client.rs
+++ b/crates/proxy/src/acme/client.rs
@@ -22,7 +22,7 @@ use tracing::{debug, error, info, trace, warn};
 use zentinel_config::server::AcmeConfig;
 
 use super::dns::challenge::{create_challenge_info, Dns01ChallengeInfo};
-use super::error::AcmeError;
+use super::error::{is_retryable_acme_error, AcmeError, ACME_RETRY_BACKOFF, ACME_RETRY_MAX};
 use super::storage::{CertificateStorage, StoredAccountCredentials};
 
 /// Let's Encrypt production directory URL
@@ -34,6 +34,38 @@ const LETSENCRYPT_STAGING: &str = "https://acme-staging-v02.api.letsencrypt.org/
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
 /// Timeout for challenge validation
 const CHALLENGE_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Retry transient ACME transport failures with exponential backoff.
+///
+/// Note on `create_order` retries: a retry creates a new ACME Order;
+/// the previous `pending` order is left to expire by the CA. This is
+/// harmless (CA auto-expires pending orders) and `429 rateLimited` is
+/// explicitly non-retryable, so quota is not burned.
+async fn retry_acme<F, Fut, T>(mut op: F) -> Result<T, AcmeError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, AcmeError>>,
+{
+    let mut backoff = ACME_RETRY_BACKOFF;
+    for attempt in 0..ACME_RETRY_MAX {
+        match op().await {
+            Ok(v) => return Ok(v),
+            Err(e) if is_retryable_acme_error(&e) && attempt + 1 < ACME_RETRY_MAX => {
+                tracing::info!(
+                    attempt = attempt + 1,
+                    max_retries = ACME_RETRY_MAX,
+                    backoff_secs = backoff.as_secs(),
+                    error = %e,
+                    "ACME transient failure, retrying"
+                );
+                tokio::time::sleep(backoff).await;
+                backoff = backoff.saturating_mul(2);
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    unreachable!("retry loop always returns")
+}
 
 /// ACME client for automatic certificate management
 ///
@@ -93,6 +125,10 @@ impl AcmeClient {
     ///
     /// Returns an error if account creation or loading fails.
     pub async fn init_account(&self) -> Result<(), AcmeError> {
+        retry_acme(|| async { self.init_account_once().await }).await
+    }
+
+    async fn init_account_once(&self) -> Result<(), AcmeError> {
         // Check for existing account credentials (stored as JSON)
         if let Some(creds_json) = self.storage.load_credentials_json()? {
             info!("Loading existing ACME account from storage");
@@ -171,6 +207,10 @@ impl AcmeClient {
     /// A tuple of (Order, Vec<`ChallengeInfo`>) containing the order and
     /// HTTP-01 challenge information for each domain.
     pub async fn create_order(&self) -> Result<(Order, Vec<ChallengeInfo>), AcmeError> {
+        retry_acme(|| async { self.create_order_once().await }).await
+    }
+
+    async fn create_order_once(&self) -> Result<(Order, Vec<ChallengeInfo>), AcmeError> {
         let account_guard = self.account.read().await;
         let account = account_guard.as_ref().ok_or(AcmeError::NoAccount)?;
 
@@ -241,6 +281,10 @@ impl AcmeClient {
     /// A tuple of (Order, Vec<`Dns01ChallengeInfo`>) containing the order and
     /// DNS-01 challenge information for each domain.
     pub async fn create_order_dns01(&self) -> Result<(Order, Vec<Dns01ChallengeInfo>), AcmeError> {
+        retry_acme(|| async { self.create_order_dns01_once().await }).await
+    }
+
+    async fn create_order_dns01_once(&self) -> Result<(Order, Vec<Dns01ChallengeInfo>), AcmeError> {
         let account_guard = self.account.read().await;
         let account = account_guard.as_ref().ok_or(AcmeError::NoAccount)?;
 
@@ -401,6 +445,35 @@ impl AcmeClient {
         &self,
         order: &mut Order,
     ) -> Result<(String, String, DateTime<Utc>), AcmeError> {
+        // retry_acme cannot hold &mut Order across the FnMut boundary
+        // (E0658: async block escapes with borrowed &mut). Keep the
+        // retry loop inline for this &mut case — same policy as
+        // retry_acme (ACME_RETRY_MAX / BACKOFF + is_retryable).
+        let mut backoff = ACME_RETRY_BACKOFF;
+        for attempt in 0..ACME_RETRY_MAX {
+            match self.finalize_order_once(order).await {
+                Ok(v) => return Ok(v),
+                Err(e) if is_retryable_acme_error(&e) && attempt + 1 < ACME_RETRY_MAX => {
+                    tracing::info!(
+                        attempt = attempt + 1,
+                        max_retries = ACME_RETRY_MAX,
+                        backoff_secs = backoff.as_secs(),
+                        error = %e,
+                        "ACME transient failure, retrying"
+                    );
+                    tokio::time::sleep(backoff).await;
+                    backoff = backoff.saturating_mul(2);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        unreachable!("retry loop always returns")
+    }
+
+    async fn finalize_order_once(
+        &self,
+        order: &mut Order,
+    ) -> Result<(String, String, DateTime<Utc>), AcmeError> {
         info!("Finalizing certificate order");
 
         // Map config key type to rcgen signature algorithm
@@ -462,7 +535,7 @@ impl AcmeClient {
                             "Timed out waiting for certificate".to_string(),
                         ));
                     }
-                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    tokio::time::sleep(ACME_RETRY_BACKOFF).await;
                 }
             }
         };

--- a/crates/proxy/src/acme/client.rs
+++ b/crates/proxy/src/acme/client.rs
@@ -128,6 +128,18 @@ impl AcmeClient {
         retry_acme(|| async { self.init_account_once().await }).await
     }
 
+    /// Ensure ACME account is initialized, initializing if needed.
+    ///
+    /// Used by `RenewalScheduler` to lazily recover after a transient
+    /// `init_account` failure that was deferred to background during
+    /// startup. If the account is already present the call is a no-op.
+    pub async fn ensure_account(&self) -> Result<(), AcmeError> {
+        if self.account.read().await.is_some() {
+            return Ok(());
+        }
+        self.init_account().await
+    }
+
     async fn init_account_once(&self) -> Result<(), AcmeError> {
         // Check for existing account credentials (stored as JSON)
         if let Some(creds_json) = self.storage.load_credentials_json()? {

--- a/crates/proxy/src/acme/error.rs
+++ b/crates/proxy/src/acme/error.rs
@@ -119,8 +119,8 @@ impl From<instant_acme::Error> for AcmeError {
 /// Covers the field-observed proxy cold-start pattern
 /// (`curl` first `35 unexpected eof` then `301`, ACME
 /// `client error (Connect)` / `TLS connect error`) and generic
-/// `hyper`/`transport`/`timeout` failures. Non-transient errors
-/// like auth/rate-limit must fail fast.
+/// transport failures. Non-transient errors like auth/rate-limit
+/// or DNS propagation timeouts must fail fast.
 pub fn is_retryable_acme_error(e: &AcmeError) -> bool {
     // Never retry deterministic errors: storage/config, missing
     // challenges, or polling timeouts (the latter is application-level
@@ -136,6 +136,25 @@ pub fn is_retryable_acme_error(e: &AcmeError) -> bool {
             | AcmeError::CertificateParse(_)
             | AcmeError::Timeout(_)
             | AcmeError::PropagationTimeout { .. }
+    ) {
+        return false;
+    }
+    // DNS provider errors: match variants explicitly instead of via
+    // string matching. `DnsProviderError::Timeout` is the real
+    // propagation timeout (`PropagationTimeout` is never constructed
+    // in practice) and must not be retried; the same string
+    // ("timed out") would otherwise incorrectly mark it retryable.
+    if matches!(
+        e,
+        AcmeError::DnsProvider(
+            DnsProviderError::Timeout { .. }
+                | DnsProviderError::RateLimited { .. }
+                | DnsProviderError::Authentication(_)
+                | DnsProviderError::ZoneNotFound { .. }
+                | DnsProviderError::Configuration(_)
+                | DnsProviderError::Credentials(_)
+                | DnsProviderError::UnsupportedDomain { .. }
+        )
     ) {
         return false;
     }
@@ -191,6 +210,24 @@ mod tests {
         let e = AcmeError::Storage(StorageError::InvalidStructure("x".to_string()));
         assert!(!is_retryable_acme_error(&e));
         let e = AcmeError::AccountCreation("401 Unauthorized".to_string());
+        assert!(!is_retryable_acme_error(&e));
+    }
+
+    #[test]
+    fn test_non_retryable_dns_provider_variants() {
+        let e = AcmeError::DnsProvider(DnsProviderError::Timeout { elapsed_secs: 120 });
+        assert!(!is_retryable_acme_error(&e));
+        // DnsProvider Timeout contains "timed out" but must not be retryable
+        assert!(e.to_string().to_lowercase().contains("timed out"));
+        let e = AcmeError::DnsProvider(DnsProviderError::Authentication("bad token".to_string()));
+        assert!(!is_retryable_acme_error(&e));
+        let e = AcmeError::DnsProvider(DnsProviderError::ZoneNotFound {
+            domain: "example.com".to_string(),
+        });
+        assert!(!is_retryable_acme_error(&e));
+        let e = AcmeError::DnsProvider(DnsProviderError::RateLimited {
+            retry_after_secs: 60,
+        });
         assert!(!is_retryable_acme_error(&e));
     }
 }

--- a/crates/proxy/src/acme/error.rs
+++ b/crates/proxy/src/acme/error.rs
@@ -6,6 +6,14 @@ use thiserror::Error;
 
 use super::dns::DnsProviderError;
 
+/// Maximum retries for transient ACME transport failures.
+///
+/// Shared by `AcmeClient::retry_acme` to avoid drift between
+/// `error` and `client` modules.
+pub const ACME_RETRY_MAX: usize = 3;
+/// Base backoff for the first transient retry (doubles each attempt).
+pub const ACME_RETRY_BACKOFF: Duration = Duration::from_secs(1);
+
 /// Errors that can occur during ACME operations
 #[derive(Debug, Error)]
 pub enum AcmeError {
@@ -103,5 +111,86 @@ impl From<serde_json::Error> for StorageError {
 impl From<instant_acme::Error> for AcmeError {
     fn from(e: instant_acme::Error) -> Self {
         AcmeError::Protocol(e.to_string())
+    }
+}
+
+/// Whether an ACME error is transient and worth retrying.
+///
+/// Covers the field-observed proxy cold-start pattern
+/// (`curl` first `35 unexpected eof` then `301`, ACME
+/// `client error (Connect)` / `TLS connect error`) and generic
+/// `hyper`/`transport`/`timeout` failures. Non-transient errors
+/// like auth/rate-limit must fail fast.
+pub fn is_retryable_acme_error(e: &AcmeError) -> bool {
+    // Never retry deterministic errors: storage/config, missing
+    // challenges, or polling timeouts (the latter is application-level
+    // "wait too long", not a transient transport failure).
+    if matches!(
+        e,
+        AcmeError::Storage(_)
+            | AcmeError::NoAccount
+            | AcmeError::NoHttp01Challenge(_)
+            | AcmeError::NoDns01Challenge(_)
+            | AcmeError::NoDnsProvider
+            | AcmeError::WildcardRequiresDns01 { .. }
+            | AcmeError::CertificateParse(_)
+            | AcmeError::Timeout(_)
+            | AcmeError::PropagationTimeout { .. }
+    ) {
+        return false;
+    }
+    let msg = e.to_string().to_lowercase();
+    // Narrow allowlist: only transport-layer transient failures.
+    // Avoid bare "hyper"/"transport"/"timeout" which also match
+    // application-level timeouts or incidental substrings.
+    msg.contains("client error (connect)")
+        || msg.contains("unexpected eof")
+        || msg.contains("connection reset")
+        || msg.contains("connection closed")
+        || msg.contains("connection aborted")
+        || msg.contains("tls connect error")
+        || msg.contains("timed out")
+        || msg.contains("transport error")
+        || msg.contains("hyper::")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn test_retryable_connect_and_eof() {
+        let e = AcmeError::AccountCreation("client error (Connect)".to_string());
+        assert!(is_retryable_acme_error(&e));
+        let e = AcmeError::Protocol("unexpected eof while reading".to_string());
+        assert!(is_retryable_acme_error(&e));
+        let e = AcmeError::AccountCreation("TLS connect error".to_string());
+        assert!(is_retryable_acme_error(&e));
+    }
+
+    #[test]
+    fn test_retryable_transport_variants() {
+        let e = AcmeError::OrderCreation("connection reset by peer".to_string());
+        assert!(is_retryable_acme_error(&e));
+        let e = AcmeError::OrderCreation("transport error: closed".to_string());
+        assert!(is_retryable_acme_error(&e));
+        let e = AcmeError::Finalization("hyper::Error(ChannelClosed)".to_string());
+        assert!(is_retryable_acme_error(&e));
+    }
+
+    #[test]
+    fn test_non_retryable_timeouts_and_storage() {
+        let e = AcmeError::Timeout("timed out waiting for order".to_string());
+        assert!(!is_retryable_acme_error(&e));
+        let e = AcmeError::PropagationTimeout {
+            record: "_acme-challenge.example.com".to_string(),
+            elapsed: Duration::from_secs(120),
+        };
+        assert!(!is_retryable_acme_error(&e));
+        let e = AcmeError::Storage(StorageError::InvalidStructure("x".to_string()));
+        assert!(!is_retryable_acme_error(&e));
+        let e = AcmeError::AccountCreation("401 Unauthorized".to_string());
+        assert!(!is_retryable_acme_error(&e));
     }
 }

--- a/crates/proxy/src/acme/mod.rs
+++ b/crates/proxy/src/acme/mod.rs
@@ -102,6 +102,6 @@ mod storage;
 
 pub use challenge::ChallengeManager;
 pub use client::AcmeClient;
-pub use error::AcmeError;
+pub use error::{is_retryable_acme_error, AcmeError};
 pub use scheduler::RenewalScheduler;
 pub use storage::CertificateStorage;

--- a/crates/proxy/src/acme/scheduler.rs
+++ b/crates/proxy/src/acme/scheduler.rs
@@ -134,6 +134,18 @@ impl RenewalScheduler {
         // config block are part of the same certificate and stored under the primary domain.
         let domain = &domains[0];
 
+        // Lazily ensure the ACME account exists. When startup deferred
+        // init_account due to a transient error, no account is present
+        // and create_order would return NoAccount forever without this.
+        if let Err(e) = self.client.ensure_account().await {
+            error!(
+                domain = %domain,
+                error = %e,
+                "Failed to ensure ACME account before renewal check"
+            );
+            return Err(e);
+        }
+
         match self.client.needs_renewal(domain) {
             Ok(true) => {
                 info!(domain = %domain, "Certificate needs renewal");

--- a/crates/proxy/src/main.rs
+++ b/crates/proxy/src/main.rs
@@ -470,20 +470,34 @@ async fn initialize_acme(
 
         // Initialize ACME account. init_account already retries transient
         // Connect/TLS EOF with exponential backoff. If it still fails,
-        // keep the proxy ready and let the background RenewalScheduler
-        // retry — matching lego/certbot/caddy. Only non-retryable
-        // errors (auth/rate-limit) abort startup visibly. The pushed
-        // scheduler already carries the DNS manager.
+        // keep the proxy ready only for renewals (cert already present)
+        // and let the background RenewalScheduler retry. For first
+        // issuance (no cert files yet) the listener would remain
+        // unbound because hot-reload only swaps certs on live
+        // listeners, so fail fast instead of deferring silently.
+        let primary_domain_for_account = acme_config.domains.first().cloned();
         if let Err(e) = acme_client.init_account().await {
             use zentinel_proxy::acme::is_retryable_acme_error;
             if is_retryable_acme_error(&e) {
-                tracing::warn!(
+                let has_cert = primary_domain_for_account
+                    .as_deref()
+                    .and_then(|d| storage.certificate_paths(d))
+                    .is_some();
+                if has_cert {
+                    tracing::warn!(
+                        source = %description,
+                        error = %e,
+                        "ACME account init transient failure, proxy will stay ready and retry in background (renewal)"
+                    );
+                    schedulers.push(scheduler);
+                    continue;
+                }
+                tracing::error!(
                     source = %description,
                     error = %e,
-                    "ACME account init transient failure, proxy will stay ready and retry in background"
+                    "ACME account init transient failure during first issuance, failing fast (no cert to serve)"
                 );
-                schedulers.push(scheduler);
-                continue;
+                return Err(e);
             } else {
                 return Err(e);
             }
@@ -495,10 +509,11 @@ async fn initialize_acme(
         })?;
 
         if acme_client.needs_renewal(primary_domain)? {
-            // Initial issuance is best-effort at startup. If the
-            // network is flaky (proxy cold-start), log and defer to
-            // the background scheduler instead of crashing the whole
-            // proxy — matching Caddy/certmagic's async renewal.
+            // Issuance at startup: defer only for renewals (cert
+            // already present). First issuance with no cert files
+            // cannot be deferred — the HTTPS listener is skipped when
+            // cert files are absent (ACME certificate files not found,
+            // continue) and hot-reload never re-adds a listener.
             let issuance_result: Result<(), AcmeError> = async {
                 info!(
                     source = %description,
@@ -539,12 +554,23 @@ async fn initialize_acme(
             if let Err(e) = issuance_result {
                 use zentinel_proxy::acme::is_retryable_acme_error;
                 if is_retryable_acme_error(&e) {
-                    tracing::warn!(
-                        source = %description,
-                        domain = %primary_domain,
-                        error = %e,
-                        "Initial ACME issuance transient failure, deferring to background renewal"
-                    );
+                    let has_cert = storage.certificate_paths(primary_domain).is_some();
+                    if has_cert {
+                        tracing::warn!(
+                            source = %description,
+                            domain = %primary_domain,
+                            error = %e,
+                            "Initial ACME renewal transient failure, deferring to background renewal"
+                        );
+                    } else {
+                        tracing::error!(
+                            source = %description,
+                            domain = %primary_domain,
+                            error = %e,
+                            "Initial ACME issuance transient failure during first issuance, failing fast (no cert to serve)"
+                        );
+                        return Err(e);
+                    }
                 } else {
                     return Err(e);
                 }

--- a/crates/proxy/src/main.rs
+++ b/crates/proxy/src/main.rs
@@ -426,11 +426,11 @@ async fn initialize_acme(
         // Create storage
         let storage = Arc::new(CertificateStorage::new(&acme_config.storage)?);
 
-        // Create client and initialize account
+        // Create client and renewal scheduler first so that even if
+        // init_account transiently fails, the pushed scheduler already
+        // carries the DNS manager and the background RenewalScheduler can
+        // retry with full context.
         let acme_client = Arc::new(AcmeClient::new(acme_config.clone(), Arc::clone(&storage)));
-        acme_client.init_account().await?;
-
-        // Create renewal scheduler
         let mut scheduler = RenewalScheduler::new(
             Arc::clone(&acme_client),
             Arc::clone(&challenge_manager),
@@ -468,58 +468,85 @@ async fn initialize_acme(
             }
         }
 
+        // Initialize ACME account. init_account already retries transient
+        // Connect/TLS EOF with exponential backoff. If it still fails,
+        // keep the proxy ready and let the background RenewalScheduler
+        // retry — matching lego/certbot/caddy. Only non-retryable
+        // errors (auth/rate-limit) abort startup visibly. The pushed
+        // scheduler already carries the DNS manager.
+        if let Err(e) = acme_client.init_account().await {
+            use zentinel_proxy::acme::is_retryable_acme_error;
+            if is_retryable_acme_error(&e) {
+                tracing::warn!(
+                    source = %description,
+                    error = %e,
+                    "ACME account init transient failure, proxy will stay ready and retry in background"
+                );
+                schedulers.push(scheduler);
+                continue;
+            } else {
+                return Err(e);
+            }
+        }
+
         // Check if initial certificate issuance is needed
         let primary_domain = acme_config.domains.first().ok_or_else(|| {
             AcmeError::OrderCreation(format!("No domains configured for ACME in {}", description))
         })?;
 
         if acme_client.needs_renewal(primary_domain)? {
-            info!(
-                source = %description,
-                domain = %primary_domain,
-                "Initial certificate issuance required"
-            );
-
-            match acme_config.challenge_type {
-                AcmeChallengeType::Http01 => {
-                    // Find an HTTP listener address for the temporary challenge server
-                    let http_addr = config
-                        .listeners
-                        .iter()
-                        .find(|l| l.protocol == zentinel_config::ListenerProtocol::Http)
-                        .map(|l| l.address.clone())
-                        .unwrap_or_else(|| "0.0.0.0:80".to_string());
-
-                    info!(
-                        address = %http_addr,
-                        "Starting temporary HTTP challenge server for initial certificate acquisition"
-                    );
-
-                    // Start temporary challenge server
-                    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
-                    let cm_clone = Arc::clone(&challenge_manager);
-                    let _server_handle = tokio::spawn(async move {
-                        zentinel_proxy::acme::challenge_server::run_challenge_server(
-                            &http_addr,
-                            cm_clone,
-                            shutdown_rx,
-                        )
-                        .await
-                    });
-
-                    // Give the server a moment to bind
-                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-
-                    // Obtain certificates
-                    let result = scheduler.ensure_certificates().await;
-
-                    // Shut down temporary server
-                    let _ = shutdown_tx.send(true);
-                    result?;
+            // Initial issuance is best-effort at startup. If the
+            // network is flaky (proxy cold-start), log and defer to
+            // the background scheduler instead of crashing the whole
+            // proxy — matching Caddy/certmagic's async renewal.
+            let issuance_result: Result<(), AcmeError> = async {
+                info!(
+                    source = %description,
+                    domain = %primary_domain,
+                    "Initial certificate issuance required"
+                );
+                match acme_config.challenge_type {
+                    AcmeChallengeType::Http01 => {
+                        let http_addr = config
+                            .listeners
+                            .iter()
+                            .find(|l| l.protocol == zentinel_config::ListenerProtocol::Http)
+                            .map(|l| l.address.clone())
+                            .unwrap_or_else(|| "0.0.0.0:80".to_string());
+                        info!(
+                            address = %http_addr,
+                            "Starting temporary HTTP challenge server for initial certificate acquisition"
+                        );
+                        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+                        let cm_clone = Arc::clone(&challenge_manager);
+                        let _server_handle = tokio::spawn(async move {
+                            zentinel_proxy::acme::challenge_server::run_challenge_server(
+                                &http_addr,
+                                cm_clone,
+                                shutdown_rx,
+                            )
+                            .await
+                        });
+                        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                        let result = scheduler.ensure_certificates().await;
+                        let _ = shutdown_tx.send(true);
+                        result
+                    }
+                    AcmeChallengeType::Dns01 => scheduler.ensure_certificates().await,
                 }
-                AcmeChallengeType::Dns01 => {
-                    // DNS-01 doesn't need a temporary server
-                    scheduler.ensure_certificates().await?;
+            }
+            .await;
+            if let Err(e) = issuance_result {
+                use zentinel_proxy::acme::is_retryable_acme_error;
+                if is_retryable_acme_error(&e) {
+                    tracing::warn!(
+                        source = %description,
+                        domain = %primary_domain,
+                        error = %e,
+                        "Initial ACME issuance transient failure, deferring to background renewal"
+                    );
+                } else {
+                    return Err(e);
                 }
             }
         }


### PR DESCRIPTION
For `fix/acme-keep-ready-and-retry` — split from `fix/dns01-propagation-and-cloudflare-idempotency` per review:

## Summary

Proxy cold-start on flaky networks (`curl https://google.com` → `TLS connect error: unexpected EOF` then success on retry, ACME `client error (Connect)`) had no retry anywhere. `init_account` / `create_order` / `finalize_order` failed once and aborted startup, even though the failure was transient.

This PR adds bounded transport retry and scopes keep-ready deferral to renewals only. It addresses review points **1, 3, 4** from the DNS-01 PR:

- **1. Recoverable keep-ready:** `AcmeClient::ensure_account()` + `RenewalScheduler::check_renewals` now lazily ensures the account, so a transient `init_account` failure deferred at startup can recover in the background instead of logging `NoAccount` forever.
- **3. Retryability:** `is_retryable_acme_error` matches `AcmeError::DnsProvider` variants explicitly. `DnsProviderError::Timeout` (the real propagation timeout — `PropagationTimeout` is never constructed) is explicitly non-retryable even though its display contains `timed out`.
- **4. First-issuance scoping:** deferral only when cert files already exist (`storage.certificate_paths(domain).is_some()` — renewal). First issuance with no cert files fails fast, avoiding a silently missing HTTPS listener (hot-reload only swaps existing listeners).

Retry is `ACME_RETRY_MAX=3` with `1s/2s` exponential backoff via `retry_acme` (`init_account`/`create_order`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Manifesto Alignment

- [x] **Bounded** — `ACME_RETRY_MAX=3`, `ACME_RETRY_BACKOFF=1s` (→ 1s/2s), storage/config timeouts unchanged
- [x] **Observable** — `INFO` retry, `WARN` deferral (renewal) / `ERROR` fail-fast (first issuance), `ensure_account` failure logged in scheduler
- [x] **Fails safely** — deterministic errors (auth/rate-limit/`Timeout`/`PropagationTimeout`/`ZoneNotFound`/storage) never retried; deferral never hides a missing listener
- [x] **No implicit behavior** — retry and scoping are explicit in logs and code, no config-hidden fallback

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have read the [design rationale documents](doc/design/) and my changes align with existing architectural decisions
- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally
- [x] I have updated documentation (if applicable)
  - [ ] Crate `docs/` updated
  - [ ] [Docs site](https://github.com/zentinelproxy/zentinelproxy.io-docs) PR opened (if user-visible)

## Testing

Split from `fix/dns01-propagation-and-cloudflare-idempotency` (points 2/5 there, 1/3/4 here). Rebased onto `origin/main` `0464d8c`.

```bash
cargo fmt --all --check
cargo check -p zentinel-proxy
cargo test -p zentinel-proxy --lib acme::error::tests
cargo test --workspace --jobs 2
```

New coverage: `is_retryable_acme_error` non-retryable `DnsProvider::Timeout` with `timed out` string, plus `AcmeError::Timeout`/`PropagationTimeout`/storage cases.

## Related Issues

Split from `fix/dns01-propagation-and-cloudflare-idempotency` addressing review **1, 3, 4**. Relates to DNS-01 propagation hang observed on `curious.host` / `*.curious.host` where cold-start `client error (Connect)` triggered the keep-ready path.
