### PR TITLE
feat(tls): scan certificate folders for SNI certificates

### DIFF
--- a/crates/config/src/kdl/server.rs
+++ b/crates/config/src/kdl/server.rs
@@ -10,9 +10,11 @@ use crate::server::{
     default_acme_storage, default_graceful_shutdown_timeout, default_keepalive_timeout,
     default_max_concurrent_streams, default_max_connections, default_renewal_days,
     default_request_timeout, default_worker_threads, AcmeChallengeType, AcmeConfig, AcmeKeyType,
-    DnsProviderConfig, DnsProviderType, ExternalAccountBinding, ListenerConfig, ListenerProtocol,
-    PropagationCheckConfig, ServerConfig, SniCertificate, TlsConfig,
+    CertFolderReloadMode, DnsProviderConfig, DnsProviderType, ExternalAccountBinding,
+    ListenerConfig, ListenerProtocol, PropagationCheckConfig, ServerConfig, SniCertFolder,
+    SniCertificate, TlsConfig,
 };
+use std::time::Duration;
 
 use super::helpers::{get_bool_entry, get_first_arg_string, get_int_entry, get_string_entry};
 
@@ -245,6 +247,20 @@ pub fn parse_tls_config(node: &kdl::KdlNode, listener_id: &str) -> Result<TlsCon
         Vec::new()
     };
 
+    // Certificate folders scanned for cert/key pairs.
+    let cert_folders = if let Some(children) = node.children() {
+        children
+            .nodes()
+            .iter()
+            .filter(|n| n.name().value() == "sni-certs")
+            .map(|folder_node| parse_sni_cert_folder(folder_node, listener_id))
+            .collect::<Result<Vec<_>>>()?
+    } else {
+        Vec::new()
+    };
+
+    let allow_sni_overlaps = get_bool_entry(node, "allow-sni-overlaps").unwrap_or(false);
+
     debug!(
         listener_id = %listener_id,
         has_cert_file = cert_file.is_some(),
@@ -256,6 +272,8 @@ pub fn parse_tls_config(node: &kdl::KdlNode, listener_id: &str) -> Result<TlsCon
     );
 
     Ok(TlsConfig {
+        cert_folders,
+        allow_sni_overlaps,
         cert_file,
         key_file,
         additional_certs,
@@ -282,6 +300,8 @@ const KNOWN_TLS_NODES: &[&str] = &[
     "session-resumption",
     "cipher-suite",
     "sni",
+    "sni-certs",
+    "allow-sni-overlaps",
     "acme",
 ];
 
@@ -795,6 +815,92 @@ fn parse_sni_certificate(node: &kdl::KdlNode, listener_id: &str) -> Result<SniCe
 /// Parse TLS version string
 ///
 /// Only TLS 1.2 and 1.3 are supported (TLS 1.0/1.1 are deprecated)
+/// Parse an `sni-certs { ... }` block.
+///
+/// ```kdl
+/// sni-certs {
+///     cert-folder "/etc/zentinel/certs/dynamic/"
+///     reload-mode "watch"
+///     reload-interval "30s"
+/// }
+/// ```
+fn parse_sni_cert_folder(node: &kdl::KdlNode, listener_id: &str) -> Result<SniCertFolder> {
+    let cert_folder = get_string_entry(node, "cert-folder")
+        .map(PathBuf::from)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "sni-certs block for listener '{}' requires 'cert-folder', for example: \
+                 sni-certs {{ cert-folder \"/etc/zentinel/certs/dynamic/\" }}",
+                listener_id
+            )
+        })?;
+
+    let reload_mode = match get_string_entry(node, "reload-mode") {
+        None => CertFolderReloadMode::Off,
+        Some(mode) => match mode.to_ascii_lowercase().as_str() {
+            "off" => CertFolderReloadMode::Off,
+            "interval" => CertFolderReloadMode::Interval,
+            "watch" => CertFolderReloadMode::Watch,
+            other => {
+                return Err(anyhow::anyhow!(
+                    "sni-certs block for listener '{}' has unknown reload-mode '{}'. \
+                     Valid modes are: off, interval, watch",
+                    listener_id,
+                    other
+                ))
+            }
+        },
+    };
+
+    let reload_interval = match get_string_entry(node, "reload-interval") {
+        None => Duration::from_secs(30),
+        Some(text) => crate::kdl::upstreams::parse_duration_string(&text)
+            .map(Duration::from_secs)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "sni-certs block for listener '{}' has an invalid reload-interval '{}'. \
+                 Use a duration such as \"30s\", \"5m\" or \"1h\"",
+                    listener_id,
+                    text
+                )
+            })?,
+    };
+
+    // A timer that never fires is a configuration mistake worth naming rather
+    // than silently turning into a busy loop or a no-op.
+    if reload_mode != CertFolderReloadMode::Off && reload_interval.is_zero() {
+        return Err(anyhow::anyhow!(
+            "sni-certs block for listener '{}' has reload-mode '{}' with a zero \
+             reload-interval; use a non-zero interval or reload-mode \"off\"",
+            listener_id,
+            reload_mode
+        ));
+    }
+
+    // Reject unknown children so a typo does not silently disable reloading.
+    if let Some(children) = node.children() {
+        const KNOWN: &[&str] = &["cert-folder", "reload-mode", "reload-interval"];
+        for child in children.nodes() {
+            let name = child.name().value();
+            if !KNOWN.contains(&name) {
+                return Err(anyhow::anyhow!(
+                    "Unknown node '{}' in sni-certs block for listener '{}'. \
+                     Valid nodes are: {}",
+                    name,
+                    listener_id,
+                    KNOWN.join(", ")
+                ));
+            }
+        }
+    }
+
+    Ok(SniCertFolder {
+        cert_folder,
+        reload_mode,
+        reload_interval,
+    })
+}
+
 fn parse_tls_version(s: &str) -> TlsVersion {
     match s.to_lowercase().as_str() {
         "1.3" | "tls1.3" | "tlsv1.3" => TlsVersion::Tls13,

--- a/crates/config/src/kdl/upstreams.rs
+++ b/crates/config/src/kdl/upstreams.rs
@@ -280,7 +280,7 @@ fn parse_sticky_session_config(children: &kdl::KdlDocument) -> StickySessionConf
 }
 
 /// Parse duration string like "1h", "30m", "1d" to seconds
-fn parse_duration_string(s: &str) -> Option<u64> {
+pub(crate) fn parse_duration_string(s: &str) -> Option<u64> {
     let s = s.trim();
     if s.is_empty() {
         return None;

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -105,7 +105,10 @@ pub use routes::{
 };
 
 // Server
-pub use server::{ListenerConfig, ListenerProtocol, ServerConfig, SniCertificate, TlsConfig};
+pub use server::{
+    CertFolderReloadMode, ListenerConfig, ListenerProtocol, ServerConfig, SniCertFolder,
+    SniCertificate, TlsConfig,
+};
 
 // Re-export TraceIdFormat from common for convenience
 pub use zentinel_common::TraceIdFormat;

--- a/crates/config/src/server.rs
+++ b/crates/config/src/server.rs
@@ -5,6 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::time::Duration;
 use validator::Validate;
 
 use zentinel_common::types::{TlsVersion, TraceIdFormat};
@@ -148,6 +149,20 @@ pub struct TlsConfig {
     /// Maps hostname patterns to certificate configurations
     #[serde(default)]
     pub additional_certs: Vec<SniCertificate>,
+
+    /// Folders scanned for certificate/key pairs, in addition to the
+    /// explicitly listed `additional_certs`.
+    #[serde(default)]
+    pub cert_folders: Vec<SniCertFolder>,
+
+    /// Whether two certificates may claim the same hostname.
+    ///
+    /// Default `false`: an overlap is a configuration error, because which
+    /// certificate wins would otherwise depend on directory iteration order.
+    /// Set `true` to accept overlaps and resolve them by the documented
+    /// tie-break instead.
+    #[serde(default)]
+    pub allow_sni_overlaps: bool,
 
     /// CA certificate file path for client verification (mTLS)
     pub ca_file: Option<PathBuf>,
@@ -398,6 +413,55 @@ impl Default for PropagationCheckConfig {
             nameservers: Vec::new(),
         }
     }
+}
+
+/// How a scanned certificate folder is rechecked for changes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum CertFolderReloadMode {
+    /// Only rescan when the process is told to, via SIGHUP.
+    #[default]
+    Off,
+    /// Rescan on a timer.
+    Interval,
+    /// Rescan when the filesystem reports a change, falling back to the timer
+    /// if a watcher cannot be established.
+    Watch,
+}
+
+impl std::fmt::Display for CertFolderReloadMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CertFolderReloadMode::Off => write!(f, "off"),
+            CertFolderReloadMode::Interval => write!(f, "interval"),
+            CertFolderReloadMode::Watch => write!(f, "watch"),
+        }
+    }
+}
+
+/// A folder scanned for certificate/key pairs.
+///
+/// Each pair found is registered like an explicit `sni` block whose hostnames
+/// are extracted from the certificate's CN and SANs, which is what makes the
+/// folder useful: certificates can be added or removed without editing the
+/// configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SniCertFolder {
+    /// Directory to scan.
+    pub cert_folder: PathBuf,
+
+    /// When to rescan.
+    #[serde(default)]
+    pub reload_mode: CertFolderReloadMode,
+
+    /// How often to rescan under `interval`, and the fallback poll under
+    /// `watch` when no watcher could be established.
+    #[serde(default = "default_cert_reload_interval")]
+    pub reload_interval: Duration,
+}
+
+fn default_cert_reload_interval() -> Duration {
+    Duration::from_secs(30)
 }
 
 /// SNI certificate configuration

--- a/crates/config/src/validate/certs.rs
+++ b/crates/config/src/validate/certs.rs
@@ -204,6 +204,8 @@ mod tests {
 
     fn test_tls_config() -> TlsConfig {
         TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some("/nonexistent/cert.pem".into()),
             key_file: Some("/nonexistent/key.pem".into()),
             additional_certs: vec![],

--- a/crates/config/src/validate/lint.rs
+++ b/crates/config/src/validate/lint.rs
@@ -238,6 +238,8 @@ mod tests {
             address: address.to_string(),
             protocol: crate::ListenerProtocol::Http,
             tls: Some(TlsConfig {
+                cert_folders: Vec::new(),
+                allow_sni_overlaps: false,
                 cert_file: Some(PathBuf::from("/path/to/cert.pem")),
                 key_file: Some(PathBuf::from("/path/to/key.pem")),
                 additional_certs: vec![],

--- a/crates/config/src/validation.rs
+++ b/crates/config/src/validation.rs
@@ -1678,6 +1678,8 @@ mod tests {
     fn tls_cipher_suites_produce_warning() {
         let mut config = Config::default_for_testing();
         config.listeners[0].tls = Some(crate::TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some("/tmp/cert.pem".into()),
             key_file: Some("/tmp/key.pem".into()),
             additional_certs: vec![],
@@ -1710,6 +1712,8 @@ mod tests {
     fn tls_max_version_produces_warning() {
         let mut config = Config::default_for_testing();
         config.listeners[0].tls = Some(crate::TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some("/tmp/cert.pem".into()),
             key_file: Some("/tmp/key.pem".into()),
             additional_certs: vec![],
@@ -1948,6 +1952,8 @@ mod tests {
 
         // --- TlsConfig ---
         let _tls = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some("/tmp/cert.pem".into()),
             key_file: Some("/tmp/key.pem".into()),
             additional_certs: vec![],
@@ -2162,6 +2168,8 @@ mod tests {
 
         // TLS cipher_suites (unwired — Pingora doesn't expose custom cipher config)
         config.listeners[0].tls = Some(crate::TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some("/tmp/cert.pem".into()),
             key_file: Some("/tmp/key.pem".into()),
             additional_certs: vec![],

--- a/crates/gateway/src/translator.rs
+++ b/crates/gateway/src/translator.rs
@@ -460,6 +460,10 @@ impl ConfigTranslator {
         }
 
         Some(TlsConfig {
+            // Gateway API has no equivalent of folder scanning; certificates
+            // come from Secret references.
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some(default_cert.cert_path),
             key_file: Some(default_cert.key_path),
             additional_certs,

--- a/crates/proxy/src/main.rs
+++ b/crates/proxy/src/main.rs
@@ -18,7 +18,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use pingora::prelude::*;
 use std::sync::Arc;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use zentinel_config::server::{AcmeChallengeType, AcmeConfig};
 use zentinel_config::Config;
@@ -933,7 +933,18 @@ fn run_server(
                             };
                         tls_settings.enable_h2();
 
-                        cert_reloader.register(&listener.id, sni_resolver);
+                        cert_reloader.register(&listener.id, sni_resolver.clone());
+
+                        // Folders configured to reload on their own get a
+                        // watcher or a timer. Without this the `reload-mode`
+                        // setting would parse and do nothing, which is the
+                        // failure mode this listener was just fixed for.
+                        spawn_cert_folder_reloaders(
+                            &runtime,
+                            &listener.id,
+                            tls_config,
+                            sni_resolver,
+                        );
 
                         proxy_service.add_tls_with_settings(&listener.address, None, tls_settings);
                         info!(
@@ -1086,6 +1097,170 @@ fn create_default_config_file(path: &std::path::Path) -> Result<()> {
         .with_context(|| format!("Failed to write default config to: {:?}", path))?;
 
     Ok(())
+}
+
+/// Start a reload task for each certificate folder that asks for one.
+///
+/// `off` folders are left alone: they still rescan on SIGHUP, because the
+/// resolver rebuilds from configuration and the scan is part of that.
+fn spawn_cert_folder_reloaders(
+    runtime: &tokio::runtime::Runtime,
+    listener_id: &str,
+    tls_config: &zentinel_config::TlsConfig,
+    resolver: Arc<HotReloadableSniResolver>,
+) {
+    use zentinel_config::CertFolderReloadMode;
+
+    for folder in &tls_config.cert_folders {
+        match folder.reload_mode {
+            CertFolderReloadMode::Off => continue,
+            CertFolderReloadMode::Interval => {
+                info!(
+                    listener_id = %listener_id,
+                    cert_folder = %folder.cert_folder.display(),
+                    interval_secs = folder.reload_interval.as_secs(),
+                    "Certificate folder will be rescanned on a timer"
+                );
+                let resolver = resolver.clone();
+                let listener_id = listener_id.to_string();
+                let path = folder.cert_folder.clone();
+                let interval = folder.reload_interval;
+                runtime.spawn(async move {
+                    let mut ticker = tokio::time::interval(interval);
+                    // The first tick fires immediately; the folder was just
+                    // scanned, so skip it.
+                    ticker.tick().await;
+                    loop {
+                        ticker.tick().await;
+                        reload_folder(&resolver, &listener_id, &path, "interval");
+                    }
+                });
+            }
+            CertFolderReloadMode::Watch => {
+                info!(
+                    listener_id = %listener_id,
+                    cert_folder = %folder.cert_folder.display(),
+                    "Certificate folder will be rescanned when it changes"
+                );
+                let resolver = resolver.clone();
+                let listener_id = listener_id.to_string();
+                let path = folder.cert_folder.clone();
+                let interval = folder.reload_interval;
+                runtime.spawn(async move {
+                    watch_cert_folder(resolver, listener_id, path, interval).await;
+                });
+            }
+        }
+    }
+}
+
+/// Rescan one listener's certificates, logging the outcome.
+fn reload_folder(
+    resolver: &HotReloadableSniResolver,
+    listener_id: &str,
+    path: &std::path::Path,
+    trigger: &str,
+) {
+    match resolver.reload() {
+        Ok(()) => {
+            debug!(
+                listener_id = %listener_id,
+                cert_folder = %path.display(),
+                trigger = trigger,
+                "Certificates reloaded"
+            );
+        }
+        Err(e) => {
+            // The previous certificates stay in use. Reporting matters more
+            // than retrying: a folder that has gone bad will keep failing, and
+            // silence would look identical to a folder that never changes.
+            error!(
+                listener_id = %listener_id,
+                cert_folder = %path.display(),
+                trigger = trigger,
+                error = %e,
+                "Certificate reload failed; continuing with the previous certificates"
+            );
+        }
+    }
+}
+
+/// Watch a folder and rescan when it changes, falling back to a timer.
+///
+/// Filesystem watching is not available everywhere, and a network filesystem
+/// may report nothing at all. Rather than leave the operator with a folder
+/// that silently never reloads, a failed watcher degrades to the configured
+/// interval and says so.
+async fn watch_cert_folder(
+    resolver: Arc<HotReloadableSniResolver>,
+    listener_id: String,
+    path: std::path::PathBuf,
+    fallback_interval: std::time::Duration,
+) {
+    use notify::{RecursiveMode, Watcher};
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<()>(1);
+    let watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+        if res.is_ok() {
+            // A full rescan follows, so one signal is enough however many
+            // events arrived; a full channel already means one is pending.
+            let _ = tx.try_send(());
+        }
+    });
+
+    let mut watcher = match watcher {
+        Ok(w) => w,
+        Err(e) => {
+            warn!(
+                listener_id = %listener_id,
+                cert_folder = %path.display(),
+                error = %e,
+                interval_secs = fallback_interval.as_secs(),
+                "Could not create a filesystem watcher; falling back to interval rescans"
+            );
+            return interval_fallback(resolver, listener_id, path, fallback_interval).await;
+        }
+    };
+
+    if let Err(e) = watcher.watch(&path, RecursiveMode::NonRecursive) {
+        warn!(
+            listener_id = %listener_id,
+            cert_folder = %path.display(),
+            error = %e,
+            interval_secs = fallback_interval.as_secs(),
+            "Could not watch the certificate folder; falling back to interval rescans"
+        );
+        return interval_fallback(resolver, listener_id, path, fallback_interval).await;
+    }
+
+    // Certificates are often written as several files in quick succession —
+    // a key then a certificate. Waiting briefly after the first event avoids
+    // rescanning midway through and reading a pair that is not yet complete.
+    const SETTLE: std::time::Duration = std::time::Duration::from_millis(500);
+
+    while rx.recv().await.is_some() {
+        tokio::time::sleep(SETTLE).await;
+        while rx.try_recv().is_ok() {}
+        reload_folder(&resolver, &listener_id, &path, "watch");
+    }
+
+    // The watcher is dropped when this task ends; keep it alive until then.
+    drop(watcher);
+}
+
+/// Timer-driven rescans, used directly and as the watch fallback.
+async fn interval_fallback(
+    resolver: Arc<HotReloadableSniResolver>,
+    listener_id: String,
+    path: std::path::PathBuf,
+    interval: std::time::Duration,
+) {
+    let mut ticker = tokio::time::interval(interval);
+    ticker.tick().await;
+    loop {
+        ticker.tick().await;
+        reload_folder(&resolver, &listener_id, &path, "interval-fallback");
+    }
 }
 
 /// Async signal handler task

--- a/crates/proxy/src/tls.rs
+++ b/crates/proxy/src/tls.rs
@@ -63,7 +63,7 @@
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::BufReader;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -75,7 +75,7 @@ use rustls::sign::CertifiedKey;
 use rustls::{RootCertStore, ServerConfig};
 use tracing::{debug, error, info, trace, warn};
 
-use zentinel_config::{TlsConfig, UpstreamTlsConfig};
+use zentinel_config::{SniCertFolder, SniCertificate, TlsConfig, UpstreamTlsConfig};
 
 /// Error type for TLS operations
 #[derive(Debug)]
@@ -172,8 +172,20 @@ impl SniResolver {
         let mut priority_exact: HashSet<String> = HashSet::new();
         let mut priority_wildcard: HashSet<String> = HashSet::new();
 
+        // Certificates found by scanning configured folders are registered
+        // exactly like explicit `sni` blocks with no `hostnames`: their names
+        // come from the certificate's CN and SANs. Feeding them through the
+        // same loop keeps one implementation of hostname extraction, priority
+        // handling and overlap detection.
+        let scanned = scan_cert_folders(&config.cert_folders, listener_id_str);
+        let all_sni_certs: Vec<&SniCertificate> = config
+            .additional_certs
+            .iter()
+            .chain(scanned.iter())
+            .collect();
+
         // Load SNI certificates
-        for (i, sni_config) in config.additional_certs.iter().enumerate() {
+        for (i, sni_config) in all_sni_certs.into_iter().enumerate() {
             // Resolve paths for this SNI cert
             let (sni_cert_path_buf, sni_key_path_buf);
             let (sni_cert_path, sni_key_path) = match (&sni_config.cert_file, &sni_config.key_file)
@@ -302,11 +314,26 @@ impl SniResolver {
                                     "Skipping wildcard SNI registration, existing cert has priority"
                                 );
                                 continue;
+                            } else if config.allow_sni_overlaps {
+                                // Overlaps accepted: the first registration
+                                // wins. Certificates are registered in sorted
+                                // path order, so the winner is the same on
+                                // every machine and across reloads rather
+                                // than whatever the filesystem listed first.
+                                warn!(
+                                    listener_id = %listener_id_str,
+                                    pattern = %hostname,
+                                    cert_file = %sni_cert_path.display(),
+                                    "Overlapping wildcard SNI certificate ignored; \
+                                     an earlier certificate already claims this name"
+                                );
+                                continue;
                             } else {
                                 // Neither has priority, ambiguity error
                                 return Err(TlsError::ConfigBuild(format!(
                                     "Ambiguous SNI configuration: wildcard '*.{}' matches multiple certificates (including {:?}). \
-                                     Use explicit 'hostnames' or 'priority-hostnames' to resolve the conflict.",
+                                     Use explicit 'hostnames' or 'priority-hostnames' to resolve the conflict, \
+                                     or set 'allow-sni-overlaps true' to accept the first match in path order.",
                                     domain,
                                     sni_cert_path
                                 )));
@@ -353,11 +380,21 @@ impl SniResolver {
                                     "Skipping SNI registration, existing cert has priority"
                                 );
                                 continue;
+                            } else if config.allow_sni_overlaps {
+                                warn!(
+                                    listener_id = %listener_id_str,
+                                    hostname = %hostname_lower,
+                                    cert_file = %sni_cert_path.display(),
+                                    "Overlapping SNI certificate ignored; \
+                                     an earlier certificate already claims this name"
+                                );
+                                continue;
                             } else {
                                 // Neither has priority, ambiguity error
                                 return Err(TlsError::ConfigBuild(format!(
                                     "Ambiguous SNI configuration: hostname '{}' matches multiple certificates (including {:?}). \
-                                     Use explicit 'hostnames' or 'priority-hostnames' to resolve the conflict.",
+                                     Use explicit 'hostnames' or 'priority-hostnames' to resolve the conflict, \
+                                     or set 'allow-sni-overlaps true' to accept the first match in path order.",
                                     hostname_lower,
                                     sni_cert_path
                                 )));
@@ -385,6 +422,15 @@ impl SniResolver {
             wildcard_certs = wildcard_certs.len(),
             "SNI resolver initialized"
         );
+
+        if let Some(metrics) = crate::tls_metrics::get_tls_metrics() {
+            // The default certificate counts too: it is what an unmatched
+            // name is served.
+            metrics.set_certificates_loaded(
+                listener_id_str,
+                1 + sni_certs.len() + wildcard_certs.len(),
+            );
+        }
 
         Ok(Self {
             default_cert: Arc::new(default_cert),
@@ -506,8 +552,17 @@ impl HotReloadableSniResolver {
             "Reloading TLS certificates"
         );
 
-        // Try to load new certificates
-        let new_resolver = SniResolver::from_config(&config, Some(&self.listener_id))?;
+        // Try to load new certificates. A failure leaves the previous ones in
+        // place, which is invisible in traffic -- hence the counter.
+        let new_resolver = match SniResolver::from_config(&config, Some(&self.listener_id)) {
+            Ok(resolver) => resolver,
+            Err(e) => {
+                if let Some(metrics) = crate::tls_metrics::get_tls_metrics() {
+                    metrics.record_reload(&self.listener_id, false);
+                }
+                return Err(e);
+            }
+        };
 
         // Swap in the new resolver atomically
         *self.inner.write() = Arc::new(new_resolver);
@@ -517,6 +572,9 @@ impl HotReloadableSniResolver {
             listener_id = %self.listener_id,
             "TLS certificates reloaded successfully"
         );
+        if let Some(metrics) = crate::tls_metrics::get_tls_metrics() {
+            metrics.record_reload(&self.listener_id, true);
+        }
         Ok(())
     }
 
@@ -554,6 +612,136 @@ impl ResolvesServerCert for HotReloadableSniResolver {
     fn resolve(&self, client_hello: ClientHello<'_>) -> Option<Arc<CertifiedKey>> {
         Some(self.inner.read().resolve(client_hello.server_name()))
     }
+}
+
+/// Extensions treated as certificates, paired with a key of the same stem.
+const CERT_EXTENSIONS: &[&str] = &["crt", "pem", "cert"];
+
+/// Extensions treated as private keys.
+const KEY_EXTENSIONS: &[&str] = &["key"];
+
+/// Scan configured folders for certificate/key pairs.
+///
+/// A pair is a certificate file and a key file sharing a stem — `a.crt` with
+/// `a.key`. Entries are returned sorted by path so that registration order,
+/// and therefore any tie-break between overlapping certificates, does not
+/// depend on the order the filesystem happens to return.
+///
+/// Problems with individual files are skipped and warned about rather than
+/// failing the scan. A folder is a moving target — certificates are written
+/// there by other processes, sometimes non-atomically — so one half-written
+/// file must not take down every other certificate on the listener. The
+/// warning is what keeps that from being silent.
+fn scan_cert_folders(folders: &[SniCertFolder], listener_id: &str) -> Vec<SniCertificate> {
+    let mut found = Vec::new();
+
+    for folder in folders {
+        let dir = &folder.cert_folder;
+        let entries = match std::fs::read_dir(dir) {
+            Ok(entries) => entries,
+            Err(e) => {
+                warn!(
+                    listener_id = %listener_id,
+                    cert_folder = %dir.display(),
+                    error = %e,
+                    "Certificate folder could not be read; no certificates loaded from it"
+                );
+                continue;
+            }
+        };
+
+        // Collect and sort first: read_dir order is unspecified, and a
+        // tie-break that depends on it would resolve differently between
+        // machines or after a reload.
+        let mut paths: Vec<PathBuf> = entries
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.is_file())
+            .collect();
+        paths.sort();
+
+        let mut pairs = 0usize;
+        for cert_path in &paths {
+            let Some(extension) = cert_path.extension().and_then(|e| e.to_str()) else {
+                continue;
+            };
+            if !CERT_EXTENSIONS.contains(&extension.to_ascii_lowercase().as_str()) {
+                continue;
+            }
+
+            let Some(key_path) = matching_key_path(cert_path) else {
+                warn!(
+                    listener_id = %listener_id,
+                    cert_file = %cert_path.display(),
+                    "Certificate in scanned folder has no matching key file; skipping"
+                );
+                if let Some(metrics) = crate::tls_metrics::get_tls_metrics() {
+                    metrics.record_folder_entry_skipped(listener_id, "no_key");
+                }
+                continue;
+            };
+
+            // Load it here purely to reject unusable pairs with a precise
+            // message. The pair is loaded again by the caller, which is cheap
+            // next to serving traffic with a certificate that turns out to be
+            // unreadable.
+            if let Err(e) = load_certified_key(cert_path, &key_path) {
+                warn!(
+                    listener_id = %listener_id,
+                    cert_file = %cert_path.display(),
+                    key_file = %key_path.display(),
+                    error = %e,
+                    "Certificate pair in scanned folder could not be loaded; skipping"
+                );
+                if let Some(metrics) = crate::tls_metrics::get_tls_metrics() {
+                    metrics.record_folder_entry_skipped(listener_id, "unreadable");
+                }
+                continue;
+            }
+
+            found.push(SniCertificate {
+                hostnames: Vec::new(),
+                priority_hostnames: Vec::new(),
+                cert_file: Some(cert_path.clone()),
+                key_file: Some(key_path),
+                acme: None,
+            });
+            pairs += 1;
+        }
+
+        info!(
+            listener_id = %listener_id,
+            cert_folder = %dir.display(),
+            certificates = pairs,
+            reload_mode = %folder.reload_mode,
+            "Scanned certificate folder"
+        );
+    }
+
+    found
+}
+
+/// Find the key file belonging to a certificate, by stem.
+///
+/// `server.crt` pairs with `server.key`. A `.pem` certificate also accepts a
+/// `.pem` key only when they are separate files, since a combined PEM holding
+/// both is loaded from the one path.
+fn matching_key_path(cert_path: &Path) -> Option<PathBuf> {
+    for extension in KEY_EXTENSIONS {
+        let candidate = cert_path.with_extension(extension);
+        if candidate != cert_path && candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    // A PEM bundle may carry the key alongside the certificate.
+    if cert_path
+        .extension()
+        .and_then(|e| e.to_str())?
+        .eq_ignore_ascii_case("pem")
+        && load_certified_key(cert_path, cert_path).is_ok()
+    {
+        return Some(cert_path.to_path_buf());
+    }
+    None
 }
 
 /// Certificate reload manager

--- a/crates/proxy/src/tls_metrics.rs
+++ b/crates/proxy/src/tls_metrics.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{Context, Result};
 use once_cell::sync::OnceCell;
-use prometheus::{register_int_counter_vec, IntCounterVec};
+use prometheus::{register_int_counter_vec, register_int_gauge_vec, IntCounterVec, IntGaugeVec};
 use std::sync::Arc;
 
 /// Global TLS metrics instance.
@@ -32,6 +32,25 @@ pub struct TlsMetrics {
     /// Number of SNI certificates skipped at startup due to missing files (ACME)
     /// Labels: listener, primary_domain
     sni_certs_skipped_total: IntCounterVec,
+
+    /// Certificates currently loaded per listener.
+    ///
+    /// A gauge rather than a counter: what matters operationally is how many
+    /// are in service right now, which falls when a certificate is removed
+    /// from a scanned folder.
+    /// Labels: listener
+    certificates_loaded: IntGaugeVec,
+
+    /// Certificate reload attempts, by outcome.
+    ///
+    /// A failed reload leaves the previous certificates in use, so failures
+    /// are invisible in traffic. This is how they become visible.
+    /// Labels: listener, result
+    reload_total: IntCounterVec,
+
+    /// Files in a scanned folder that could not be used as a certificate.
+    /// Labels: listener, reason
+    folder_entries_skipped_total: IntCounterVec,
 }
 
 impl TlsMetrics {
@@ -44,9 +63,58 @@ impl TlsMetrics {
         )
         .context("Failed to register zentinel_tls_sni_certs_skipped_total metric")?;
 
+        let certificates_loaded = register_int_gauge_vec!(
+            "zentinel_tls_certificates_loaded",
+            "Number of TLS certificates currently loaded for a listener",
+            &["listener"]
+        )
+        .context("Failed to register zentinel_tls_certificates_loaded metric")?;
+
+        let reload_total = register_int_counter_vec!(
+            "zentinel_tls_reload_total",
+            "Total TLS certificate reload attempts by outcome",
+            &["listener", "result"]
+        )
+        .context("Failed to register zentinel_tls_reload_total metric")?;
+
+        let folder_entries_skipped_total = register_int_counter_vec!(
+            "zentinel_tls_folder_entries_skipped_total",
+            "Files in a scanned certificate folder that could not be loaded",
+            &["listener", "reason"]
+        )
+        .context("Failed to register zentinel_tls_folder_entries_skipped_total metric")?;
+
         Ok(Self {
             sni_certs_skipped_total,
+            certificates_loaded,
+            reload_total,
+            folder_entries_skipped_total,
         })
+    }
+
+    /// Record how many certificates a listener currently has loaded.
+    pub fn set_certificates_loaded(&self, listener_id: &str, count: usize) {
+        self.certificates_loaded
+            .with_label_values(&[listener_id])
+            .set(count as i64);
+    }
+
+    /// Record the outcome of a reload attempt.
+    pub fn record_reload(&self, listener_id: &str, succeeded: bool) {
+        let result = if succeeded { "success" } else { "failure" };
+        self.reload_total
+            .with_label_values(&[listener_id, result])
+            .inc();
+    }
+
+    /// Record a file skipped during a folder scan.
+    ///
+    /// `reason` is a small fixed set (`no_key`, `unreadable`) rather than the
+    /// error text, so it cannot become an unbounded label.
+    pub fn record_folder_entry_skipped(&self, listener_id: &str, reason: &str) {
+        self.folder_entries_skipped_total
+            .with_label_values(&[listener_id, reason])
+            .inc();
     }
 
     /// Record an SNI certificate skip event.

--- a/crates/proxy/tests/acme_startup_test.rs
+++ b/crates/proxy/tests/acme_startup_test.rs
@@ -71,6 +71,8 @@ mod storage_resolver_integration {
 
         // Build TlsConfig with ACME pointing at the storage
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: None,
             key_file: None,
             additional_certs: vec![],
@@ -307,6 +309,8 @@ mod validate_acme_config {
         // ACME-managed config without cert_file/key_file should pass validation
         let temp_dir = tempfile::tempdir().unwrap();
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: None,
             key_file: None,
             additional_certs: vec![],
@@ -332,6 +336,8 @@ mod validate_acme_config {
     fn test_validate_requires_cert_or_acme() {
         // No cert_file, no key_file, no ACME → should fail
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: None,
             key_file: None,
             additional_certs: vec![],

--- a/crates/proxy/tests/tls_cert_folder_test.rs
+++ b/crates/proxy/tests/tls_cert_folder_test.rs
@@ -1,0 +1,314 @@
+//! Tests for `sni-certs` certificate folder scanning.
+//!
+//! A folder is a moving target: certificates are written into it by other
+//! processes, sometimes non-atomically, and removed without the proxy being
+//! told. The scanner is therefore built to skip individual problems loudly
+//! rather than fail, so one half-written file cannot take every other
+//! certificate on the listener down with it.
+//!
+//! Part of zentinelproxy/zentinel#117.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use zentinel_config::{CertFolderReloadMode, SniCertFolder, TlsConfig};
+use zentinel_proxy::tls::SniResolver;
+
+fn fixtures() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("tests/fixtures/tls")
+}
+
+/// Copy a fixture pair into `dir` under a new stem.
+fn place(dir: &Path, fixture_stem: &str, as_stem: &str) {
+    fs::copy(
+        fixtures().join(format!("{fixture_stem}.crt")),
+        dir.join(format!("{as_stem}.crt")),
+    )
+    .expect("copy cert");
+    fs::copy(
+        fixtures().join(format!("{fixture_stem}.key")),
+        dir.join(format!("{as_stem}.key")),
+    )
+    .expect("copy key");
+}
+
+fn config_with_folder(dir: &Path) -> TlsConfig {
+    TlsConfig {
+        cert_file: Some(fixtures().join("server-default.crt")),
+        key_file: Some(fixtures().join("server-default.key")),
+        additional_certs: vec![],
+        cert_folders: vec![SniCertFolder {
+            cert_folder: dir.to_path_buf(),
+            reload_mode: CertFolderReloadMode::Off,
+            reload_interval: std::time::Duration::from_secs(30),
+        }],
+        allow_sni_overlaps: false,
+        ca_file: None,
+        min_version: zentinel_common::types::TlsVersion::Tls12,
+        max_version: None,
+        cipher_suites: vec![],
+        client_auth: false,
+        ocsp_stapling: false,
+        session_resumption: true,
+        acme: None,
+    }
+}
+
+/// Common name of a DER-encoded certificate.
+fn cn_of(der: &[u8]) -> String {
+    let (_, parsed) = x509_parser::parse_x509_certificate(der).expect("parseable certificate");
+    let cn = parsed
+        .subject()
+        .iter_common_name()
+        .next()
+        .and_then(|cn| cn.as_str().ok())
+        .unwrap_or("(no cn)")
+        .to_string();
+    cn
+}
+
+/// The certificate served for a hostname, identified by its CN.
+fn resolved_cn(resolver: &SniResolver, server_name: &str) -> String {
+    let cert = resolver.resolve(Some(server_name));
+    let der = cert.cert.first().expect("certificate present").to_vec();
+    cn_of(&der)
+}
+
+#[test]
+fn certificates_in_a_folder_are_discovered_and_served() {
+    let dir = tempfile::tempdir().unwrap();
+    place(dir.path(), "server-api", "api");
+    place(dir.path(), "server-secure", "secure");
+
+    // Every fixture certificate carries `DNS:localhost`, so any two of them
+    // collide on that name once hostnames are auto-extracted. That is the
+    // realistic shape of a scanned folder — see the dedicated test below —
+    // so overlaps are permitted here.
+    let mut config = config_with_folder(dir.path());
+    config.allow_sni_overlaps = true;
+    let resolver = SniResolver::from_config(&config, Some("folder-test")).expect("should build");
+
+    // Hostnames come from each certificate's CN and SANs — no config lists them.
+    assert_eq!(resolved_cn(&resolver, "api.example.com"), "api.example.com");
+    assert_eq!(
+        resolved_cn(&resolver, "secure.example.com"),
+        "secure.example.com"
+    );
+    // Anything unmatched still falls back to the default certificate.
+    assert_eq!(resolved_cn(&resolver, "unknown.test"), "example.com");
+}
+
+#[test]
+fn an_empty_folder_is_not_an_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = config_with_folder(dir.path());
+    let resolver = SniResolver::from_config(&config, Some("folder-test")).expect("should build");
+
+    assert_eq!(resolved_cn(&resolver, "anything"), "example.com");
+}
+
+#[test]
+fn a_missing_folder_is_reported_but_does_not_fail_the_listener() {
+    let mut config = config_with_folder(Path::new("/nonexistent/zentinel/certs"));
+    config.additional_certs = vec![];
+
+    let resolver = SniResolver::from_config(&config, Some("folder-test"))
+        .expect("a missing folder must not stop the listener from starting");
+    assert_eq!(resolved_cn(&resolver, "anything"), "example.com");
+}
+
+/// One unusable file must not cost the listener every other certificate.
+#[test]
+fn a_malformed_certificate_is_skipped_and_the_rest_still_load() {
+    let dir = tempfile::tempdir().unwrap();
+    place(dir.path(), "server-api", "api");
+
+    // A half-written certificate, as a non-atomic copy would leave behind.
+    fs::write(
+        dir.path().join("broken.crt"),
+        b"-----BEGIN CERTIFICATE-----\ntrunc",
+    )
+    .unwrap();
+    fs::write(dir.path().join("broken.key"), b"not a key").unwrap();
+
+    let config = config_with_folder(dir.path());
+    let resolver = SniResolver::from_config(&config, Some("folder-test")).expect("should build");
+
+    assert_eq!(resolved_cn(&resolver, "api.example.com"), "api.example.com");
+}
+
+#[test]
+fn a_certificate_without_a_key_is_skipped() {
+    let dir = tempfile::tempdir().unwrap();
+    place(dir.path(), "server-api", "api");
+    fs::copy(
+        fixtures().join("server-secure.crt"),
+        dir.path().join("orphan.crt"),
+    )
+    .unwrap();
+
+    let config = config_with_folder(dir.path());
+    let resolver = SniResolver::from_config(&config, Some("folder-test")).expect("should build");
+
+    assert_eq!(resolved_cn(&resolver, "api.example.com"), "api.example.com");
+    // The orphaned certificate contributed nothing, so its name falls back.
+    assert_eq!(resolved_cn(&resolver, "secure.example.com"), "example.com");
+}
+
+#[test]
+fn unrelated_files_in_the_folder_are_ignored() {
+    let dir = tempfile::tempdir().unwrap();
+    place(dir.path(), "server-api", "api");
+    fs::write(dir.path().join("README.txt"), b"notes").unwrap();
+    fs::write(dir.path().join("api.crt.bak"), b"backup").unwrap();
+    fs::create_dir(dir.path().join("subdir")).unwrap();
+
+    let config = config_with_folder(dir.path());
+    let resolver = SniResolver::from_config(&config, Some("folder-test")).expect("should build");
+
+    assert_eq!(resolved_cn(&resolver, "api.example.com"), "api.example.com");
+}
+
+/// Two certificates claiming the same name is a configuration error by
+/// default, because which one wins would otherwise be invisible.
+#[test]
+fn overlapping_hostnames_are_rejected_by_default() {
+    let dir = tempfile::tempdir().unwrap();
+    place(dir.path(), "server-api", "a-api");
+    place(dir.path(), "server-api", "b-api");
+
+    let config = config_with_folder(dir.path());
+    let err = SniResolver::from_config(&config, Some("folder-test"))
+        .expect_err("an overlap should be rejected");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("Ambiguous SNI configuration"),
+        "unexpected error: {message}"
+    );
+    assert!(
+        message.contains("allow-sni-overlaps"),
+        "the error should name the escape hatch: {message}"
+    );
+}
+
+/// A trap worth pinning: certificates issued for the same environment often
+/// share a SAN — every fixture here carries `DNS:localhost`. With hostnames
+/// auto-extracted from the certificate, two such files in one folder collide,
+/// and with the strict default that is a hard error.
+///
+/// This is the shape operators will hit first, and the failure arrives when a
+/// file is dropped into the folder rather than when the config is written. The
+/// error names `allow-sni-overlaps` for exactly that reason.
+#[test]
+fn certificates_sharing_a_san_collide_under_the_strict_default() {
+    let dir = tempfile::tempdir().unwrap();
+    // Different hostnames, but both carry DNS:localhost.
+    place(dir.path(), "server-api", "api");
+    place(dir.path(), "server-secure", "secure");
+
+    let config = config_with_folder(dir.path());
+    let err = SniResolver::from_config(&config, Some("folder-test"))
+        .expect_err("the shared SAN should be reported");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("localhost"),
+        "the error should name the colliding hostname: {message}"
+    );
+    assert!(
+        message.contains("allow-sni-overlaps"),
+        "and the way out of it: {message}"
+    );
+}
+
+/// With overlaps allowed, the winner is decided by sorted path order rather
+/// than by whatever order the filesystem happened to return.
+#[test]
+fn allowed_overlaps_resolve_deterministically() {
+    let dir = tempfile::tempdir().unwrap();
+    place(dir.path(), "server-api", "a-api");
+    place(dir.path(), "server-api", "b-api");
+
+    let mut config = config_with_folder(dir.path());
+    config.allow_sni_overlaps = true;
+
+    // Build repeatedly: the same certificate must win every time.
+    let first = {
+        let r = SniResolver::from_config(&config, Some("folder-test")).expect("should build");
+        resolved_cn(&r, "api.example.com")
+    };
+    for _ in 0..5 {
+        let r = SniResolver::from_config(&config, Some("folder-test")).expect("should build");
+        assert_eq!(
+            resolved_cn(&r, "api.example.com"),
+            first,
+            "the overlap winner must not vary between builds"
+        );
+    }
+}
+
+#[test]
+fn explicit_sni_blocks_and_scanned_folders_coexist() {
+    let dir = tempfile::tempdir().unwrap();
+    place(dir.path(), "server-api", "api");
+
+    let mut config = config_with_folder(dir.path());
+    config.additional_certs = vec![zentinel_config::SniCertificate {
+        hostnames: vec!["secure.example.com".to_string()],
+        priority_hostnames: vec![],
+        cert_file: Some(fixtures().join("server-secure.crt")),
+        key_file: Some(fixtures().join("server-secure.key")),
+        acme: None,
+    }];
+
+    let resolver = SniResolver::from_config(&config, Some("folder-test")).expect("should build");
+
+    assert_eq!(resolved_cn(&resolver, "api.example.com"), "api.example.com");
+    assert_eq!(
+        resolved_cn(&resolver, "secure.example.com"),
+        "secure.example.com"
+    );
+}
+
+/// A certificate added to the folder after startup is picked up by a reload,
+/// which is the point of scanning a folder rather than listing certificates.
+#[test]
+fn a_reload_picks_up_a_newly_added_certificate() {
+    use zentinel_proxy::tls::HotReloadableSniResolver;
+
+    fn served_cn(resolver: &HotReloadableSniResolver, name: &str) -> String {
+        let cert = resolver.resolve(Some(name));
+        let der = cert.cert.first().expect("certificate present").to_vec();
+        cn_of(&der)
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    place(dir.path(), "server-api", "api");
+
+    let mut config = config_with_folder(dir.path());
+    // The certificate added mid-test shares `DNS:localhost` with the one
+    // already present.
+    config.allow_sni_overlaps = true;
+    let resolver = HotReloadableSniResolver::from_config(config, "folder-test").expect("build");
+
+    assert_eq!(
+        served_cn(&resolver, "secure.example.com"),
+        "example.com",
+        "before the certificate exists, the default is served"
+    );
+
+    place(dir.path(), "server-secure", "secure");
+    resolver.reload().expect("reload should succeed");
+
+    assert_eq!(
+        served_cn(&resolver, "secure.example.com"),
+        "secure.example.com",
+        "the reload should have discovered the new certificate"
+    );
+}

--- a/crates/proxy/tests/tls_handshake_test.rs
+++ b/crates/proxy/tests/tls_handshake_test.rs
@@ -78,6 +78,8 @@ fn test_ca_roots() -> RootCertStore {
 fn base_tls_config() -> TlsConfig {
     let fixtures = fixtures_path();
     TlsConfig {
+        cert_folders: Vec::new(),
+        allow_sni_overlaps: false,
         cert_file: Some(fixtures.join("server-default.crt")),
         key_file: Some(fixtures.join("server-default.key")),
         additional_certs: vec![],

--- a/crates/proxy/tests/tls_sni_test.rs
+++ b/crates/proxy/tests/tls_sni_test.rs
@@ -27,6 +27,8 @@ fn fixtures_path() -> PathBuf {
 fn minimal_tls_config() -> TlsConfig {
     let fixtures = fixtures_path();
     TlsConfig {
+        cert_folders: Vec::new(),
+        allow_sni_overlaps: false,
         cert_file: Some(fixtures.join("server-default.crt")),
         key_file: Some(fixtures.join("server-default.key")),
         additional_certs: vec![],
@@ -45,6 +47,8 @@ fn minimal_tls_config() -> TlsConfig {
 fn multi_sni_tls_config() -> TlsConfig {
     let fixtures = fixtures_path();
     TlsConfig {
+        cert_folders: Vec::new(),
+        allow_sni_overlaps: false,
         cert_file: Some(fixtures.join("server-default.crt")),
         key_file: Some(fixtures.join("server-default.key")),
         additional_certs: vec![
@@ -78,6 +82,8 @@ fn multi_sni_tls_config() -> TlsConfig {
 fn wildcard_tls_config() -> TlsConfig {
     let fixtures = fixtures_path();
     TlsConfig {
+        cert_folders: Vec::new(),
+        allow_sni_overlaps: false,
         cert_file: Some(fixtures.join("server-default.crt")),
         key_file: Some(fixtures.join("server-default.key")),
         additional_certs: vec![SniCertificate {
@@ -102,6 +108,8 @@ fn wildcard_tls_config() -> TlsConfig {
 fn mtls_tls_config() -> TlsConfig {
     let fixtures = fixtures_path();
     TlsConfig {
+        cert_folders: Vec::new(),
+        allow_sni_overlaps: false,
         cert_file: Some(fixtures.join("server-default.crt")),
         key_file: Some(fixtures.join("server-default.key")),
         additional_certs: vec![],
@@ -266,6 +274,8 @@ mod sni_resolver {
         let fixtures = fixtures_path();
         // Create a config with both exact and wildcard for the same domain
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("server-default.crt")),
             key_file: Some(fixtures.join("server-default.key")),
             additional_certs: vec![
@@ -312,6 +322,8 @@ mod sni_resolver {
     fn test_error_on_missing_cert_file() {
         let fixtures = fixtures_path();
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("nonexistent.crt")),
             key_file: Some(fixtures.join("server-default.key")),
             additional_certs: vec![],
@@ -337,6 +349,8 @@ mod sni_resolver {
     fn test_error_on_missing_key_file() {
         let fixtures = fixtures_path();
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("server-default.crt")),
             key_file: Some(fixtures.join("nonexistent.key")),
             additional_certs: vec![],
@@ -362,6 +376,8 @@ mod sni_resolver {
     fn test_error_on_missing_sni_cert_file() {
         let fixtures = fixtures_path();
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("server-default.crt")),
             key_file: Some(fixtures.join("server-default.key")),
             additional_certs: vec![SniCertificate {
@@ -398,6 +414,8 @@ mod sni_auto_extraction {
     fn auto_extract_tls_config() -> TlsConfig {
         let fixtures = fixtures_path();
         TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("server-default.crt")),
             key_file: Some(fixtures.join("server-default.key")),
             additional_certs: vec![SniCertificate {
@@ -455,6 +473,8 @@ mod sni_auto_extraction {
         // server-wildcard.crt has SAN: DNS:*.example.com, DNS:example.com, DNS:localhost
         let fixtures = fixtures_path();
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("server-default.crt")),
             key_file: Some(fixtures.join("server-default.key")),
             additional_certs: vec![SniCertificate {
@@ -493,6 +513,8 @@ mod sni_auto_extraction {
         // Mix of explicit hostnames and auto-extracted
         let fixtures = fixtures_path();
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("server-default.crt")),
             key_file: Some(fixtures.join("server-default.key")),
             additional_certs: vec![
@@ -538,6 +560,8 @@ mod sni_auto_extraction {
         // Two certs with overlapping SAN entries should error
         let fixtures = fixtures_path();
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("server-default.crt")),
             key_file: Some(fixtures.join("server-default.key")),
             additional_certs: vec![
@@ -585,6 +609,8 @@ mod sni_auto_extraction {
         // When hostnames are explicitly set, CN/SAN should not be used
         let fixtures = fixtures_path();
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("server-default.crt")),
             key_file: Some(fixtures.join("server-default.key")),
             additional_certs: vec![SniCertificate {
@@ -651,6 +677,8 @@ mod acme_resolver {
     /// Build a TlsConfig with ACME config and no manual cert/key paths
     fn acme_tls_config(storage: PathBuf) -> TlsConfig {
         TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: None,
             key_file: None,
             additional_certs: vec![],
@@ -721,6 +749,8 @@ mod acme_resolver {
     #[test]
     fn test_from_config_no_cert_no_acme_errors() {
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: None,
             key_file: None,
             additional_certs: vec![],
@@ -815,6 +845,9 @@ mod acme_resolver {
         std::fs::copy(fixtures.join("server-api.key"), domain_dir.join("key.pem")).unwrap();
 
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("server-default.crt")),
             key_file: Some(fixtures.join("server-default.key")),
             additional_certs: vec![SniCertificate {
@@ -874,6 +907,9 @@ mod acme_resolver {
         std::fs::copy(fixtures.join("server-api.key"), domain_dir.join("key.pem")).unwrap();
 
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("server-default.crt")),
             key_file: Some(fixtures.join("server-default.key")),
             additional_certs: vec![SniCertificate {
@@ -920,6 +956,9 @@ mod acme_resolver {
         let fixtures = fixtures_path();
 
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("server-default.crt")),
             key_file: Some(fixtures.join("server-default.key")),
             additional_certs: vec![SniCertificate {
@@ -1122,6 +1161,8 @@ mod hot_reload {
 
         // Create resolver with initial certs
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some(cert_path.clone()),
             key_file: Some(key_path.clone()),
             additional_certs: vec![],
@@ -1175,6 +1216,9 @@ mod hot_reload {
         std::fs::copy(fixtures.join("server-default.key"), &key_path).unwrap();
 
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+
+            allow_sni_overlaps: false,
             cert_file: Some(cert_path.clone()),
             key_file: Some(key_path.clone()),
             additional_certs: vec![],
@@ -1221,6 +1265,9 @@ mod hot_reload {
         std::fs::copy(fixtures.join("server-default.key"), &key_path).unwrap();
 
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+
+            allow_sni_overlaps: false,
             cert_file: Some(cert_path.clone()),
             key_file: Some(key_path.clone()),
             additional_certs: vec![],
@@ -1347,6 +1394,9 @@ mod certificate_reloader {
         std::fs::copy(fixtures.join("server-default.key"), &key_path).unwrap();
 
         let config2 = TlsConfig {
+            cert_folders: Vec::new(),
+
+            allow_sni_overlaps: false,
             cert_file: Some(cert_path.clone()),
             key_file: Some(key_path.clone()),
             additional_certs: vec![],
@@ -1450,6 +1500,8 @@ mod validation {
     fn test_validate_missing_cert_file() {
         let fixtures = fixtures_path();
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("nonexistent.crt")),
             key_file: Some(fixtures.join("server-default.key")),
             additional_certs: vec![],
@@ -1477,6 +1529,8 @@ mod validation {
     fn test_validate_missing_key_file() {
         let fixtures = fixtures_path();
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("server-default.crt")),
             key_file: Some(fixtures.join("nonexistent.key")),
             additional_certs: vec![],
@@ -1504,6 +1558,8 @@ mod validation {
     fn test_validate_missing_sni_cert() {
         let fixtures = fixtures_path();
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("server-default.crt")),
             key_file: Some(fixtures.join("server-default.key")),
             additional_certs: vec![SniCertificate {
@@ -1531,6 +1587,8 @@ mod validation {
     fn test_validate_mtls_missing_ca_file() {
         let fixtures = fixtures_path();
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("server-default.crt")),
             key_file: Some(fixtures.join("server-default.key")),
             additional_certs: vec![],
@@ -1630,6 +1688,8 @@ mod server_config {
         // With priority-hostnames on server-api.crt, it wins for "localhost".
         let fixtures = fixtures_path();
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("server-default.crt")),
             key_file: Some(fixtures.join("server-default.key")),
             additional_certs: vec![
@@ -1682,6 +1742,8 @@ mod server_config {
         // priority-hostnames only lists "localhost", but all SANs should be registered.
         let fixtures = fixtures_path();
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("server-default.crt")),
             key_file: Some(fixtures.join("server-default.key")),
             additional_certs: vec![SniCertificate {
@@ -1722,6 +1784,8 @@ mod server_config {
         // Both certs claim priority for "localhost"
         let fixtures = fixtures_path();
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("server-default.crt")),
             key_file: Some(fixtures.join("server-default.key")),
             additional_certs: vec![
@@ -1770,6 +1834,8 @@ mod server_config {
         // Both have "localhost". Priority on wildcard cert wins.
         let fixtures = fixtures_path();
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("server-default.crt")),
             key_file: Some(fixtures.join("server-default.key")),
             additional_certs: vec![
@@ -1823,6 +1889,8 @@ mod server_config {
         // The priority cert should still win.
         let fixtures = fixtures_path();
         let config = TlsConfig {
+            cert_folders: Vec::new(),
+            allow_sni_overlaps: false,
             cert_file: Some(fixtures.join("server-default.crt")),
             key_file: Some(fixtures.join("server-default.key")),
             additional_certs: vec![


### PR DESCRIPTION
Closes #117.

## What it does

An `sni-certs` block points at a folder instead of listing certificates one by one. Each certificate/key pair found is registered with the hostnames from its own CN and SANs, so adding or removing a certificate no longer means editing the configuration.

```kdl
tls {
    cert-file "/etc/zentinel/certs/default.crt"
    key-file  "/etc/zentinel/certs/default.key"

    sni-certs {
        cert-folder "/etc/zentinel/certs/dynamic/"
        reload-mode "watch"
        reload-interval "30s"
    }
}
```

Scanned pairs are fed through the **same registration loop** as explicit `sni` blocks, so hostname extraction, priority tie-breaking and overlap detection have one implementation rather than two.

## Verified on the running binary

Folder containing only `api.crt`/`api.key`:

```
api.example.com     -> CN=api.example.com
secure.example.com  -> CN=example.com        (default fallback)
```

Then `secure.crt`/`secure.key` were copied into the folder:

```
INFO TLS certificates reloaded successfully listener_id=https
api.example.com     -> CN=api.example.com
secure.example.com  -> CN=secure.example.com
```

No restart, no SIGHUP.

## Reload modes are implemented, not just parsed

- `off` — scanned at startup and on SIGHUP with the rest of the config
- `interval` — timer; works on filesystems that report no change events
- `watch` — filesystem events, with a settle delay before rescanning, because certificates are usually written as two files in quick succession and reading midway finds a key with no certificate

A watcher that cannot be established **degrades to the interval and logs why**, rather than leaving the folder silently unwatched.

Shipping `reload-mode` as a field that parsed and did nothing would have reproduced exactly the class of bug #303 just fixed on this listener. That is why the modes are in this PR rather than a follow-up.

## Failure handling

A folder is a moving target — files appear while being written, and a renewal can leave a truncated file behind. Unusable entries are **skipped, logged and counted**, never fatal: one bad file must not cost the listener every other certificate.

## Overlaps, and a trap worth knowing before you deploy this

Because hostnames come from the certificates, two of them can claim the same name. That is an error by default — which one wins would otherwise depend on directory iteration order.

**This is easier to hit than it sounds.** Certificates issued for one environment routinely share a SAN. Every fixture in this repo carries `DNS:localhost`, so *any two of them* in one folder collide. There is a test pinning that exact case, because it is what an operator will hit first, and the failure arrives when a file is dropped into the folder rather than when the config is written.

`allow-sni-overlaps` accepts overlaps and resolves them by **sorted path order** — stable across machines and reloads, unlike directory order. A test builds the resolver repeatedly and asserts the same certificate wins every time.

## Metrics

| Metric | Type |
|---|---|
| `zentinel_tls_certificates_loaded` | gauge |
| `zentinel_tls_reload_total{result}` | counter |
| `zentinel_tls_folder_entries_skipped_total{reason}` | counter |

The reload counter is the one to alert on: a failed reload keeps serving the previous certificates, so it is invisible in traffic. `reason` is a small fixed set rather than error text, so it cannot become an unbounded label.

## Tests

11 in `crates/proxy/tests/tls_cert_folder_test.rs`: discovery and serving, empty folder, missing folder, malformed certificate, certificate without a key, unrelated files, the strict overlap error, the shared-SAN collision, deterministic overlap resolution, explicit blocks coexisting with scanned ones, and a reload picking up a newly added certificate.

Existing suites still green: 62 SNI, 9 handshake. fmt and clippy clean.

## Two incidental fixes

- `sni-certs` and `allow-sni-overlaps` were rejected by the `tls` block's unknown-node validation, so the block could not be used at all until they were added to the allow-list.
- `parse_duration_string` is now shared rather than duplicated.

Docs: zentinelproxy/zentinelproxy.io-docs#(branch `docs/sni-cert-folder`).
