### PR TITLE
chore: bump version to 0.6.25 for release 26.08_2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8259,7 +8259,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.24"
+version = "0.6.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8299,7 +8299,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.24"
+version = "0.6.25"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8321,7 +8321,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.24"
+version = "0.6.25"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8400,7 +8400,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.24"
+version = "0.6.25"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8431,7 +8431,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.24"
+version = "0.6.25"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8522,7 +8522,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.24"
+version = "0.6.25"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8539,7 +8539,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.24"
+version = "0.6.25"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.24"
+version = "0.6.25"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Post-release version bump for **26.08_2**, which published crate 0.6.25.

The release workflow tries to push this straight to `main`; branch protection blocks it, so it leaves the branch behind without a PR (`release.yml` has a "Create PR for version bump if push was blocked" step, but the branch was still sitting there unopened). Opening it manually.

## Two commits

1. **`789fccd`** — the workflow's own bump: `Cargo.toml` 0.6.24 → 0.6.25.
2. **`4cf1fab`** — `Cargo.lock` for the same. The workflow bumps only the manifest, so the committed lockfile still recorded 0.6.24 for all seven workspace crates while the manifest said 0.6.25. CI does not pass `--locked`, so nothing fails loudly and cargo silently re-resolves — but anyone doing a reproducible or vendored build hits the mismatch. (Same defect recently fixed in `zentinel-agent-rust-sdk`.)

`cargo update -w` touched exactly the seven workspace member versions and no dependencies. Verified with `cargo check --workspace --locked`.

Worth considering as a follow-up: have the release workflow run `cargo update -w` alongside its `Cargo.toml` edit, so the lockfile never drifts on a release.