### PR TITLE
feat(tls): serve per-SNI certificates and enforce TLS settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,9 +5,9 @@ version = 4
 [[package]]
 name = "TinyUFO"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=b8d0c00#b8d0c006629cfb91a64f0749a7d260d5bc0be31f"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "crossbeam-queue",
  "crossbeam-skiplist",
  "flurry",
@@ -46,6 +46,17 @@ dependencies = [
  "cipher",
  "cpubits",
  "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
 ]
 
 [[package]]
@@ -1854,7 +1865,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf5efcf77a4da27927d3ab0509dec5b0954bb3bc59da5a1de9e52642ebd4cdf9"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "num_cpus",
  "parking_lot",
  "seize",
@@ -2222,6 +2233,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3064,7 +3078,7 @@ version = "0.49.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ec8a241beed129f06114aa68007e905ca350e7baeb6e17a7631bb7978d91b2"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bytecount",
  "data-encoding",
  "email_address",
@@ -3104,7 +3118,7 @@ version = "0.49.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ec7637f83e510868ae6ed625f7ebfbbde4554ee8ce49854caa5126a8b9b9ecb"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bytecount",
  "fraction",
  "num-cmp",
@@ -3244,7 +3258,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c072737075826ee74d3e615e80334e41e617ca3d14fb46ef7cdfda822d6f15f2"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "async-broadcast",
  "async-stream",
  "backon",
@@ -4261,7 +4275,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 [[package]]
 name = "pingora"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=b8d0c00#b8d0c006629cfb91a64f0749a7d260d5bc0be31f"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
 dependencies = [
  "pingora-cache",
  "pingora-core",
@@ -4274,9 +4288,9 @@ dependencies = [
 [[package]]
 name = "pingora-cache"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=b8d0c00#b8d0c006629cfb91a64f0749a7d260d5bc0be31f"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "async-trait",
  "blake2",
  "bstr",
@@ -4310,9 +4324,9 @@ dependencies = [
 [[package]]
 name = "pingora-core"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=b8d0c00#b8d0c006629cfb91a64f0749a7d260d5bc0be31f"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "async-trait",
  "brotli 3.5.0",
  "bstr",
@@ -4348,7 +4362,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "sfv",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tokio",
@@ -4363,12 +4377,12 @@ dependencies = [
 [[package]]
 name = "pingora-error"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=b8d0c00#b8d0c006629cfb91a64f0749a7d260d5bc0be31f"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
 
 [[package]]
 name = "pingora-header-serde"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=b8d0c00#b8d0c006629cfb91a64f0749a7d260d5bc0be31f"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
 dependencies = [
  "bytes",
  "http 1.5.0",
@@ -4383,7 +4397,7 @@ dependencies = [
 [[package]]
 name = "pingora-http"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=b8d0c00#b8d0c006629cfb91a64f0749a7d260d5bc0be31f"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
 dependencies = [
  "bytes",
  "http 1.5.0",
@@ -4393,7 +4407,7 @@ dependencies = [
 [[package]]
 name = "pingora-ketama"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=b8d0c00#b8d0c006629cfb91a64f0749a7d260d5bc0be31f"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
 dependencies = [
  "crc32fast",
 ]
@@ -4401,15 +4415,15 @@ dependencies = [
 [[package]]
 name = "pingora-limits"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=b8d0c00#b8d0c006629cfb91a64f0749a7d260d5bc0be31f"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
 ]
 
 [[package]]
 name = "pingora-load-balancing"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=b8d0c00#b8d0c006629cfb91a64f0749a7d260d5bc0be31f"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4430,10 +4444,10 @@ dependencies = [
 [[package]]
 name = "pingora-lru"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=b8d0c00#b8d0c006629cfb91a64f0749a7d260d5bc0be31f"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
 dependencies = [
  "arrayvec",
- "hashbrown 0.17.0",
+ "hashbrown 0.12.3",
  "parking_lot",
  "rand 0.8.6",
 ]
@@ -4441,10 +4455,10 @@ dependencies = [
 [[package]]
 name = "pingora-memory-cache"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=b8d0c00#b8d0c006629cfb91a64f0749a7d260d5bc0be31f"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
 dependencies = [
  "TinyUFO",
- "ahash",
+ "ahash 0.8.12",
  "async-trait",
  "log",
  "parking_lot",
@@ -4456,7 +4470,7 @@ dependencies = [
 [[package]]
 name = "pingora-pool"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=b8d0c00#b8d0c006629cfb91a64f0749a7d260d5bc0be31f"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
 dependencies = [
  "crossbeam-queue",
  "log",
@@ -4470,7 +4484,7 @@ dependencies = [
 [[package]]
 name = "pingora-proxy"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=b8d0c00#b8d0c006629cfb91a64f0749a7d260d5bc0be31f"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4492,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "pingora-runtime"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=b8d0c00#b8d0c006629cfb91a64f0749a7d260d5bc0be31f"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
 dependencies = [
  "once_cell",
  "rand 0.8.6",
@@ -4503,7 +4517,7 @@ dependencies = [
 [[package]]
 name = "pingora-rustls"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=b8d0c00#b8d0c006629cfb91a64f0749a7d260d5bc0be31f"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
 dependencies = [
  "log",
  "no_debug",
@@ -4519,7 +4533,7 @@ dependencies = [
 [[package]]
 name = "pingora-timeout"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=b8d0c00#b8d0c006629cfb91a64f0749a7d260d5bc0be31f"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
 dependencies = [
  "once_cell",
  "parking_lot",
@@ -5165,7 +5179,7 @@ version = "0.49.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6efa2154ea6f5ce0fdecdd2a8d18f2fa1a39a8fbba91564f555a592e4dce8278"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "fluent-uri",
  "getrandom 0.3.4",
  "hashbrown 0.17.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,15 +30,15 @@ rust-version = "1.95.0"
 
 [workspace.dependencies]
 # Core dependencies (using our fork with security fixes, rebased on 0.8.1)
-pingora = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "b8d0c00", features = ["proxy", "lb", "rustls"] }
-pingora-core = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "b8d0c00", features = ["rustls"] }
-pingora-http = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "b8d0c00" }
-pingora-proxy = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "b8d0c00" }
-pingora-load-balancing = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "b8d0c00" }
-pingora-timeout = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "b8d0c00" }
-pingora-limits = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "b8d0c00" }
-pingora-cache = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "b8d0c00" }
-pingora-memory-cache = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "b8d0c00" }
+pingora = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "ffaf897", features = ["proxy", "lb", "rustls"] }
+pingora-core = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "ffaf897", features = ["rustls"] }
+pingora-http = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "ffaf897" }
+pingora-proxy = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "ffaf897" }
+pingora-load-balancing = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "ffaf897" }
+pingora-timeout = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "ffaf897" }
+pingora-limits = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "ffaf897" }
+pingora-cache = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "ffaf897" }
+pingora-memory-cache = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "ffaf897" }
 
 # Async runtime
 # Minimal feature set for proxy workloads (trimmed from "full" for smaller binary)
@@ -127,4 +127,3 @@ debug = true
 [profile.bench]
 opt-level = 3
 debug = false
-

--- a/crates/proxy/src/main.rs
+++ b/crates/proxy/src/main.rs
@@ -26,7 +26,7 @@ use zentinel_proxy::acme::{
     AcmeClient, AcmeError, CertificateStorage, ChallengeManager, RenewalScheduler,
 };
 use zentinel_proxy::bundle::{run_bundle_command, BundleArgs};
-use zentinel_proxy::tls::HotReloadableSniResolver;
+use zentinel_proxy::tls::{self, CertificateReloader, HotReloadableSniResolver};
 use zentinel_proxy::{ReloadTrigger, SignalManager, SignalType, ZentinelProxy};
 
 /// Version string combining Cargo semver and CalVer release tag
@@ -793,6 +793,10 @@ fn run_server(
         .server_options(server_options)
         .build();
 
+    // Tracks the certificate resolver of every TLS listener, so SIGHUP can
+    // refresh certificates from disk without restarting the process.
+    let cert_reloader = Arc::new(CertificateReloader::new());
+
     // Configure listening addresses from config
     for listener in &config.listeners {
         match listener.protocol {
@@ -875,15 +879,47 @@ fn run_server(
                             continue;
                         }
 
-                        // TODO: Once the Pingora fork's TlsSettings supports accepting
-                        // a pre-built rustls::ServerConfig, use tls::build_server_config()
-                        // here to apply cipher_suites, min/max_version, and session_resumption.
-                        // Currently Pingora's TlsSettings::build() creates its own ServerConfig
-                        // with hardcoded defaults, ignoring our TLS hardening settings.
+                        // Build the certificate resolver first and keep a handle
+                        // on it. The resolver installed in the ServerConfig has
+                        // to be the same object the reloader refreshes, or a
+                        // reload updates something no live connection consults.
+                        let sni_resolver = match HotReloadableSniResolver::from_config(
+                            tls_config.clone(),
+                            listener.id.clone(),
+                        ) {
+                            Ok(r) => Arc::new(r),
+                            Err(e) => {
+                                error!(
+                                    listener_id = %listener.id,
+                                    error = %e,
+                                    "Failed to load TLS certificates for listener"
+                                );
+                                continue;
+                            }
+                        };
+
+                        // Everything the operator configured -- SNI certificates,
+                        // client auth, protocol versions, cipher suites, session
+                        // resumption -- is expressed here and handed to the
+                        // listener as a complete rustls ServerConfig.
+                        let server_config = match tls::build_server_config_with_resolver(
+                            tls_config,
+                            sni_resolver.clone(),
+                        ) {
+                            Ok(c) => c,
+                            Err(e) => {
+                                error!(
+                                    listener_id = %listener.id,
+                                    error = %e,
+                                    "Failed to build TLS configuration for listener"
+                                );
+                                continue;
+                            }
+                        };
+
                         let mut tls_settings =
-                            match pingora::listeners::tls::TlsSettings::intermediate(
-                                &cert_path_str,
-                                &key_path_str,
+                            match pingora::listeners::tls::TlsSettings::with_server_config(
+                                server_config,
                             ) {
                                 Ok(s) => s,
                                 Err(e) => {
@@ -897,53 +933,7 @@ fn run_server(
                             };
                         tls_settings.enable_h2();
 
-                        // Until the Pingora fork accepts a pre-built rustls
-                        // ServerConfig (see TODO above and issue #303), settings
-                        // beyond the primary certificate are parsed but never
-                        // reach the listener. Say so loudly instead of letting
-                        // the config imply protections that are not active.
-                        if !tls_config.additional_certs.is_empty() {
-                            warn!(
-                                listener_id = %listener.id,
-                                sni_cert_count = tls_config.additional_certs.len(),
-                                "SNI certificates are configured but NOT served: \
-                                 per-SNI certificate selection is not wired into \
-                                 the TLS listener yet (issue #303). All clients \
-                                 receive the primary certificate."
-                            );
-                        }
-                        if tls_config.client_auth {
-                            warn!(
-                                listener_id = %listener.id,
-                                "SECURITY: client-auth (mTLS) is configured but \
-                                 NOT enforced: the listener does not request or \
-                                 verify client certificates (issue #303). Do not \
-                                 rely on mTLS for this listener."
-                            );
-                        }
-                        let mut unapplied: Vec<&str> = Vec::new();
-                        if tls_config.min_version != zentinel_common::types::TlsVersion::Tls12 {
-                            unapplied.push("min-version");
-                        }
-                        if tls_config.max_version.is_some() {
-                            unapplied.push("max-version");
-                        }
-                        if !tls_config.cipher_suites.is_empty() {
-                            unapplied.push("cipher-suite");
-                        }
-                        if !tls_config.session_resumption {
-                            unapplied.push("session-resumption");
-                        }
-                        if !unapplied.is_empty() {
-                            warn!(
-                                listener_id = %listener.id,
-                                settings = ?unapplied,
-                                "TLS hardening settings are configured but NOT \
-                                 applied: the listener uses Pingora's built-in \
-                                 intermediate profile (TLS 1.2+, default cipher \
-                                 suites) until issue #303 is resolved."
-                            );
-                        }
+                        cert_reloader.register(&listener.id, sni_resolver);
 
                         proxy_service.add_tls_with_settings(&listener.address, None, tls_settings);
                         info!(
@@ -951,6 +941,8 @@ fn run_server(
                             address = %listener.address,
                             cert_file = %cert_path_str,
                             acme_enabled = tls_config.acme.is_some(),
+                            sni_cert_count = tls_config.additional_certs.len(),
+                            client_auth = tls_config.client_auth,
                             "HTTPS (h2+http/1.1) listening on: {}", listener.address
                         );
                     }
@@ -1005,8 +997,9 @@ fn run_server(
 
     // Spawn signal handler task in the runtime
     let signal_manager_clone = signal_manager.clone();
+    let cert_reloader_clone = cert_reloader.clone();
     runtime.spawn(async move {
-        run_signal_handler(signal_manager_clone, config_manager).await;
+        run_signal_handler(signal_manager_clone, config_manager, cert_reloader_clone).await;
     });
 
     info!("Zentinel proxy started successfully");
@@ -1101,6 +1094,7 @@ fn create_default_config_file(path: &std::path::Path) -> Result<()> {
 async fn run_signal_handler(
     signal_manager: Arc<SignalManager>,
     config_manager: Arc<zentinel_proxy::ConfigManager>,
+    cert_reloader: Arc<CertificateReloader>,
 ) {
     loop {
         // Use spawn_blocking to wait for signals without blocking the async runtime
@@ -1119,6 +1113,27 @@ async fn run_signal_handler(
                         error!("Configuration reload failed: {}", e);
                         error!("Continuing with previous configuration");
                     }
+                }
+
+                // Certificates are reloaded independently of the configuration:
+                // a renewed certificate changes the file on disk without
+                // changing a byte of config, so a config reload alone would
+                // never pick it up. A listener whose reload fails keeps serving
+                // its previous certificate.
+                let (reloaded, failures) = cert_reloader.reload_all();
+                for (listener_id, e) in &failures {
+                    error!(
+                        listener_id = %listener_id,
+                        error = %e,
+                        "TLS certificate reload failed, keeping previous certificates"
+                    );
+                }
+                if reloaded > 0 || !failures.is_empty() {
+                    info!(
+                        reloaded = reloaded,
+                        failed = failures.len(),
+                        "TLS certificates reloaded"
+                    );
                 }
             }
             Ok(Some(SignalType::Shutdown)) => {

--- a/crates/proxy/src/tls.rs
+++ b/crates/proxy/src/tls.rs
@@ -1531,20 +1531,30 @@ fn resolve_cipher_suites(names: &[String]) -> Result<Vec<rustls::SupportedCipher
 /// Applies protocol versions, cipher suites, session resumption, mTLS,
 /// and SNI certificate resolution from the Zentinel TLS config.
 ///
-/// # Note
-///
-/// This ServerConfig is fully configured but currently not used by
-/// Pingora's listener infrastructure. Pingora's rustls `TlsSettings`
-/// builds its own `ServerConfig` internally with hardcoded defaults.
-/// A future update to the Pingora fork should accept a pre-built
-/// `ServerConfig` via `TlsSettings`, at which point this function's
-/// output will be wired into the listener setup.
+/// The certificate resolver is built fresh from `config` and never changes
+/// afterwards. Use [`build_server_config_with_resolver`] to supply a
+/// [`HotReloadableSniResolver`] instead, so that certificates reloaded from
+/// disk are picked up by connections already being served.
 pub fn build_server_config(
     config: &TlsConfig,
     listener_id: &str,
 ) -> Result<ServerConfig, TlsError> {
     let resolver = SniResolver::from_config(config, Some(listener_id))?;
+    build_server_config_with_resolver(config, Arc::new(resolver))
+}
 
+/// Build a TLS ServerConfig around a caller-supplied certificate resolver.
+///
+/// Everything except certificate selection still comes from `config`:
+/// protocol versions, cipher suites, client authentication and session
+/// resumption. Separating the resolver lets the caller keep a handle on it,
+/// which is what makes certificate hot-reload possible — the resolver
+/// installed in the [`ServerConfig`] and the one being reloaded have to be
+/// the same object, or reloads update something no connection consults.
+pub fn build_server_config_with_resolver(
+    config: &TlsConfig,
+    resolver: Arc<dyn ResolvesServerCert>,
+) -> Result<ServerConfig, TlsError> {
     // Resolve protocol versions from config
     let versions = resolve_protocol_versions(config);
     info!(
@@ -1587,17 +1597,17 @@ pub fn build_server_config(
 
             builder
                 .with_client_cert_verifier(verifier)
-                .with_cert_resolver(Arc::new(resolver))
+                .with_cert_resolver(resolver.clone())
         } else {
             warn!("client_auth enabled but no ca_file specified, disabling client auth");
             builder
                 .with_no_client_auth()
-                .with_cert_resolver(Arc::new(resolver))
+                .with_cert_resolver(resolver.clone())
         }
     } else {
         builder
             .with_no_client_auth()
-            .with_cert_resolver(Arc::new(resolver))
+            .with_cert_resolver(resolver.clone())
     };
 
     // Configure ALPN for HTTP/2 support

--- a/crates/proxy/tests/tls_handshake_test.rs
+++ b/crates/proxy/tests/tls_handshake_test.rs
@@ -1,0 +1,462 @@
+//! TLS handshake tests.
+//!
+//! `tls_sni_test.rs` covers certificate resolution thoroughly, but every one of
+//! those tests calls the resolver directly. None of them proves the resolver is
+//! reached during a handshake, which is exactly where per-SNI certificate
+//! selection used to be lost: the settings were parsed, validated, and then
+//! dropped, because the listener built its own rustls config.
+//!
+//! These tests run real TLS handshakes over a loopback socket and assert on
+//! what the client actually observed -- which certificate it was served,
+//! whether its own certificate was demanded, and which protocol version and
+//! cipher suite were negotiated. They fail if TLS settings stop reaching the
+//! handshake, regardless of how faithfully the config layer parses them.
+//!
+//! All fixture certificates are signed by the same test CA and carry
+//! `DNS:localhost`, so the client can verify them for real rather than
+//! disabling verification, which would weaken what these tests prove.
+
+use std::fs::File;
+use std::io::{BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::thread;
+
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};
+use rustls::{ClientConfig, ClientConnection, RootCertStore, ServerConfig, ServerConnection};
+use zentinel_config::{SniCertificate, TlsConfig};
+use zentinel_proxy::tls::{build_server_config, CertificateReloader, HotReloadableSniResolver};
+
+/// Pick the crypto provider explicitly, as `main.rs` does at startup.
+///
+/// Feature unification leaves both `ring` (via pingora-rustls) and `aws-lc-rs`
+/// (via this crate) enabled, so rustls refuses to guess a process-level
+/// default. Every test that touches rustls has to install one first.
+fn install_crypto_provider() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .expect("installing the aws-lc-rs crypto provider");
+    });
+}
+
+fn fixtures_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("tests/fixtures/tls")
+}
+
+fn load_certs(name: &str) -> Vec<CertificateDer<'static>> {
+    let path = fixtures_path().join(name);
+    let file = File::open(&path).unwrap_or_else(|e| panic!("opening {}: {e}", path.display()));
+    rustls_pemfile::certs(&mut BufReader::new(file))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap_or_else(|e| panic!("parsing {}: {e}", path.display()))
+}
+
+fn load_key(name: &str) -> PrivateKeyDer<'static> {
+    let path = fixtures_path().join(name);
+    let file = File::open(&path).unwrap_or_else(|e| panic!("opening {}: {e}", path.display()));
+    rustls_pemfile::private_key(&mut BufReader::new(file))
+        .unwrap_or_else(|e| panic!("parsing {}: {e}", path.display()))
+        .unwrap_or_else(|| panic!("no private key in {}", path.display()))
+}
+
+fn test_ca_roots() -> RootCertStore {
+    let mut roots = RootCertStore::empty();
+    for cert in load_certs("ca.crt") {
+        roots.add(cert).expect("adding test CA to root store");
+    }
+    roots
+}
+
+fn base_tls_config() -> TlsConfig {
+    let fixtures = fixtures_path();
+    TlsConfig {
+        cert_file: Some(fixtures.join("server-default.crt")),
+        key_file: Some(fixtures.join("server-default.key")),
+        additional_certs: vec![],
+        ca_file: None,
+        min_version: zentinel_common::types::TlsVersion::Tls12,
+        max_version: None,
+        cipher_suites: vec![],
+        client_auth: false,
+        ocsp_stapling: false,
+        session_resumption: true,
+        acme: None,
+    }
+}
+
+fn sni_certificate(hostname: &str, stem: &str) -> SniCertificate {
+    let fixtures = fixtures_path();
+    SniCertificate {
+        hostnames: vec![hostname.to_string()],
+        priority_hostnames: vec![],
+        cert_file: Some(fixtures.join(format!("{stem}.crt"))),
+        key_file: Some(fixtures.join(format!("{stem}.key"))),
+        acme: None,
+    }
+}
+
+/// What the client observed about a completed handshake.
+struct HandshakeOutcome {
+    peer_certificates: Vec<CertificateDer<'static>>,
+    protocol_version: Option<rustls::ProtocolVersion>,
+    cipher_suite: Option<rustls::CipherSuite>,
+}
+
+/// Marker the server sends once it considers the connection established.
+const SERVER_GREETING: &[u8] = b"zentinel-test-ok";
+
+fn to_tls_error(e: std::io::Error) -> rustls::Error {
+    // A rejected handshake surfaces as an I/O error wrapping the rustls error,
+    // or as a plain transport error once the peer has closed. Prefer the
+    // rustls error when there is one.
+    match e.get_ref().and_then(|i| i.downcast_ref::<rustls::Error>()) {
+        Some(tls_err) => tls_err.clone(),
+        None => rustls::Error::General(e.to_string()),
+    }
+}
+
+/// Run one handshake against a server built from `server_config`, presenting
+/// `sni` as the server name. Returns what the client saw, or the client-side
+/// error if the connection was rejected.
+///
+/// The server accepts one connection and, on success, sends [`SERVER_GREETING`].
+/// The client requires that greeting, which is what makes rejection detectable:
+/// under TLS 1.3 a server rejects a missing client certificate *after* the
+/// client has sent its Finished message, so the client believes it is done
+/// handshaking and only learns otherwise on its next read. Testing the
+/// handshake alone would report an mTLS-rejected connection as successful.
+fn handshake(
+    server_config: ServerConfig,
+    sni: &str,
+    client_config: ClientConfig,
+) -> Result<HandshakeOutcome, rustls::Error> {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("binding loopback listener");
+    let addr = listener.local_addr().expect("reading listener address");
+
+    let server = thread::spawn(move || {
+        let (mut socket, _) = listener.accept().expect("accepting connection");
+        let mut conn =
+            ServerConnection::new(Arc::new(server_config)).expect("creating server connection");
+        while conn.is_handshaking() {
+            if conn.complete_io(&mut socket).is_err() {
+                // Rejected, or the client went away. Either way the client's
+                // view is what the tests assert on.
+                return;
+            }
+        }
+        if conn.writer().write_all(SERVER_GREETING).is_ok() {
+            let _ = conn.complete_io(&mut socket);
+        }
+    });
+
+    let server_name = ServerName::try_from(sni.to_string()).expect("parsing server name");
+    let mut conn = ClientConnection::new(Arc::new(client_config), server_name)
+        .expect("creating client connection");
+    let mut socket = TcpStream::connect(addr).expect("connecting to test server");
+
+    let outcome = (|| {
+        while conn.is_handshaking() {
+            conn.complete_io(&mut socket).map_err(to_tls_error)?;
+        }
+
+        // Read the greeting. This is where a post-handshake rejection lands.
+        let mut greeting = vec![0u8; SERVER_GREETING.len()];
+        rustls::Stream::new(&mut conn, &mut socket)
+            .read_exact(&mut greeting)
+            .map_err(to_tls_error)?;
+        assert_eq!(greeting, SERVER_GREETING, "unexpected server greeting");
+
+        Ok(HandshakeOutcome {
+            peer_certificates: conn
+                .peer_certificates()
+                .map(|certs| certs.to_vec())
+                .unwrap_or_default(),
+            protocol_version: conn.protocol_version(),
+            cipher_suite: conn.negotiated_cipher_suite().map(|s| s.suite()),
+        })
+    })();
+
+    let _ = server.join();
+    outcome
+}
+
+fn verifying_client() -> ClientConfig {
+    ClientConfig::builder()
+        .with_root_certificates(test_ca_roots())
+        .with_no_client_auth()
+}
+
+/// The core of issue #303: the certificate served must depend on the SNI name
+/// the client sent. Before per-SNI selection was wired into the listener,
+/// every one of these cases returned the default certificate.
+#[test]
+fn sni_hostname_selects_the_matching_certificate() {
+    install_crypto_provider();
+    let mut config = base_tls_config();
+    config.additional_certs = vec![
+        sni_certificate("api.example.com", "server-api"),
+        sni_certificate("secure.example.com", "server-secure"),
+    ];
+
+    // "localhost" matches no configured SNI certificate, so it exercises the
+    // default-certificate fallback. It verifies because every fixture carries
+    // DNS:localhost.
+    let cases = [
+        ("api.example.com", "server-api.crt"),
+        ("secure.example.com", "server-secure.crt"),
+        ("localhost", "server-default.crt"),
+    ];
+
+    for (sni, expected_cert) in cases {
+        let server_config =
+            build_server_config(&config, "sni-test").expect("building server config");
+        let outcome = handshake(server_config, sni, verifying_client())
+            .unwrap_or_else(|e| panic!("handshake for SNI {sni} failed: {e}"));
+
+        assert_eq!(
+            outcome.peer_certificates.first(),
+            load_certs(expected_cert).first(),
+            "SNI {sni} should have been served {expected_cert}"
+        );
+    }
+}
+
+/// A wildcard certificate has to be selected by the handshake too, not only by
+/// the resolver in isolation.
+#[test]
+fn wildcard_certificate_is_served_for_a_matching_subdomain() {
+    install_crypto_provider();
+    let mut config = base_tls_config();
+    config.additional_certs = vec![sni_certificate("*.example.com", "server-wildcard")];
+
+    let server_config = build_server_config(&config, "wildcard-test").expect("building config");
+    let outcome = handshake(server_config, "anything.example.com", verifying_client())
+        .expect("handshake should succeed");
+
+    assert_eq!(
+        outcome.peer_certificates.first(),
+        load_certs("server-wildcard.crt").first(),
+        "a subdomain should be served the wildcard certificate"
+    );
+}
+
+/// `client-auth` used to parse and then do nothing, which is the worst
+/// possible failure mode for an access control setting: the operator believes
+/// connections are authenticated when any client can connect.
+#[test]
+fn client_auth_requires_a_client_certificate() {
+    install_crypto_provider();
+    let mut config = base_tls_config();
+    config.client_auth = true;
+    config.ca_file = Some(fixtures_path().join("ca.crt"));
+
+    let server_config = build_server_config(&config, "mtls-test").expect("building config");
+    let result = handshake(server_config, "localhost", verifying_client());
+
+    assert!(
+        result.is_err(),
+        "a client with no certificate must not complete an mTLS handshake"
+    );
+}
+
+/// The other half: a client presenting a certificate from the configured CA
+/// must be admitted. Without this, the test above would also pass if mTLS were
+/// broken in a way that rejected everyone.
+#[test]
+fn client_auth_admits_a_certificate_from_the_configured_ca() {
+    install_crypto_provider();
+    let mut config = base_tls_config();
+    config.client_auth = true;
+    config.ca_file = Some(fixtures_path().join("ca.crt"));
+
+    let client_config = ClientConfig::builder()
+        .with_root_certificates(test_ca_roots())
+        .with_client_auth_cert(load_certs("client.crt"), load_key("client.key"))
+        .expect("building client config with client certificate");
+
+    let server_config = build_server_config(&config, "mtls-test").expect("building config");
+    let outcome = handshake(server_config, "localhost", client_config)
+        .expect("a client certificate signed by the configured CA should be accepted");
+
+    assert_eq!(
+        outcome.peer_certificates.first(),
+        load_certs("server-default.crt").first()
+    );
+}
+
+/// `max-version` has to constrain the handshake, not just the config struct.
+#[test]
+fn max_version_caps_the_negotiated_protocol_version() {
+    install_crypto_provider();
+    let mut config = base_tls_config();
+    config.max_version = Some(zentinel_common::types::TlsVersion::Tls12);
+
+    let server_config = build_server_config(&config, "version-test").expect("building config");
+    let outcome = handshake(server_config, "localhost", verifying_client())
+        .expect("handshake should succeed");
+
+    assert_eq!(
+        outcome.protocol_version,
+        Some(rustls::ProtocolVersion::TLSv1_2),
+        "a TLS 1.3 capable client should have been held to TLS 1.2"
+    );
+}
+
+/// A client that will only speak a version the server has excluded must fail
+/// rather than silently negotiating something else.
+#[test]
+fn min_version_rejects_a_client_below_the_floor() {
+    install_crypto_provider();
+    let mut config = base_tls_config();
+    config.min_version = zentinel_common::types::TlsVersion::Tls13;
+
+    let tls12_only_client =
+        ClientConfig::builder_with_protocol_versions(&[&rustls::version::TLS12])
+            .with_root_certificates(test_ca_roots())
+            .with_no_client_auth();
+
+    let server_config = build_server_config(&config, "version-test").expect("building config");
+    let result = handshake(server_config, "localhost", tls12_only_client);
+
+    assert!(
+        result.is_err(),
+        "a TLS 1.2 only client must be rejected when min-version is TLS 1.3"
+    );
+}
+
+/// Certificate hot-reload, end to end.
+///
+/// This is the invariant that makes reload work at all: the resolver installed
+/// in the `ServerConfig` has to be the same object `CertificateReloader`
+/// refreshes. If a listener were built with its own separate resolver, every
+/// assertion below would still hold for the *reloader* while connections kept
+/// being served the original certificate -- reload would appear to succeed and
+/// change nothing.
+///
+/// Note the `ServerConfig` is built once and reused across both handshakes,
+/// exactly as a running listener holds one config for its lifetime.
+#[test]
+fn reloading_certificates_changes_what_a_live_config_serves() {
+    install_crypto_provider();
+
+    let dir = tempfile::tempdir().expect("creating temp dir");
+    let cert_path = dir.path().join("server.crt");
+    let key_path = dir.path().join("server.key");
+
+    let install = |stem: &str| {
+        std::fs::copy(fixtures_path().join(format!("{stem}.crt")), &cert_path).expect("copy cert");
+        std::fs::copy(fixtures_path().join(format!("{stem}.key")), &key_path).expect("copy key");
+    };
+    install("server-default");
+
+    let mut config = base_tls_config();
+    config.cert_file = Some(cert_path.clone());
+    config.key_file = Some(key_path.clone());
+
+    let resolver = Arc::new(
+        HotReloadableSniResolver::from_config(config.clone(), "reload-test")
+            .expect("building hot-reloadable resolver"),
+    );
+    let reloader = CertificateReloader::new();
+    reloader.register("reload-test", resolver.clone());
+
+    let server_config = zentinel_proxy::tls::build_server_config_with_resolver(&config, resolver)
+        .expect("building server config");
+
+    let before = handshake(server_config.clone(), "localhost", verifying_client())
+        .expect("handshake before reload");
+    assert_eq!(
+        before.peer_certificates.first(),
+        load_certs("server-default.crt").first(),
+        "the original certificate should be served before any reload"
+    );
+
+    // Renewal: same paths, different certificate.
+    install("server-api");
+    let (reloaded, failures) = reloader.reload_all();
+    assert_eq!(reloaded, 1, "one listener should have reloaded");
+    assert!(
+        failures.is_empty(),
+        "reload reported failures: {failures:?}"
+    );
+
+    let after =
+        handshake(server_config, "localhost", verifying_client()).expect("handshake after reload");
+    assert_eq!(
+        after.peer_certificates.first(),
+        load_certs("server-api.crt").first(),
+        "the reloaded certificate should be served without rebuilding the config"
+    );
+}
+
+/// A reload that cannot read its certificates must not take the listener down
+/// or start serving nothing -- the previous certificate stays in use.
+#[test]
+fn a_failed_reload_keeps_serving_the_previous_certificate() {
+    install_crypto_provider();
+
+    let dir = tempfile::tempdir().expect("creating temp dir");
+    let cert_path = dir.path().join("server.crt");
+    let key_path = dir.path().join("server.key");
+    std::fs::copy(fixtures_path().join("server-default.crt"), &cert_path).expect("copy cert");
+    std::fs::copy(fixtures_path().join("server-default.key"), &key_path).expect("copy key");
+
+    let mut config = base_tls_config();
+    config.cert_file = Some(cert_path.clone());
+    config.key_file = Some(key_path.clone());
+
+    let resolver = Arc::new(
+        HotReloadableSniResolver::from_config(config.clone(), "reload-failure")
+            .expect("building hot-reloadable resolver"),
+    );
+    let reloader = CertificateReloader::new();
+    reloader.register("reload-failure", resolver.clone());
+
+    let server_config = zentinel_proxy::tls::build_server_config_with_resolver(&config, resolver)
+        .expect("building server config");
+
+    // A truncated certificate file, as a half-written renewal would leave.
+    std::fs::write(&cert_path, b"").expect("truncating cert");
+    let (reloaded, failures) = reloader.reload_all();
+    assert_eq!(
+        reloaded, 0,
+        "a broken certificate must not count as reloaded"
+    );
+    assert_eq!(failures.len(), 1, "the failure should be reported");
+
+    let after = handshake(server_config, "localhost", verifying_client())
+        .expect("connections should still be served after a failed reload");
+    assert_eq!(
+        after.peer_certificates.first(),
+        load_certs("server-default.crt").first(),
+        "the previous certificate should still be in use"
+    );
+}
+
+/// Cipher suite selection reaching the handshake, asserted on the suite the
+/// client actually negotiated.
+#[test]
+fn configured_cipher_suite_is_the_one_negotiated() {
+    install_crypto_provider();
+    let mut config = base_tls_config();
+    config.min_version = zentinel_common::types::TlsVersion::Tls13;
+    config.cipher_suites = vec!["TLS_CHACHA20_POLY1305_SHA256".to_string()];
+
+    let server_config = build_server_config(&config, "cipher-test").expect("building config");
+    let outcome = handshake(server_config, "localhost", verifying_client())
+        .expect("handshake should succeed");
+
+    assert_eq!(
+        outcome.cipher_suite,
+        Some(rustls::CipherSuite::TLS13_CHACHA20_POLY1305_SHA256),
+        "the single configured cipher suite should have been negotiated"
+    );
+}


### PR DESCRIPTION
Closes #303.

## What was wrong

TLS settings were parsed, validated, and then thrown away. The listener was built with `TlsSettings::intermediate(cert, key)` — one certificate, fixed profile — so `build_server_config()` produced a fully correct `rustls::ServerConfig` that nothing ever consulted.

Five things silently did nothing:

| Setting | Configured behaviour | Actual behaviour |
|---|---|---|
| `sni { }` blocks | per-hostname certificates | every client got the primary certificate |
| `client-auth` | require+verify client certs | listener never requested one |
| `min-version` / `max-version` | version floor/ceiling | Pingora's profile (TLS 1.2+) |
| `cipher-suite` | restrict suites | provider defaults |
| `session-resumption false` | disable resumption | resumption enabled |

The old code warned about each of these at startup, which was the right call at the time, but a warning is not a fix. An operator who configured `client-auth true` got an unauthenticated listener.

## What changed

The fork now accepts a caller-supplied `ServerConfig` ([zentinelproxy/pingora#6](https://github.com/zentinelproxy/pingora/pull/6), merged as `ffaf897`), so `build_server_config()`'s output goes straight to the listener. All five categories now take effect, and the startup warnings are deleted because there is nothing left to warn about.

`build_server_config` is split so the caller can supply the resolver:

```rust
pub fn build_server_config_with_resolver(
    config: &TlsConfig,
    resolver: Arc<dyn ResolvesServerCert>,
) -> Result<ServerConfig, TlsError>
```

`main.rs` installs a `HotReloadableSniResolver` and keeps the handle. That is the point of the split — the resolver inside the `ServerConfig` and the one being reloaded must be the same object, or a reload updates something no live connection consults. SIGHUP now refreshes certificates from disk, which is what makes ACME renewal visible to a running proxy rather than only after a restart.

## Verification

I ran the built binary against a config with two SNI certificates:

```
SNI api.example.com        -> served CN=api.example.com
SNI secure.example.com     -> served CN=secure.example.com
SNI unknown.example.com    -> served CN=example.com      (default fallback)
```

and SIGHUP:

```
INFO zentinel_proxy::tls: All certificates reloaded successfully success_count=1
INFO zentinel: TLS certificates reloaded reloaded=1 failed=0
```

Startup log now reports `sni_cert_count=2 client_auth=false` with no "NOT served" / "NOT enforced" warnings.

### New tests

`crates/proxy/tests/tls_handshake_test.rs`, 9 tests. The existing `tls_sni_test.rs` has 28 thorough resolver tests, and **not one of them could have caught this bug** — they all call the resolver directly, and the bug was that the resolver was never reached. The new tests run real handshakes over loopback and assert on what the client observed.

Covered: per-SNI selection, wildcard selection, default fallback, mTLS rejected without a client cert, mTLS accepted with one, `max-version` capping the negotiation, `min-version` rejecting a low client, the configured cipher suite being the one negotiated, a reload changing what a live config serves, and a failed reload keeping the previous certificate.

One detail worth flagging for review: **mTLS rejection is only visible after the handshake.** Under TLS 1.3 the server rejects a missing client certificate after the client has sent Finished, so the client believes it finished handshaking and learns otherwise on its next read. My first version of that test passed against a server that was correctly rejecting the connection. The helper now requires a post-handshake read, which is what makes the assertion real.

Full suite green (585 lib + all integration), clippy clean, fmt clean.

## What this does not cover

The literal call site in `main.rs` has no automated test — the repo has no harness that spawns the binary, and adding one is a larger piece of work than this change. It is covered at both ends instead: the fork's tests assert a supplied config is the one used, and these tests assert the config is correct. The join between them is what I verified by hand above.

`initialize_acme` is still passed `None` for its resolver, so ACME renewal does not push directly into the resolver; it writes to disk and SIGHUP picks it up. Wiring it directly needs the ACME init to move after listener construction, which is a separate change.

## Note on Cargo.lock

`ahash 0.7.8` is added — a transitive dependency of `hashbrown 0.12.3` that the committed lock was missing. It appears from the rev bump alone on a clean re-resolve. No dependency was added by this change.
