### PR TITLE
fix(agent-protocol): stop sending correlation_id twice under MessagePack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,10 +116,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
 
+      # --all-features here too: without it, docs on feature-gated items are
+      # never rendered and their broken links go unnoticed.
       - name: Check documentation
         env:
           RUSTDOCFLAGS: -D warnings
-        run: cargo doc --workspace --no-deps
+        run: cargo doc --workspace --no-deps --all-features
 
   test:
     name: Unit Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,5 +159,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
 
+      # --all-features matches the clippy job above. Without it, optional
+      # features are compiled by clippy but executed by nothing, which is how
+      # `binary-uds` shipped hanging every agent call but one (#359, #360).
       - name: Run unit tests
-        run: cargo test --workspace --lib
+        run: cargo test --workspace --lib --all-features

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,8 @@
 #   - workflow_dispatch: lets a maintainer trigger a run on demand
 #     before merging a risky PR.
 #
-# Locally: `cargo test --workspace` reproduces what this job runs.
+# Locally: `cargo test --workspace --all-features` reproduces what this job
+# runs.
 
 name: Tests
 
@@ -73,5 +74,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
 
+      # --all-features so that optional features are exercised and not merely
+      # compiled — see the note in ci.yml's unit-test job.
       - name: Run tests
-        run: cargo test --workspace
+        run: cargo test --workspace --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,10 @@ for details.
   healthy. A route configured for request resilience was getting extra tries at
   an operation that rarely fails. Peer selection now has its own small fixed
   count. Re-check any route relying on the old meaning. (#279)
+- **CI runs tests with `--all-features`.** Optional features were compiled by
+  the clippy job and executed by no job at all, which is how two `binary-uds`
+  faults (#359, #360) reached main. The documentation job passes it too, so docs
+  on feature-gated items are rendered rather than skipped. (#360)
 - **Host matching is case-insensitive**, per RFC 3986 §3.2.2. This previously
   failed in both directions: a request for `EXAMPLE.COM` missed a route for
   `example.com`, and a route written `host "Example.com"` matched nothing at
@@ -123,13 +127,19 @@ for details.
   positionally, so that partial read failed and the server answered with an empty
   correlation id. The proxy, which matches responses by correlation id, waited
   out its timeout on every request. Structs are now encoded as maps. (#359)
+- **`binary-uds` no longer hangs six of the seven agent event types.** The
+  client added `correlation_id` beside each event with `#[serde(flatten)]`, but
+  every event except `RequestHeadersEvent` already carries one — so the key went
+  out twice. JSON hid it, because that path mutates a `serde_json::Value` and the
+  second insert overwrites the first; a MessagePack map keeps both entries and
+  the server rejected the payload as a duplicate field. The server's fallback for
+  recovering a correlation id from an undecodable payload was derived too, and
+  failed on the same duplicate, so the reply carried an empty id and the caller
+  waited out its timeout. Request bodies, response headers, response bodies,
+  request completion, WebSocket frames and guardrail inspection were all affected;
+  `RequestHeadersEvent` escaped only because it nests its id under `metadata`.
+  (#360)
 
-### Known issues
-- **`binary-uds` still breaks WebSocket agent inspection.** After the fix above,
-  7 of 8 WebSocket frame-inspection tests still time out with that feature
-  enabled. Root cause not yet identified; tracked in #360, along with the reason
-  neither fault was caught — feature-gated code is compiled by the clippy job but
-  runs in no job that executes tests.
 
 ---
 

--- a/crates/agent-protocol/src/mmap_buffer.rs
+++ b/crates/agent-protocol/src/mmap_buffer.rs
@@ -286,7 +286,7 @@ impl LargeBodyBuffer {
         self.total_written = 0;
     }
 
-    /// Take ownership of the buffer contents as a Vec<u8>.
+    /// Take ownership of the buffer contents as a `Vec<u8>`.
     ///
     /// For mmap storage, this reads the entire file into memory.
     /// Use with caution for large bodies.

--- a/crates/agent-protocol/src/v2/uds.rs
+++ b/crates/agent-protocol/src/v2/uds.rs
@@ -724,12 +724,36 @@ impl AgentClientV2Uds {
     }
 
     /// Send a configure event.
+    ///
+    /// Unlike the typed events, a configure payload is arbitrary operator
+    /// configuration with no correlation id of its own, so one is added here.
+    /// The server needs it to address its reply, and [`Self::send_event`] no
+    /// longer injects one.
     pub async fn send_configure(
         &self,
         correlation_id: &str,
         event: &serde_json::Value,
     ) -> Result<AgentResponse, AgentProtocolError> {
-        self.send_event(MessageType::Configure, correlation_id, event)
+        let mut payload = event.clone();
+        match payload.as_object_mut() {
+            Some(obj) => {
+                obj.insert(
+                    "correlation_id".to_string(),
+                    serde_json::Value::String(correlation_id.to_string()),
+                );
+            }
+            // A non-object payload has nowhere to put the id. Wrapping it would
+            // change the shape agents are told to expect, so send it as-is and
+            // let the server fall back to an empty id rather than silently
+            // reshaping an operator's configuration.
+            None => {
+                warn!(
+                    correlation_id = %correlation_id,
+                    "Configure payload is not a JSON object; sending without a correlation id"
+                );
+            }
+        }
+        self.send_event(MessageType::Configure, correlation_id, &payload)
             .await
     }
 
@@ -919,18 +943,18 @@ impl AgentClientV2Uds {
                     .map_err(|e| AgentProtocolError::Serialization(e.to_string()))?
             }
             UdsEncoding::MessagePack => {
-                // MessagePack path: use wrapper struct for efficient serialization
-                #[derive(serde::Serialize)]
-                struct EventWithCorrelation<'a, T: serde::Serialize> {
-                    correlation_id: &'a str,
-                    #[serde(flatten)]
-                    event: &'a T,
-                }
-                let wrapped = EventWithCorrelation {
-                    correlation_id,
-                    event,
-                };
-                encoding.serialize(&wrapped)?
+                // The event is serialized as it stands. This used to go through
+                // a wrapper struct that added `correlation_id` alongside a
+                // `#[serde(flatten)]`ed event, which emitted the key *twice*
+                // for the six event types that already carry one of their own.
+                // JSON never showed it, because the branch above mutates a
+                // `Value` and the second insert overwrites the first; a
+                // MessagePack map keeps both entries, and the server's derived
+                // `Deserialize` rejects the payload with "duplicate field". The
+                // correlation id is part of every typed event already —
+                // `send_configure` puts one into its untyped payload before
+                // handing it over.
+                encoding.serialize(event)?
             }
         };
 

--- a/crates/agent-protocol/src/v2/uds.rs
+++ b/crates/agent-protocol/src/v2/uds.rs
@@ -727,8 +727,8 @@ impl AgentClientV2Uds {
     ///
     /// Unlike the typed events, a configure payload is arbitrary operator
     /// configuration with no correlation id of its own, so one is added here.
-    /// The server needs it to address its reply, and [`Self::send_event`] no
-    /// longer injects one.
+    /// The server needs it to address its reply, and `send_event` no longer
+    /// injects one.
     pub async fn send_configure(
         &self,
         correlation_id: &str,

--- a/crates/agent-protocol/src/v2/uds_server.rs
+++ b/crates/agent-protocol/src/v2/uds_server.rs
@@ -470,31 +470,94 @@ async fn write_response<W: tokio::io::AsyncWriteExt + Unpin>(
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /// Best-effort extraction of `correlation_id` from a payload (for error paths).
+///
+/// Returns an empty string only when the payload holds no usable id at all.
+/// That outcome is expensive: a response carrying an empty correlation id can
+/// never be matched to the request waiting for it, so the client blocks until
+/// its timeout expires. Every reasonable effort to find an id is worth making.
 fn extract_correlation_id(encoding: &UdsEncoding, payload: &[u8]) -> String {
-    #[derive(serde::Deserialize)]
-    struct CidOnly {
-        #[serde(default)]
-        correlation_id: String,
-        #[serde(default)]
-        metadata: Option<MetaCid>,
-    }
-    #[derive(serde::Deserialize)]
-    struct MetaCid {
-        #[serde(default)]
-        correlation_id: String,
-    }
-
     if let Ok(parsed) = encoding.deserialize::<CidOnly>(payload) {
-        if !parsed.correlation_id.is_empty() {
-            return parsed.correlation_id;
-        }
-        if let Some(meta) = parsed.metadata {
-            if !meta.correlation_id.is_empty() {
-                return meta.correlation_id;
-            }
-        }
+        return parsed.0;
     }
     String::new()
+}
+
+/// A payload reduced to just its correlation id, taken either from the top
+/// level or from a nested `metadata` object.
+///
+/// The `Deserialize` implementation is written out by hand rather than derived
+/// because this type runs *after* a derived implementation has already failed
+/// on the same bytes. A derived one shares too many of its failure modes to be
+/// a useful fallback — notably, it rejects a duplicate key outright, and a
+/// payload with two `correlation_id` entries is precisely the sort this needs
+/// to salvage an id from. Unrecognised fields are skipped without being
+/// interpreted.
+struct CidOnly(String);
+
+impl<'de> serde::Deserialize<'de> for CidOnly {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::{IgnoredAny, MapAccess, Visitor};
+
+        struct CidVisitor;
+
+        impl<'de> Visitor<'de> for CidVisitor {
+            type Value = CidOnly;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("an agent event payload")
+            }
+
+            fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<CidOnly, A::Error> {
+                let mut direct: Option<String> = None;
+                let mut nested: Option<String> = None;
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        // First writer wins, so a duplicate key cannot
+                        // overwrite an id already found with a later empty one.
+                        "correlation_id" => {
+                            let value: String = map.next_value()?;
+                            if direct.is_none() && !value.is_empty() {
+                                direct = Some(value);
+                            }
+                        }
+                        // `metadata` is itself a map with a correlation id in
+                        // it, so the same visitor handles it one level down.
+                        "metadata" => {
+                            let inner: CidOnly = map.next_value()?;
+                            if nested.is_none() && !inner.0.is_empty() {
+                                nested = Some(inner.0);
+                            }
+                        }
+                        _ => {
+                            map.next_value::<IgnoredAny>()?;
+                        }
+                    }
+                }
+
+                Ok(CidOnly(direct.or(nested).unwrap_or_default()))
+            }
+
+            // `metadata` is optional; absent or null is not an error here, it
+            // just means there is no id to be had at that level.
+            fn visit_unit<E>(self) -> Result<CidOnly, E> {
+                Ok(CidOnly(String::new()))
+            }
+
+            fn visit_none<E>(self) -> Result<CidOnly, E> {
+                Ok(CidOnly(String::new()))
+            }
+
+            fn visit_some<D: serde::Deserializer<'de>>(
+                self,
+                deserializer: D,
+            ) -> Result<CidOnly, D::Error> {
+                deserializer.deserialize_any(CidVisitor)
+            }
+        }
+
+        deserializer.deserialize_any(CidVisitor)
+    }
 }
 
 #[cfg(test)]
@@ -518,6 +581,285 @@ mod tests {
                 name: "x-test-agent".to_string(),
                 value: event.metadata.correlation_id.clone(),
             })
+        }
+    }
+
+    /// Every event type, driven through a real client and server over the
+    /// negotiated encoding.
+    ///
+    /// The bug this guards against (#360) reached only one event type through
+    /// its test: `RequestHeadersEvent` is the sole event that keeps its
+    /// correlation id in a nested `metadata` object, and so the sole one that
+    /// survived a client which emitted the key a second time at the top level.
+    /// The other six carry the id directly, ended up with it twice under
+    /// MessagePack, and were rejected by the server as a duplicate field —
+    /// every call hanging until it timed out.
+    ///
+    /// Asserting `Ok` is not enough on its own: the server answers malformed
+    /// payloads too, and a good enough correlation-id fallback would make a
+    /// broken client look healthy. So the handler records what it was actually
+    /// handed, and the test checks that every event arrived decoded.
+    mod every_event_type {
+        use super::*;
+        use crate::v2::uds::AgentClientV2Uds;
+        use std::sync::Mutex;
+        use std::time::Duration;
+
+        #[derive(Default)]
+        struct RecordingHandler {
+            seen: Arc<Mutex<Vec<String>>>,
+        }
+
+        impl RecordingHandler {
+            fn record(&self, what: &str, cid: &str) {
+                self.seen
+                    .lock()
+                    .expect("recording handler lock")
+                    .push(format!("{what}:{cid}"));
+            }
+        }
+
+        #[async_trait]
+        impl AgentHandlerV2 for RecordingHandler {
+            fn capabilities(&self) -> AgentCapabilities {
+                AgentCapabilities::new("recording", "Recording Agent", "1.0.0")
+                    .with_event(crate::EventType::RequestHeaders)
+                    .with_event(crate::EventType::RequestBodyChunk)
+                    .with_event(crate::EventType::ResponseHeaders)
+                    .with_event(crate::EventType::ResponseBodyChunk)
+                    .with_event(crate::EventType::RequestComplete)
+                    .with_event(crate::EventType::WebSocketFrame)
+            }
+
+            async fn on_request_headers(&self, event: RequestHeadersEvent) -> AgentResponse {
+                self.record("request_headers", &event.metadata.correlation_id);
+                AgentResponse::default_allow()
+            }
+
+            async fn on_request_body_chunk(
+                &self,
+                event: crate::RequestBodyChunkEvent,
+            ) -> AgentResponse {
+                self.record("request_body_chunk", &event.correlation_id);
+                AgentResponse::default_allow()
+            }
+
+            async fn on_response_headers(
+                &self,
+                event: crate::ResponseHeadersEvent,
+            ) -> AgentResponse {
+                self.record("response_headers", &event.correlation_id);
+                AgentResponse::default_allow()
+            }
+
+            async fn on_response_body_chunk(
+                &self,
+                event: crate::ResponseBodyChunkEvent,
+            ) -> AgentResponse {
+                self.record("response_body_chunk", &event.correlation_id);
+                AgentResponse::default_allow()
+            }
+
+            async fn on_request_complete(
+                &self,
+                event: crate::RequestCompleteEvent,
+            ) -> AgentResponse {
+                self.record("request_complete", &event.correlation_id);
+                AgentResponse::default_allow()
+            }
+
+            async fn on_websocket_frame(&self, event: WebSocketFrameEvent) -> AgentResponse {
+                self.record("websocket_frame", &event.correlation_id);
+                AgentResponse::websocket_allow()
+            }
+
+            // A configure payload is an envelope: the correlation id sits
+            // beside the config rather than inside it, so what is recorded
+            // here is the config itself — enough to show it arrived decoded.
+            async fn on_configure(
+                &self,
+                config: serde_json::Value,
+                _version: Option<String>,
+            ) -> bool {
+                let setting = config
+                    .get("some-setting")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("<missing>");
+                self.record("configure", setting);
+                true
+            }
+        }
+
+        fn metadata(cid: &str) -> RequestMetadata {
+            RequestMetadata {
+                correlation_id: cid.to_string(),
+                request_id: "req-1".to_string(),
+                client_ip: "127.0.0.1".to_string(),
+                client_port: 12345,
+                server_name: None,
+                protocol: "HTTP/1.1".to_string(),
+                tls_version: None,
+                tls_cipher: None,
+                route_id: None,
+                upstream_id: None,
+                timestamp: "0".to_string(),
+                traceparent: None,
+            }
+        }
+
+        /// Sends one of every event and returns what the handler saw.
+        async fn exercise_every_event(socket_suffix: &str) -> Vec<String> {
+            let seen = Arc::new(Mutex::new(Vec::new()));
+            let handler = RecordingHandler {
+                seen: Arc::clone(&seen),
+            };
+
+            let socket_path = format!(
+                "/tmp/zentinel-every-event-{}-{}.sock",
+                std::process::id(),
+                socket_suffix
+            );
+            let _ = std::fs::remove_file(&socket_path);
+
+            let server = UdsAgentServerV2::new("every-event", &socket_path, Box::new(handler));
+            let server_handle = tokio::spawn(async move {
+                let _ = server.run().await;
+            });
+            tokio::time::sleep(Duration::from_millis(50)).await;
+
+            let client = AgentClientV2Uds::new("client", &socket_path, Duration::from_secs(5))
+                .await
+                .expect("client connects");
+            client.connect().await.expect("handshake succeeds");
+
+            // Each call blocks until the server's reply is matched back to it
+            // by correlation id, so a mismatched id shows up as a timeout.
+            client
+                .send_request_headers(
+                    "cid-headers",
+                    &RequestHeadersEvent {
+                        metadata: metadata("cid-headers"),
+                        method: "GET".to_string(),
+                        uri: "/test".to_string(),
+                        headers: std::collections::HashMap::new(),
+                    },
+                )
+                .await
+                .expect("request headers");
+
+            client
+                .send_request_body_chunk(
+                    "cid-req-body",
+                    &crate::RequestBodyChunkEvent {
+                        correlation_id: "cid-req-body".to_string(),
+                        data: "aGk=".to_string(),
+                        is_last: true,
+                        total_size: Some(2),
+                        chunk_index: 0,
+                        bytes_received: 2,
+                    },
+                )
+                .await
+                .expect("request body chunk");
+
+            client
+                .send_response_headers(
+                    "cid-resp-headers",
+                    &crate::ResponseHeadersEvent {
+                        correlation_id: "cid-resp-headers".to_string(),
+                        status: 200,
+                        headers: std::collections::HashMap::new(),
+                    },
+                )
+                .await
+                .expect("response headers");
+
+            client
+                .send_response_body_chunk(
+                    "cid-resp-body",
+                    &crate::ResponseBodyChunkEvent {
+                        correlation_id: "cid-resp-body".to_string(),
+                        data: "aGk=".to_string(),
+                        is_last: true,
+                        total_size: Some(2),
+                        chunk_index: 0,
+                        bytes_sent: 2,
+                    },
+                )
+                .await
+                .expect("response body chunk");
+
+            client
+                .send_request_complete(
+                    "cid-complete",
+                    &crate::RequestCompleteEvent {
+                        correlation_id: "cid-complete".to_string(),
+                        status: 200,
+                        duration_ms: 1,
+                        request_body_size: 2,
+                        response_body_size: 2,
+                        upstream_attempts: 1,
+                        error: None,
+                    },
+                )
+                .await
+                .expect("request complete");
+
+            client
+                .send_websocket_frame(
+                    "cid-ws",
+                    &WebSocketFrameEvent {
+                        correlation_id: "cid-ws".to_string(),
+                        opcode: "text".to_string(),
+                        data: "aGk=".to_string(),
+                        client_to_server: true,
+                        frame_index: 0,
+                        fin: true,
+                        route_id: None,
+                        client_ip: "127.0.0.1".to_string(),
+                    },
+                )
+                .await
+                .expect("websocket frame");
+
+            client
+                .send_configure(
+                    "cid-configure",
+                    &serde_json::json!({ "config": { "some-setting": "value" } }),
+                )
+                .await
+                .expect("configure");
+
+            server_handle.abort();
+            let _ = std::fs::remove_file(&socket_path);
+
+            let recorded = seen.lock().expect("recording handler lock").clone();
+            recorded
+        }
+
+        fn expected() -> Vec<String> {
+            vec![
+                "request_headers:cid-headers".to_string(),
+                "request_body_chunk:cid-req-body".to_string(),
+                "response_headers:cid-resp-headers".to_string(),
+                "response_body_chunk:cid-resp-body".to_string(),
+                "request_complete:cid-complete".to_string(),
+                "websocket_frame:cid-ws".to_string(),
+                "configure:value".to_string(),
+            ]
+        }
+
+        #[tokio::test]
+        async fn every_event_type_round_trips_over_json() {
+            assert_eq!(exercise_every_event("json").await, expected());
+        }
+
+        /// The regression test for #360. Without the fix this hangs on the
+        /// second event and fails on the first `expect` after it.
+        #[cfg(feature = "binary-uds")]
+        #[tokio::test]
+        async fn every_event_type_round_trips_over_messagepack() {
+            assert_eq!(exercise_every_event("msgpack").await, expected());
         }
     }
 


### PR DESCRIPTION
Closes #360.

`binary-uds` hung on every call for six of the seven agent event types. Not slowly — every call ran to its full timeout, whatever the agent did.

## What was happening

The client wrapped each outgoing event in a struct that added `correlation_id` alongside the flattened event:

```rust
struct EventWithCorrelation<'a, T> {
    correlation_id: &'a str,
    #[serde(flatten)]
    event: &'a T,
}
```

Every event except `RequestHeadersEvent` already has a `correlation_id` field. So the wrapper produced a second one.

JSON never showed this, because that branch builds a `serde_json::Value` and inserts — the second insert overwrites the first, and one key goes out. A MessagePack map keeps both entries, and the server's derived `Deserialize` rejects the payload outright:

```
Invalid message format: duplicate field `correlation_id`
```

Then it got quiet instead of loud. The server falls back to `extract_correlation_id` so it can still answer, but that helper was derived too, and failed on the same duplicate. The reply went out with an **empty** correlation id. Since the client matches replies to requests by that id, it had nothing to match and waited out its timeout.

So an agent that decoded nothing still replied, and an agent replying correctly and instantly still looked dead.

## Why #359 looked like it fixed this

`RequestHeadersEvent` is the only event that keeps its correlation id nested in `metadata` — the only one with nothing to collide with, and the only one #359's round-trip test covered. It passed. The other six were never exercised.

| Event | Top-level `correlation_id` | Before |
|---|---|---|
| `RequestHeadersEvent` | no (nested in `metadata`) | worked |
| `RequestBodyChunkEvent` | yes | hung |
| `ResponseHeadersEvent` | yes | hung |
| `ResponseBodyChunkEvent` | yes | hung |
| `RequestCompleteEvent` | yes | hung |
| `WebSocketFrameEvent` | yes | hung |
| `GuardrailInspectEvent` | yes | hung |

## The fix

- **The MessagePack path serializes the event as it stands.** Every typed event already carries its correlation id; nothing needed adding.
- **`send_configure` injects its own.** A configure payload is arbitrary operator config with no id of its own, so it is the one caller that genuinely needs the injection — it now does it explicitly rather than relying on a generic wrapper.
- **`extract_correlation_id` is hand-written rather than derived.** It only ever runs after a derived impl has already failed on the same bytes, so sharing that impl's failure modes made it useless in exactly the case it exists for. It now skips unrecognised fields and takes the first id it finds. Returning empty costs the caller its whole timeout, which is worth some effort to avoid.

## Tests

All seven event types, driven through a real client and server, over both encodings.

The handler records what it was handed, and the test asserts every event arrived **decoded** — not merely that the call returned. Asserting `Ok` alone would be too weak here: the server answers malformed payloads too, so a sufficiently good correlation-id fallback would make a broken client look healthy.

The proxy's WebSocket suite goes from 1/8 to 8/8 under `binary-uds`, and from ~40s of timeouts to 0.1s.

## The CI gap

Both test jobs now run `--all-features`, matching the clippy job.

This is the reason the bug shipped at all: clippy compiled the feature on every PR, and no job ever ran it. Two bugs (#359, #360) reached main through that gap.

`cargo test --workspace --all-features` is green.

## Note, unrelated

Clippy 1.97 flags a pre-existing `question_mark` lint in `crates/config/src/kdl/upstreams.rs:179` that CI's current toolchain doesn't. Not touched here — main is green — but it will need a one-line fix when CI's stable moves up.
