### PR TITLE
fix(config): read the documented connection-pool and timeout key names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,11 +66,12 @@ for details.
 
 ## [Unreleased]
 
-> **Three behaviour changes to check before upgrading.** `retry-policy.max-attempts`
+> **Four behaviour changes to check before upgrading.** `retry-policy.max-attempts`
 > now retries requests rather than backend selection, host matching in routes is
 > now case-insensitive — a route written `host "Example.com"` previously matched
 > nothing and now matches `example.com` — and `connection-pool.max-lifetime-secs`
-> now takes effect, where it was previously ignored. All three are detailed below.
+> now takes effect, where it was previously ignored, as do the four
+> `upstream.timeouts` settings. All four are detailed below.
 
 ### Added
 - **Certificate folders.** An `sni-certs` block points at a directory, and every
@@ -112,6 +113,16 @@ for details.
   nothing will now start matching. (#113)
 
 ### Fixed
+- **Upstream timeouts are read.** `timeouts` accepted `connect`, `request`,
+  `read` and `write`, while every shipped config and the documentation write
+  `connect-secs`, `request-secs`, `read-secs` and `write-secs`. Every timeout in
+  every shipped config was therefore discarded in favour of its default. The
+  worst case was an upstream asking for `request-secs 300` — the inference
+  examples do — and being cut off at the 60s default, a fifth of what it asked
+  for; `connect-secs 2` likewise waited 10s. **Timeouts will now take the values
+  your config specifies**, which for existing deployments means both shorter
+  connect timeouts and longer request timeouts than they have been running with.
+  The unsuffixed names remain accepted as aliases. (#365)
 - **`connection-pool.idle-timeout-secs` and `max-lifetime-secs` are read.** The
   parser looked for `idle-timeout` and `max-lifetime` — names that appear in no
   config anywhere, including this repo's own. The documented `-secs` spellings,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,10 +66,11 @@ for details.
 
 ## [Unreleased]
 
-> **Two behaviour changes to check before upgrading.** `retry-policy.max-attempts`
-> now retries requests rather than backend selection, and host matching in routes
-> is now case-insensitive — a route written `host "Example.com"` previously
-> matched nothing and now matches `example.com`. Both are detailed below.
+> **Three behaviour changes to check before upgrading.** `retry-policy.max-attempts`
+> now retries requests rather than backend selection, host matching in routes is
+> now case-insensitive — a route written `host "Example.com"` previously matched
+> nothing and now matches `example.com` — and `connection-pool.max-lifetime-secs`
+> now takes effect, where it was previously ignored. All three are detailed below.
 
 ### Added
 - **Certificate folders.** An `sni-certs` block points at a directory, and every
@@ -111,6 +112,16 @@ for details.
   nothing will now start matching. (#113)
 
 ### Fixed
+- **`connection-pool.idle-timeout-secs` and `max-lifetime-secs` are read.** The
+  parser looked for `idle-timeout` and `max-lifetime` — names that appear in no
+  config anywhere, including this repo's own. The documented `-secs` spellings,
+  used by `config/zentinel.kdl` and four shipped examples, were discarded. The
+  visible effect was that `max-lifetime-secs 300` produced *no* lifetime cap, so
+  pooled connections were never retired by age; `idle-timeout-secs` appeared to
+  work only because 60 is also the default. **Deployments using the shipped
+  config or those examples will now cap connection lifetime at 300s where they
+  previously had none.** The bare names remain accepted as aliases. Found via
+  #365. (#365)
 - **Route cache poisoning across query parameters.** The cache key was built
   from method, host, path and headers, and `path` carries no query string — so
   `/api?version=v2` and `/api?version=v1` shared an entry and the second request

--- a/crates/config/src/kdl/upstreams.rs
+++ b/crates/config/src/kdl/upstreams.rs
@@ -176,12 +176,8 @@ pub fn parse_upstreams(node: &kdl::KdlNode) -> Result<HashMap<String, UpstreamCo
     if let Some(children) = node.children() {
         for child in children.nodes() {
             if child.name().value() == "upstream" {
-                match parse_upstream(child) {
-                    Ok(config) => {
-                        upstreams.insert(config.id.clone(), config);
-                    }
-                    Err(e) => return Err(e),
-                }
+                let config = parse_upstream(child)?;
+                upstreams.insert(config.id.clone(), config);
             }
         }
     }
@@ -352,10 +348,13 @@ fn parse_http_version(node: &kdl::KdlNode) -> HttpVersionConfig {
 /// connection-pool {
 ///     max-connections 100
 ///     max-idle 20
-///     idle-timeout 60
-///     max-lifetime 3600
+///     idle-timeout-secs 60
+///     max-lifetime-secs 3600
 /// }
 /// ```
+///
+/// `idle-timeout` and `max-lifetime` are accepted as aliases for the two
+/// `-secs` names.
 fn parse_connection_pool(node: &kdl::KdlNode) -> ConnectionPoolConfig {
     let max_connections = get_int_entry(node, "max-connections")
         .map(|v| v as usize)
@@ -365,11 +364,20 @@ fn parse_connection_pool(node: &kdl::KdlNode) -> ConnectionPoolConfig {
         .map(|v| v as usize)
         .unwrap_or(20);
 
-    let idle_timeout_secs = get_int_entry(node, "idle-timeout")
+    // `-secs` is the documented spelling and the one every shipped config and
+    // example uses; the bare form appears only in this function's own doc
+    // comment. Reading only the bare form meant `max-lifetime-secs 300` in
+    // config/zentinel.kdl was discarded and pools ran with no lifetime cap at
+    // all. Both are accepted so anyone who followed the old rustdoc keeps
+    // working, with the documented name taking precedence.
+    let idle_timeout_secs = get_int_entry(node, "idle-timeout-secs")
+        .or_else(|| get_int_entry(node, "idle-timeout"))
         .map(|v| v as u64)
         .unwrap_or(60);
 
-    let max_lifetime_secs = get_int_entry(node, "max-lifetime").map(|v| v as u64);
+    let max_lifetime_secs = get_int_entry(node, "max-lifetime-secs")
+        .or_else(|| get_int_entry(node, "max-lifetime"))
+        .map(|v| v as u64);
 
     ConnectionPoolConfig {
         max_connections,
@@ -727,6 +735,89 @@ mod tests {
             .unwrap()
             .targets
             .clone()
+    }
+
+    /// The documented spellings carry a unit suffix. Reading only the bare
+    /// names meant every config written against the documentation — including
+    /// the ones shipped in this repo — had its pool lifetime silently dropped.
+    mod connection_pool_key_names {
+        use super::*;
+
+        fn pool_of(kdl: &str) -> ConnectionPoolConfig {
+            parse_kdl_upstreams(kdl)
+                .unwrap()
+                .get("backend")
+                .unwrap()
+                .connection_pool
+                .clone()
+        }
+
+        fn with_pool(body: &str) -> String {
+            format!(
+                r#"upstreams {{
+                    upstream "backend" {{
+                        target "127.0.0.1:9000"
+                        connection-pool {{ {body} }}
+                    }}
+                }}"#
+            )
+        }
+
+        #[test]
+        fn documented_secs_names_are_read() {
+            let pool = pool_of(&with_pool("idle-timeout-secs 45\nmax-lifetime-secs 300"));
+            assert_eq!(pool.idle_timeout_secs, 45);
+            assert_eq!(pool.max_lifetime_secs, Some(300));
+        }
+
+        /// The bare names were what the parser used to read, and they appeared
+        /// in its own rustdoc, so anyone who copied from there keeps working.
+        #[test]
+        fn bare_names_still_work_as_aliases() {
+            let pool = pool_of(&with_pool("idle-timeout 45\nmax-lifetime 300"));
+            assert_eq!(pool.idle_timeout_secs, 45);
+            assert_eq!(pool.max_lifetime_secs, Some(300));
+        }
+
+        #[test]
+        fn documented_name_wins_when_both_are_present() {
+            let pool = pool_of(&with_pool(
+                "idle-timeout-secs 45\nidle-timeout 99\nmax-lifetime-secs 300\nmax-lifetime 999",
+            ));
+            assert_eq!(pool.idle_timeout_secs, 45);
+            assert_eq!(pool.max_lifetime_secs, Some(300));
+        }
+
+        #[test]
+        fn absent_lifetime_stays_unbounded() {
+            let pool = pool_of(&with_pool("max-connections 10"));
+            assert_eq!(pool.idle_timeout_secs, 60);
+            assert_eq!(pool.max_lifetime_secs, None);
+        }
+
+        /// Pins the regression to the file it actually broke: the shipped
+        /// default config asks for a 300s lifetime cap and used to get none.
+        #[test]
+        fn shipped_default_config_gets_the_lifetime_it_asks_for() {
+            let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../config/zentinel.kdl");
+            let text = std::fs::read_to_string(path).expect("shipped config should be readable");
+            let config = crate::Config::from_kdl(&text).expect("shipped config should parse");
+
+            // Only `api-backend` declares a connection-pool in the shipped
+            // config; the rest take pool defaults, where an absent lifetime
+            // legitimately means unbounded.
+            let api = config
+                .upstreams
+                .get("api-backend")
+                .expect("shipped config should define the api-backend upstream");
+
+            assert_eq!(
+                api.connection_pool.max_lifetime_secs,
+                Some(300),
+                "api-backend asks for max-lifetime-secs 300 and must get it"
+            );
+            assert_eq!(api.connection_pool.idle_timeout_secs, 60);
+        }
     }
 
     #[test]

--- a/crates/config/src/kdl/upstreams.rs
+++ b/crates/config/src/kdl/upstreams.rs
@@ -392,24 +392,32 @@ fn parse_connection_pool(node: &kdl::KdlNode) -> ConnectionPoolConfig {
 /// Example KDL:
 /// ```kdl
 /// timeouts {
-///     connect 10
-///     request 60
-///     read 30
-///     write 30
+///     connect-secs 10
+///     request-secs 60
+///     read-secs 30
+///     write-secs 30
 /// }
 /// ```
+///
+/// The unsuffixed names (`connect`, `request`, `read`, `write`) are accepted as
+/// aliases.
 fn parse_upstream_timeouts(node: &kdl::KdlNode) -> UpstreamTimeouts {
-    let connect_secs = get_int_entry(node, "connect")
-        .map(|v| v as u64)
-        .unwrap_or(10);
+    // As with the connection pool above, the `-secs` spellings are what every
+    // config and the documentation use, and the unsuffixed ones are what this
+    // parser used to read. Reading only the latter meant every timeout in
+    // every shipped config was discarded in favour of the default — an
+    // upstream asking for `request-secs 300` was cut off at 60.
+    let timeout = |suffixed: &str, bare: &str, default: u64| {
+        get_int_entry(node, suffixed)
+            .or_else(|| get_int_entry(node, bare))
+            .map(|v| v as u64)
+            .unwrap_or(default)
+    };
 
-    let request_secs = get_int_entry(node, "request")
-        .map(|v| v as u64)
-        .unwrap_or(60);
-
-    let read_secs = get_int_entry(node, "read").map(|v| v as u64).unwrap_or(30);
-
-    let write_secs = get_int_entry(node, "write").map(|v| v as u64).unwrap_or(30);
+    let connect_secs = timeout("connect-secs", "connect", 10);
+    let request_secs = timeout("request-secs", "request", 60);
+    let read_secs = timeout("read-secs", "read", 30);
+    let write_secs = timeout("write-secs", "write", 30);
 
     UpstreamTimeouts {
         connect_secs,
@@ -817,6 +825,96 @@ mod tests {
                 "api-backend asks for max-lifetime-secs 300 and must get it"
             );
             assert_eq!(api.connection_pool.idle_timeout_secs, 60);
+        }
+    }
+
+    /// Same defect as the connection-pool names above, with a sharper edge:
+    /// every timeout in every shipped config was being replaced by a default.
+    mod upstream_timeout_key_names {
+        use super::*;
+
+        fn timeouts_of(body: &str) -> UpstreamTimeouts {
+            let kdl = format!(
+                r#"upstreams {{
+                    upstream "backend" {{
+                        target "127.0.0.1:9000"
+                        timeouts {{ {body} }}
+                    }}
+                }}"#
+            );
+            parse_kdl_upstreams(&kdl)
+                .unwrap()
+                .get("backend")
+                .unwrap()
+                .timeouts
+                .clone()
+        }
+
+        #[test]
+        fn documented_secs_names_are_read() {
+            let t = timeouts_of("connect-secs 2\nrequest-secs 300\nread-secs 120\nwrite-secs 15");
+            assert_eq!(t.connect_secs, 2);
+            assert_eq!(t.request_secs, 300);
+            assert_eq!(t.read_secs, 120);
+            assert_eq!(t.write_secs, 15);
+        }
+
+        #[test]
+        fn bare_names_still_work_as_aliases() {
+            let t = timeouts_of("connect 2\nrequest 300\nread 120\nwrite 15");
+            assert_eq!(t.connect_secs, 2);
+            assert_eq!(t.request_secs, 300);
+            assert_eq!(t.read_secs, 120);
+            assert_eq!(t.write_secs, 15);
+        }
+
+        #[test]
+        fn documented_name_wins_when_both_are_present() {
+            let t = timeouts_of("connect-secs 2\nconnect 99\nrequest-secs 300\nrequest 999");
+            assert_eq!(t.connect_secs, 2);
+            assert_eq!(t.request_secs, 300);
+        }
+
+        #[test]
+        fn defaults_apply_when_absent() {
+            let t = timeouts_of("connect-secs 5");
+            assert_eq!(t.connect_secs, 5);
+            assert_eq!(t.request_secs, 60);
+            assert_eq!(t.read_secs, 30);
+            assert_eq!(t.write_secs, 30);
+        }
+
+        /// The case that made this expensive: an inference upstream asking for
+        /// a 300s request timeout was silently cut off at the 60s default.
+        #[test]
+        fn a_long_request_timeout_is_not_replaced_by_the_default() {
+            let t = timeouts_of("request-secs 300");
+            assert_eq!(
+                t.request_secs, 300,
+                "a configured 300s request timeout must not fall back to 60s"
+            );
+        }
+
+        /// Pins it to the shipped config, which asks for a 30s request timeout
+        /// and used to run with 60.
+        #[test]
+        fn shipped_default_config_gets_the_timeouts_it_asks_for() {
+            let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../config/zentinel.kdl");
+            let text = std::fs::read_to_string(path).expect("shipped config should be readable");
+            let config = crate::Config::from_kdl(&text).expect("shipped config should parse");
+
+            let api = config
+                .upstreams
+                .get("api-backend")
+                .expect("shipped config should define the api-backend upstream");
+
+            assert_eq!(api.timeouts.connect_secs, 10);
+            assert_eq!(
+                api.timeouts.request_secs, 30,
+                "api-backend asks for request-secs 30 and must get it, not the 60s default"
+            );
+            assert_eq!(api.timeouts.read_secs, 30);
+            assert_eq!(api.timeouts.write_secs, 30);
         }
     }
 


### PR DESCRIPTION
Two concrete casualties of #365, found while building the general fix for it. Both are the same defect: **the parser reads one key name, every config and the documentation write another, and the difference is silently discarded.**

## 1. `connection-pool` — no lifetime cap

The parser read `idle-timeout` / `max-lifetime`. Every config writes `idle-timeout-secs` / `max-lifetime-secs`.

`config/zentinel.kdl` asks for a 300s connection lifetime and got `max_lifetime_secs: None` — **pooled connections were never retired by age**:

```
upstream api-backend  max_connections=100 max_idle=20 idle_timeout_secs=60 max_lifetime_secs=None
```

`idle-timeout-secs` appeared to work only because 60 is also the fallback.

## 2. `timeouts` — every timeout replaced by its default

The parser read `connect` / `request` / `read` / `write`. Every config writes the `-secs` forms. So **every upstream timeout in every shipped config was discarded**:

```
api-backend   config says request-secs 30   ->   actually ran with 60s
```

Across the shipped configs and examples:

| Configured | Actually applied | |
|---|---|---|
| `connect-secs 2` | 10s | 5× longer |
| `connect-secs 5` (×7) | 10s | 2× longer |
| `request-secs 300` (×4) | 60s | **cut off at a fifth** |
| `request-secs 10` | 60s | 6× longer |

The `request-secs 300` case is the one that would hurt: the inference-routing examples set it for slow model calls, and those requests were being killed at 60 seconds.

## Scope

`config/zentinel.kdl` and the `shadow-traffic`, `multiple-upstreams-health-check`, `load-balancer` and `inference-routing` examples — plus anyone who followed https://zentinelproxy.io/docs, which documents the `-secs` names in defaults tables.

Both are also direct hits on #128's bounded-resources goal: a pool with no lifetime cap and a timeout that isn't the one you set are unbounded resources that the config file claims are bounded.

## ⚠️ Behaviour changes

Both fixes change runtime behaviour for existing deployments, in the direction the config always asked for:

- Connection lifetime is now capped at 300s where it previously wasn't.
- Timeouts now take configured values — **shorter** connect timeouts and **longer** request timeouts than deployments have actually been running with.

Both are called out in the changelog's upgrade note.

## Compatibility

The unsuffixed names are accepted as aliases, so anyone who copied them from the old rustdoc keeps working. The documented `-secs` form wins if both appear.

## Tests

11 tests: both spellings for both blocks, precedence when both appear, absent-means-default, and two that pin the regressions to `config/zentinel.kdl` itself — so if the shipped config and the parser ever disagree again, a test fails instead of a deployment.

`cargo test --workspace --all-features` is green.

## Also included

One `match` → `?` in `parse_upstreams`: clippy 1.97 rejects it under `-D warnings`. CI's current stable doesn't flag it yet, but it will, and this file was already open.

---

**How these were found, which matters for #365:** by diffing every key written in the shipped configs against every string the parser mentions. That comparison turned up 54 unmatched keys. Most are legitimately arbitrary (JSON-schema field names inside `api-schema` blocks), but these two were real, and several others in the list still need checking — `requests-per-second`, `max-connections-per-ip`, `ping-interval-secs` and `max-message-size-bytes` among them.

The general fix for #365 — surfacing unknown keys as lint warnings so this class can't recur silently — is still in progress and will follow separately.
