### PR TITLE
feat(routes): implement retry-policy behaviour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "TinyUFO"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=de28721#de28721d24a1975c86136d781ffc5e44340cfbe0"
 dependencies = [
  "ahash 0.8.12",
  "crossbeam-queue",
@@ -4275,7 +4275,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 [[package]]
 name = "pingora"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=de28721#de28721d24a1975c86136d781ffc5e44340cfbe0"
 dependencies = [
  "pingora-cache",
  "pingora-core",
@@ -4288,7 +4288,7 @@ dependencies = [
 [[package]]
 name = "pingora-cache"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=de28721#de28721d24a1975c86136d781ffc5e44340cfbe0"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -4324,7 +4324,7 @@ dependencies = [
 [[package]]
 name = "pingora-core"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=de28721#de28721d24a1975c86136d781ffc5e44340cfbe0"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -4377,12 +4377,12 @@ dependencies = [
 [[package]]
 name = "pingora-error"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=de28721#de28721d24a1975c86136d781ffc5e44340cfbe0"
 
 [[package]]
 name = "pingora-header-serde"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=de28721#de28721d24a1975c86136d781ffc5e44340cfbe0"
 dependencies = [
  "bytes",
  "http 1.5.0",
@@ -4397,7 +4397,7 @@ dependencies = [
 [[package]]
 name = "pingora-http"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=de28721#de28721d24a1975c86136d781ffc5e44340cfbe0"
 dependencies = [
  "bytes",
  "http 1.5.0",
@@ -4407,7 +4407,7 @@ dependencies = [
 [[package]]
 name = "pingora-ketama"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=de28721#de28721d24a1975c86136d781ffc5e44340cfbe0"
 dependencies = [
  "crc32fast",
 ]
@@ -4415,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "pingora-limits"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=de28721#de28721d24a1975c86136d781ffc5e44340cfbe0"
 dependencies = [
  "ahash 0.8.12",
 ]
@@ -4423,7 +4423,7 @@ dependencies = [
 [[package]]
 name = "pingora-load-balancing"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=de28721#de28721d24a1975c86136d781ffc5e44340cfbe0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4444,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "pingora-lru"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=de28721#de28721d24a1975c86136d781ffc5e44340cfbe0"
 dependencies = [
  "arrayvec",
  "hashbrown 0.12.3",
@@ -4455,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "pingora-memory-cache"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=de28721#de28721d24a1975c86136d781ffc5e44340cfbe0"
 dependencies = [
  "TinyUFO",
  "ahash 0.8.12",
@@ -4470,7 +4470,7 @@ dependencies = [
 [[package]]
 name = "pingora-pool"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=de28721#de28721d24a1975c86136d781ffc5e44340cfbe0"
 dependencies = [
  "crossbeam-queue",
  "log",
@@ -4484,7 +4484,7 @@ dependencies = [
 [[package]]
 name = "pingora-proxy"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=de28721#de28721d24a1975c86136d781ffc5e44340cfbe0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4506,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "pingora-runtime"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=de28721#de28721d24a1975c86136d781ffc5e44340cfbe0"
 dependencies = [
  "once_cell",
  "rand 0.8.6",
@@ -4517,7 +4517,7 @@ dependencies = [
 [[package]]
 name = "pingora-rustls"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=de28721#de28721d24a1975c86136d781ffc5e44340cfbe0"
 dependencies = [
  "log",
  "no_debug",
@@ -4533,7 +4533,7 @@ dependencies = [
 [[package]]
 name = "pingora-timeout"
 version = "0.8.1"
-source = "git+https://github.com/zentinelproxy/pingora.git?rev=ffaf897#ffaf897847dbe6212c862cdae73df855bfd59470"
+source = "git+https://github.com/zentinelproxy/pingora.git?rev=de28721#de28721d24a1975c86136d781ffc5e44340cfbe0"
 dependencies = [
  "once_cell",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,15 +30,15 @@ rust-version = "1.95.0"
 
 [workspace.dependencies]
 # Core dependencies (using our fork with security fixes, rebased on 0.8.1)
-pingora = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "ffaf897", features = ["proxy", "lb", "rustls"] }
-pingora-core = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "ffaf897", features = ["rustls"] }
-pingora-http = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "ffaf897" }
-pingora-proxy = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "ffaf897" }
-pingora-load-balancing = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "ffaf897" }
-pingora-timeout = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "ffaf897" }
-pingora-limits = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "ffaf897" }
-pingora-cache = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "ffaf897" }
-pingora-memory-cache = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "ffaf897" }
+pingora = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "de28721", features = ["proxy", "lb", "rustls"] }
+pingora-core = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "de28721", features = ["rustls"] }
+pingora-http = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "de28721" }
+pingora-proxy = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "de28721" }
+pingora-load-balancing = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "de28721" }
+pingora-timeout = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "de28721" }
+pingora-limits = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "de28721" }
+pingora-cache = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "de28721" }
+pingora-memory-cache = { version = "0.8.1", git = "https://github.com/zentinelproxy/pingora.git", rev = "de28721" }
 
 # Async runtime
 # Minimal feature set for proxy workloads (trimmed from "full" for smaller binary)

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -8,6 +8,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
+use std::time::Duration;
 
 /// HTTP method wrapper with validation
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -221,12 +222,97 @@ pub enum HealthCheckType {
 /// Retry policy
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RetryPolicy {
+    /// Total attempts, including the first. `3` means one try and two retries.
     pub max_attempts: u32,
+
+    /// Upstream status codes that cause the response to be discarded and the
+    /// request retried.
+    ///
+    /// Empty by default: retrying on a status code replays the request, and
+    /// which codes are safe to replay depends on the application. `503` from
+    /// a load shedder is worth retrying; `500` from a handler that already
+    /// charged a card is not.
+    #[serde(default)]
+    pub retryable_status_codes: Vec<u16>,
+
+    /// Delay before the first retry. Doubles each attempt, capped at
+    /// `max_backoff`.
+    #[serde(default = "default_retry_backoff")]
+    pub backoff: Duration,
+
+    /// Ceiling for the doubling backoff.
+    #[serde(default = "default_retry_max_backoff")]
+    pub max_backoff: Duration,
+
+    /// Connection timeout applied to each attempt.
+    ///
+    /// Without this, three attempts against a black-holed upstream each wait
+    /// the full connect timeout, so a policy meant to improve availability
+    /// triples the worst-case latency instead.
+    #[serde(default)]
+    pub per_attempt_timeout: Option<Duration>,
+
+    /// Whether a request may be retried when its method is not idempotent.
+    ///
+    /// Off by default. Replaying a POST can duplicate a side effect the
+    /// origin already performed, and the proxy cannot tell whether it did.
+    #[serde(default)]
+    pub retry_non_idempotent: bool,
+}
+
+fn default_retry_backoff() -> Duration {
+    Duration::from_millis(100)
+}
+
+fn default_retry_max_backoff() -> Duration {
+    Duration::from_secs(2)
 }
 
 impl Default for RetryPolicy {
     fn default() -> Self {
-        Self { max_attempts: 3 }
+        Self {
+            max_attempts: 3,
+            retryable_status_codes: Vec::new(),
+            backoff: default_retry_backoff(),
+            max_backoff: default_retry_max_backoff(),
+            per_attempt_timeout: None,
+            retry_non_idempotent: false,
+        }
+    }
+}
+
+impl RetryPolicy {
+    /// Backoff before `attempt` (1-based: the delay before attempt 2 is
+    /// `backoff`, before attempt 3 is `backoff * 2`, and so on).
+    pub fn backoff_for(&self, attempt: u32) -> Duration {
+        if attempt <= 1 {
+            return Duration::ZERO;
+        }
+        let doublings = attempt.saturating_sub(2).min(16);
+        let scaled = self
+            .backoff
+            .saturating_mul(1u32.checked_shl(doublings).unwrap_or(u32::MAX));
+        scaled.min(self.max_backoff)
+    }
+
+    /// Whether this status code should cause a retry.
+    pub fn is_retryable_status(&self, status: u16) -> bool {
+        self.retryable_status_codes.contains(&status)
+    }
+
+    /// Whether a request using `method` may be replayed.
+    ///
+    /// Idempotent methods are safe by definition. Anything else needs
+    /// `retry_non_idempotent`, because replaying it can duplicate a side
+    /// effect the origin already performed.
+    pub fn may_retry_method(&self, method: &str) -> bool {
+        if self.retry_non_idempotent {
+            return true;
+        }
+        matches!(
+            method.to_ascii_uppercase().as_str(),
+            "GET" | "HEAD" | "PUT" | "DELETE" | "OPTIONS" | "TRACE"
+        )
     }
 }
 
@@ -494,5 +580,94 @@ mod tests {
             TraceIdFormat::from_str_loose("unknown"),
             TraceIdFormat::TinyFlake
         );
+    }
+}
+
+#[cfg(test)]
+mod retry_policy_tests {
+    use super::*;
+
+    fn policy() -> RetryPolicy {
+        RetryPolicy {
+            backoff: Duration::from_millis(100),
+            max_backoff: Duration::from_secs(2),
+            ..RetryPolicy::default()
+        }
+    }
+
+    /// `backoff_for` takes the attempt number the delay precedes, so attempt 1
+    /// (the first try) has no delay and attempt 2 waits the base backoff.
+    /// Getting this off by one silently skips the first retry's backoff, which
+    /// is the difference between spacing retries out and hammering a struggling
+    /// upstream three times in a millisecond.
+    #[test]
+    fn backoff_doubles_from_the_second_attempt() {
+        let p = policy();
+        assert_eq!(p.backoff_for(1), Duration::ZERO);
+        assert_eq!(p.backoff_for(2), Duration::from_millis(100));
+        assert_eq!(p.backoff_for(3), Duration::from_millis(200));
+        assert_eq!(p.backoff_for(4), Duration::from_millis(400));
+    }
+
+    #[test]
+    fn backoff_is_capped() {
+        let p = policy();
+        assert_eq!(p.backoff_for(20), Duration::from_secs(2));
+        // And does not overflow at absurd attempt counts.
+        assert_eq!(p.backoff_for(u32::MAX), Duration::from_secs(2));
+    }
+
+    #[test]
+    fn zero_backoff_stays_zero() {
+        let p = RetryPolicy {
+            backoff: Duration::ZERO,
+            ..RetryPolicy::default()
+        };
+        assert_eq!(p.backoff_for(3), Duration::ZERO);
+    }
+
+    #[test]
+    fn only_configured_status_codes_are_retryable() {
+        let p = RetryPolicy {
+            retryable_status_codes: vec![502, 503],
+            ..RetryPolicy::default()
+        };
+        assert!(p.is_retryable_status(503));
+        assert!(!p.is_retryable_status(500));
+        assert!(!p.is_retryable_status(200));
+    }
+
+    /// Nothing is retryable by default. Replaying a request has side effects
+    /// the proxy cannot see, so it should take a deliberate choice.
+    #[test]
+    fn no_status_code_is_retryable_by_default() {
+        let p = RetryPolicy::default();
+        for status in [500, 502, 503, 504] {
+            assert!(!p.is_retryable_status(status));
+        }
+    }
+
+    #[test]
+    fn only_idempotent_methods_are_replayed_by_default() {
+        let p = RetryPolicy::default();
+        for method in ["GET", "HEAD", "PUT", "DELETE", "OPTIONS", "TRACE", "get"] {
+            assert!(p.may_retry_method(method), "{method} should be retryable");
+        }
+        for method in ["POST", "PATCH", "post", "LOCK"] {
+            assert!(
+                !p.may_retry_method(method),
+                "{method} must not be replayed without opting in"
+            );
+        }
+    }
+
+    #[test]
+    fn opting_in_allows_replaying_any_method() {
+        let p = RetryPolicy {
+            retry_non_idempotent: true,
+            ..RetryPolicy::default()
+        };
+        assert!(p.may_retry_method("POST"));
+        assert!(p.may_retry_method("PATCH"));
     }
 }

--- a/crates/config/src/kdl/retrypolicy_helper.rs
+++ b/crates/config/src/kdl/retrypolicy_helper.rs
@@ -11,15 +11,121 @@ pub fn parse_retry_policy(node: &kdl::KdlNode) -> Result<RetryPolicy> {
             "max-attempts" => {
                 cfg.max_attempts = extract_u32_with_limits(node)?;
             }
+            "retryable-status-codes" => {
+                let mut codes = Vec::new();
+                for entry in node.entries() {
+                    let code = entry.value().as_integer().ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "retryable-status-codes takes status codes as numbers, \
+                             for example: retryable-status-codes 502 503 504"
+                        )
+                    })?;
+                    let code = u16::try_from(code).ok().filter(|c| (100..=599).contains(c));
+                    match code {
+                        Some(c) => codes.push(c),
+                        None => {
+                            return Err(anyhow::anyhow!(
+                                "retryable-status-codes contains a value that is not an \
+                                 HTTP status code (100-599)"
+                            ))
+                        }
+                    }
+                }
+                if codes.is_empty() {
+                    return Err(anyhow::anyhow!(
+                        "retryable-status-codes was given no status codes; omit the node \
+                         instead of leaving it empty"
+                    ));
+                }
+                cfg.retryable_status_codes = codes;
+            }
+            "backoff" => {
+                cfg.backoff = parse_retry_duration(node, "backoff")?;
+            }
+            "max-backoff" => {
+                cfg.max_backoff = parse_retry_duration(node, "max-backoff")?;
+            }
+            "per-attempt-timeout" => {
+                cfg.per_attempt_timeout = Some(parse_retry_duration(node, "per-attempt-timeout")?);
+            }
+            "retry-non-idempotent" => {
+                cfg.retry_non_idempotent = node
+                    .entries()
+                    .first()
+                    .and_then(|e| e.value().as_bool())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "retry-non-idempotent takes a boolean, for example: \
+                             retry-non-idempotent #true"
+                        )
+                    })?;
+            }
             d => {
-                return Err(anyhow::anyhow!("Got unknown key {}", d));
+                return Err(anyhow::anyhow!(
+                    "Unknown key '{}' in retry-policy. Valid keys are: max-attempts, \
+                     retryable-status-codes, backoff, max-backoff, per-attempt-timeout, \
+                     retry-non-idempotent",
+                    d
+                ));
             }
         }
 
         Ok(cfg)
     }
 
-    node.iter_children().try_fold(default_config, rp_config_map)
+    let policy = node
+        .iter_children()
+        .try_fold(default_config, rp_config_map)?;
+
+    // A doubling backoff that starts above its own ceiling never doubles, so
+    // the ceiling silently becomes the only delay. Say so rather than let the
+    // config imply a ramp that cannot happen.
+    if policy.backoff > policy.max_backoff {
+        return Err(anyhow::anyhow!(
+            "retry-policy backoff ({:?}) is greater than max-backoff ({:?}); \
+             the backoff would never grow",
+            policy.backoff,
+            policy.max_backoff
+        ));
+    }
+
+    Ok(policy)
+}
+
+/// Parse a duration node such as `backoff "250ms"`.
+fn parse_retry_duration(node: &kdl::KdlNode, key: &str) -> Result<std::time::Duration> {
+    let text = node
+        .entries()
+        .first()
+        .and_then(|e| e.value().as_string())
+        .ok_or_else(|| {
+            anyhow::anyhow!("{key} takes a duration string, for example: {key} \"250ms\"")
+        })?;
+    parse_short_duration(text).ok_or_else(|| {
+        anyhow::anyhow!(
+            "{key} has an invalid duration '{text}'. Use a value such as \"250ms\", \
+             \"2s\" or \"1m\""
+        )
+    })
+}
+
+/// Durations here are usually sub-second, which the shared seconds-resolution
+/// parser cannot express -- a `100ms` backoff would round to zero.
+fn parse_short_duration(text: &str) -> Option<std::time::Duration> {
+    let text = text.trim();
+    let idx = text.find(|c: char| c.is_alphabetic())?;
+    let (value, unit) = text.split_at(idx);
+    let value: f64 = value.trim().parse().ok()?;
+    if value < 0.0 || !value.is_finite() {
+        return None;
+    }
+    let millis = match unit.trim().to_ascii_lowercase().as_str() {
+        "ms" => value,
+        "s" | "sec" | "secs" => value * 1_000.0,
+        "m" | "min" | "mins" => value * 60_000.0,
+        _ => return None,
+    };
+    Some(std::time::Duration::from_millis(millis as u64))
 }
 
 #[cfg(test)]
@@ -59,7 +165,7 @@ mod tests {
 
         let rp = parse_retry_policy(rp_node);
         let err_msg = rp.unwrap_err();
-        assert_eq!(format!("{}", err_msg), "Got unknown key max-attempt");
+        assert_eq!(format!("{}", err_msg), "Unknown key 'max-attempt' in retry-policy. Valid keys are: max-attempts, retryable-status-codes, backoff, max-backoff, per-attempt-timeout, retry-non-idempotent");
     }
 
     /// retry-policy stanza present, new key unrecognized, expect to Err and panic out
@@ -77,7 +183,7 @@ mod tests {
 
         let rp = parse_retry_policy(rp_node);
         let err_msg = rp.unwrap_err();
-        assert_eq!(format!("{}", err_msg), "Got unknown key frob");
+        assert_eq!(format!("{}", err_msg), "Unknown key 'frob' in retry-policy. Valid keys are: max-attempts, retryable-status-codes, backoff, max-backoff, per-attempt-timeout, retry-non-idempotent");
     }
 
     /// retry-policy stanza present, one value unrecognized, expect to Err and panic out
@@ -173,5 +279,95 @@ mod tests {
         let default_rp = RetryPolicy::default();
 
         assert_eq!(rp.max_attempts, default_rp.max_attempts);
+    }
+}
+
+#[cfg(test)]
+mod extended_tests {
+    use super::parse_retry_policy;
+    use std::time::Duration;
+
+    fn parse(kdl: &str) -> Result<zentinel_common::types::RetryPolicy, String> {
+        let doc: kdl::KdlDocument = kdl.parse().unwrap();
+        let node = doc.get("retry-policy").unwrap();
+        parse_retry_policy(node).map_err(|e| e.to_string())
+    }
+
+    #[test]
+    fn full_policy_parses() {
+        let p = parse(
+            r#"
+            retry-policy {
+                max-attempts 4
+                retryable-status-codes 502 503 504
+                backoff "250ms"
+                max-backoff "5s"
+                per-attempt-timeout "1s"
+                retry-non-idempotent #true
+            }
+        "#,
+        )
+        .expect("should parse");
+
+        assert_eq!(p.max_attempts, 4);
+        assert_eq!(p.retryable_status_codes, vec![502, 503, 504]);
+        assert_eq!(p.backoff, Duration::from_millis(250));
+        assert_eq!(p.max_backoff, Duration::from_secs(5));
+        assert_eq!(p.per_attempt_timeout, Some(Duration::from_secs(1)));
+        assert!(p.retry_non_idempotent);
+    }
+
+    /// Sub-second backoffs are the common case, so a parser that only
+    /// understands whole seconds would round `100ms` to zero and quietly
+    /// remove the spacing between retries.
+    #[test]
+    fn sub_second_durations_are_preserved() {
+        let p = parse("retry-policy {\n backoff \"50ms\"\n}").unwrap();
+        assert_eq!(p.backoff, Duration::from_millis(50));
+    }
+
+    #[test]
+    fn a_backoff_above_its_ceiling_is_rejected() {
+        // Otherwise the ceiling silently becomes the only delay and the
+        // configured ramp never happens.
+        let err = parse("retry-policy {\n backoff \"10s\"\n max-backoff \"1s\"\n}")
+            .expect_err("should be rejected");
+        assert!(err.contains("never grow"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn a_non_status_code_is_rejected() {
+        let err = parse("retry-policy {\n retryable-status-codes 700\n}")
+            .expect_err("should be rejected");
+        assert!(err.contains("100-599"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn an_empty_status_code_list_is_rejected() {
+        // An empty list reads as "retry on any status" but means "retry on
+        // none", so it is better refused than misread.
+        let err =
+            parse("retry-policy {\n retryable-status-codes\n}").expect_err("should be rejected");
+        assert!(err.contains("no status codes"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn an_invalid_duration_is_rejected() {
+        let err = parse("retry-policy {\n backoff \"soon\"\n}").expect_err("should be rejected");
+        assert!(err.contains("invalid duration"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn defaults_are_conservative() {
+        let p = parse("retry-policy {\n max-attempts 3\n}").unwrap();
+        assert!(
+            p.retryable_status_codes.is_empty(),
+            "no status should be retryable unless asked for"
+        );
+        assert!(
+            !p.retry_non_idempotent,
+            "replaying a POST should take a deliberate choice"
+        );
+        assert_eq!(p.per_attempt_timeout, None);
     }
 }

--- a/crates/proxy/src/proxy/context.rs
+++ b/crates/proxy/src/proxy/context.rs
@@ -101,6 +101,12 @@ pub struct RequestContext {
     pub(crate) selected_upstream_address: Option<String>,
     /// Number of upstream attempts
     pub(crate) upstream_attempts: u32,
+    /// Times the request itself has been sent upstream.
+    ///
+    /// Distinct from `upstream_attempts`, which counts tries at *selecting* a
+    /// backend. This one backs the route's `retry-policy` and is incremented
+    /// in `upstream_peer`, which Pingora re-enters on every retry.
+    pub(crate) request_attempts: u32,
 
     // === Scope (for namespaced configurations) ===
     /// Namespace for this request (if routed to a namespace scope)
@@ -340,6 +346,7 @@ impl RequestContext {
             upstream: None,
             selected_upstream_address: None,
             upstream_attempts: 0,
+            request_attempts: 0,
             namespace: None,
             service: None,
             method: String::new(),
@@ -491,6 +498,11 @@ impl RequestContext {
 
     /// Get the number of upstream attempts.
     #[inline]
+    /// Times the request itself has been sent upstream.
+    pub fn request_attempts(&self) -> u32 {
+        self.request_attempts
+    }
+
     pub fn upstream_attempts(&self) -> u32 {
         self.upstream_attempts
     }

--- a/crates/proxy/src/proxy/http_trait.rs
+++ b/crates/proxy/src/proxy/http_trait.rs
@@ -70,6 +70,67 @@ impl ProxyHttp for ZentinelProxy {
         RequestContext::new()
     }
 
+    /// Whether to discard this upstream response and retry the request.
+    ///
+    /// Pingora calls this before any of the response reaches downstream, which
+    /// is the only point where discarding is still possible. Without it a
+    /// `retry-policy` could only ever cover transport errors, because a status
+    /// code is not an error for the retry loop to react to.
+    ///
+    /// Deliberately returns `false` on the final attempt: three failed tries
+    /// should end with the upstream's 503, not a generic gateway error.
+    fn should_retry_response(
+        &self,
+        session: &Session,
+        resp: &ResponseHeader,
+        ctx: &mut Self::CTX,
+    ) -> bool {
+        let Some(route) = ctx.route_config() else {
+            return false;
+        };
+        let Some(policy) = route.retry_policy.as_ref() else {
+            return false;
+        };
+
+        if !policy.is_retryable_status(resp.status.as_u16()) {
+            return false;
+        }
+
+        // Replaying a POST can duplicate a side effect the origin already
+        // performed, and nothing here can tell whether it did.
+        let method = session.req_header().method.as_str();
+        if !policy.may_retry_method(method) {
+            debug!(
+                correlation_id = %ctx.trace_id,
+                method = method,
+                status = resp.status.as_u16(),
+                "Not retrying a non-idempotent request; set retry-non-idempotent to allow it"
+            );
+            return false;
+        }
+
+        // `max_attempts` counts the first try, so the last attempt must let
+        // the response through rather than turning it into a proxy error.
+        if ctx.request_attempts >= policy.max_attempts {
+            debug!(
+                correlation_id = %ctx.trace_id,
+                status = resp.status.as_u16(),
+                attempts = ctx.request_attempts,
+                "Retry budget exhausted; forwarding the upstream response"
+            );
+            return false;
+        }
+
+        info!(
+            correlation_id = %ctx.trace_id,
+            status = resp.status.as_u16(),
+            attempt = ctx.request_attempts,
+            max_attempts = policy.max_attempts,
+            "Retrying request after a retryable upstream status"
+        );
+        true
+    }
+
     fn fail_to_connect(
         &self,
         _session: &mut Session,
@@ -654,13 +715,35 @@ impl ProxyHttp for ZentinelProxy {
                 )
             })?;
 
-        // Select peer from pool with retries
-        let max_retries = route_match
-            .config
-            .retry_policy
-            .as_ref()
-            .map(|r| r.max_attempts)
-            .unwrap_or(1);
+        // Retry *peer selection*, which fails only when the pool has no
+        // healthy member. This is deliberately not `retry-policy.max-attempts`:
+        // that governs retrying the request, and conflating the two meant a
+        // route configured for request resilience got extra tries at picking a
+        // backend instead -- an operation that rarely fails, and where retrying
+        // only delays the error.
+        const PEER_SELECTION_ATTEMPTS: u32 = 2;
+        let max_retries = PEER_SELECTION_ATTEMPTS;
+
+        // Delay before this attempt at the *request*, from the route's policy.
+        // upstream_peer is re-entered by Pingora's retry loop, so this is where
+        // the backoff belongs.
+        // Count first, then decide: this call *is* attempt N, so gating on
+        // the pre-increment value skipped the backoff before the first retry.
+        ctx.request_attempts += 1;
+        if ctx.request_attempts > 1 {
+            if let Some(policy) = route_match.config.retry_policy.as_ref() {
+                let backoff = policy.backoff_for(ctx.request_attempts);
+                if !backoff.is_zero() {
+                    trace!(
+                        correlation_id = %ctx.trace_id,
+                        attempt = ctx.request_attempts,
+                        backoff_ms = backoff.as_millis(),
+                        "Backing off before retrying the request"
+                    );
+                    tokio::time::sleep(backoff).await;
+                }
+            }
+        }
 
         trace!(
             correlation_id = %ctx.trace_id,
@@ -731,6 +814,20 @@ impl ProxyHttp for ZentinelProxy {
                     }
                     if let Some(upstream_secs) = ctx.filter_upstream_timeout_secs {
                         peer.options.read_timeout = Some(Duration::from_secs(upstream_secs));
+                    }
+
+                    // A retry policy's per-attempt timeout caps each try.
+                    // Without it, three attempts against a black-holed
+                    // upstream each wait the full connect timeout, so a policy
+                    // meant to improve availability triples the worst-case
+                    // latency instead.
+                    if let Some(per_attempt) = route_match
+                        .config
+                        .retry_policy
+                        .as_ref()
+                        .and_then(|p| p.per_attempt_timeout)
+                    {
+                        peer.options.connection_timeout = Some(per_attempt);
                     }
 
                     return Ok(Box::new(peer));


### PR DESCRIPTION
Closes #279.

## What was wrong

A route configured with `retry-policy { max-attempts 3 }` reads as "retry failed requests three times". It did not do that.

`max_attempts` bounded retries of **peer selection** — picking a backend from the pool — which fails only when no pool member is healthy. There was no request retry at all: no retry on an upstream 5xx, no `retryable-status-codes`, no per-attempt timeout, and a backoff hardcoded at `100ms * 2^n`.

Operators believed they had resilience they did not have. Unlike a setting that is silently ignored, this one did something plausible-looking instead, which is harder to notice.

## What's implemented

| Option | Notes |
|---|---|
| `max-attempts` | Now governs **request** retries. Peer selection keeps its own small fixed count. |
| `retryable-status-codes` | Empty by default. |
| `backoff` / `max-backoff` | Doubling with a ceiling. |
| `per-attempt-timeout` | Caps each attempt. |
| `retry-non-idempotent` | Off by default. |

**Nothing is retryable by default**, deliberately. Which codes are safe to replay depends on the application: a `503` from a load shedder is worth another try; a `500` from a handler that already charged a card is not. Same reasoning for `POST` — replaying it can duplicate a side effect the origin already performed, and nothing here can tell whether it did.

## The fork change

Retrying on a *status code* needed a hook in the fork ([pingora#8](https://github.com/zentinelproxy/pingora/pull/8), merged): the built-in retry loop only re-runs on transport errors, so a status code leaves no error for it to react to.

Most of the machinery was already there — Pingora buffers request bodies and replays them on retry. What was missing was a way to trigger that from a response. Pinned rev moves `ffaf897` → `de28721`.

## Verified against a real upstream

Not just tests — a flaky origin returning 503 then 200:

```
GET,  upstream 503s twice then 200 -> HTTP 200 in 0.158s (2 retries, 50ms + 100ms)
GET,  upstream always 503          -> HTTP 503, not a gateway error
POST, default policy               -> HTTP 503, not replayed
POST, retry-non-idempotent #true   -> HTTP 200, body "payload=important-data" intact
```

The second line matters as much as the first. When the budget runs out the client gets the **upstream's own response** — three failed tries end with its 503, not a generic gateway error. That falls out of returning `false` from `should_retry_response` on the final attempt.

## A bug the timing caught

The first successful run took 57ms where 50ms + 100ms of backoff should have made it ≥150ms. The backoff gate was off by one, so the **first retry ran with no delay at all**.

Worth flagging because the failure is invisible in behaviour — retries still worked, they just hammered a struggling upstream instead of spacing out, which is the opposite of what a backoff is for. There is now a unit test pinning `backoff_for`'s attempt numbering.

## Tests

7 unit tests for the policy logic (backoff doubling and capping, overflow at `u32::MAX`, method idempotency, conservative defaults) and 7 for KDL parsing, including the rejections: a non-status-code value, an empty `retryable-status-codes` list (reads as "any", means "none"), an invalid duration, and a `backoff` above its own `max-backoff`.

Full workspace suite green, clippy and fmt clean.

Docs: zentinelproxy/zentinelproxy.io-docs#22.
