### PR TITLE
feat(lint): report config keys that no parser reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,16 @@ for details.
 > `failure-mode` — are now read at all. All five are detailed below.
 
 ### Added
+- **`zentinel lint` reports config keys that no parser reads.** A misspelled key
+  in a nested KDL block was accepted and discarded — no error, no warning, no
+  effect — so `failure_mode` with an underscore, or `ratelimit` without a
+  hyphen, silently disabled a policy while the config file said otherwise. The
+  lint now names the key, says it is being ignored, and suggests the intended
+  spelling. It checks blocks whose key set is fixed (`connection-pool`,
+  `timeouts`, `policies`); blocks that legitimately hold arbitrary keys, like a
+  JSON schema's properties, are left alone. A test asserts every shipped config
+  passes, so an under-listed key set fails the build rather than warning
+  operators about valid configuration. (#365)
 - **Certificate folders.** An `sni-certs` block points at a directory, and every
   certificate/key pair found there is registered with the hostnames from its own
   CN and SANs — no config edit to add or remove one. `reload-mode` selects `off`

--- a/config/examples/static-site.kdl
+++ b/config/examples/static-site.kdl
@@ -34,6 +34,15 @@ listeners {
 // =============================================================================
 // Routes - ordered by specificity
 // =============================================================================
+filters {
+    // Serves index.html for any path, so a single-page app can handle
+    // routing on the client.
+    filter "spa-index" {
+        type "url-rewrite"
+        replace-full-path "/index.html"
+    }
+}
+
 routes {
     // Health check
     route "health" {
@@ -133,10 +142,12 @@ routes {
 
         upstream "static-origin"
 
-        // Rewrite all paths to index.html for SPA
+        // Rewrite every path to index.html so client-side routing works.
+        // `rewrite-path` is not a setting; path rewriting is a filter.
+        filters "spa-index"
+
         policies {
             timeout-secs 10
-            rewrite-path "/index.html"
         }
     }
 }

--- a/crates/config/src/validate/mod.rs
+++ b/crates/config/src/validate/mod.rs
@@ -7,6 +7,7 @@ pub mod agents;
 pub mod certs;
 pub mod lint;
 pub mod network;
+pub mod unknown_keys;
 
 use std::fmt;
 

--- a/crates/config/src/validate/unknown_keys.rs
+++ b/crates/config/src/validate/unknown_keys.rs
@@ -1,0 +1,328 @@
+//! Reports configuration keys that no parser reads.
+//!
+//! KDL blocks accept any key. A name the parser does not recognise is dropped
+//! without complaint, so a misspelling produces no error, no warning, and no
+//! effect — the proxy runs on the default while the config file says otherwise.
+//! That has cost real behaviour more than once: `max-lifetime-secs` left
+//! connection pools with no lifetime cap, and the whole `timeouts` block was
+//! discarded in favour of defaults, because in each case the parser read a
+//! slightly different name than every config wrote.
+//!
+//! This check works from the KDL document rather than the parsed `Config`,
+//! because by the time a `Config` exists the unknown keys are already gone.
+//!
+//! # Only closed blocks are checked
+//!
+//! Some blocks legitimately hold arbitrary keys — a JSON schema's properties,
+//! a header map, agent configuration forwarded verbatim. Warning about those
+//! would be noise, and noise in a linter is worse than silence because it
+//! teaches people to skip the output.
+//!
+//! So this checks an explicit list of blocks whose key set is known and fixed
+//! (`CLOSED_BLOCKS`). Anything not on that list is not inspected. Adding a
+//! block to the list is deliberately a decision, and `shipped_configs_use_only_known_keys`
+//! guards it: if a real config uses a key the list does not know about, that
+//! test fails rather than operators getting a false warning.
+//!
+//! Part of zentinelproxy/zentinel#365.
+
+use super::{ValidationResult, ValidationWarning};
+
+/// A block whose full set of valid keys is known.
+struct ClosedBlock {
+    /// The block's node name in KDL.
+    name: &'static str,
+    /// Every key the parser reads inside it, including nested block names.
+    keys: &'static [&'static str],
+}
+
+/// Blocks this check inspects.
+///
+/// Each entry must list *every* key the corresponding parser reads, aliases
+/// included. Under-listing produces false warnings on valid configs, which is
+/// the failure mode to avoid.
+const CLOSED_BLOCKS: &[ClosedBlock] = &[
+    ClosedBlock {
+        name: "connection-pool",
+        keys: &[
+            "max-connections",
+            "max-idle",
+            "idle-timeout-secs",
+            "max-lifetime-secs",
+            // Accepted aliases; see parse_connection_pool.
+            "idle-timeout",
+            "max-lifetime",
+        ],
+    },
+    ClosedBlock {
+        name: "timeouts",
+        keys: &[
+            "connect-secs",
+            "request-secs",
+            "read-secs",
+            "write-secs",
+            // Accepted aliases; see parse_upstream_timeouts.
+            "connect",
+            "request",
+            "read",
+            "write",
+        ],
+    },
+    ClosedBlock {
+        name: "policies",
+        keys: &[
+            "request-headers",
+            "response-headers",
+            "cache",
+            "timeout-secs",
+            "max-body-size",
+            "failure-mode",
+            "rate-limit",
+            // Parsed by nothing today, but named in configs and tracked in
+            // #366. Listing them keeps this check quiet about a known gap
+            // rather than reporting it as a typo.
+            "buffer-requests",
+            "buffer-responses",
+        ],
+    },
+];
+
+/// Warn about keys inside closed blocks that no parser reads.
+pub fn check_unknown_keys(kdl_source: &str, result: &mut ValidationResult) {
+    let Ok(document) = kdl_source.parse::<kdl::KdlDocument>() else {
+        // A document that does not parse is not this check's problem; the
+        // parser will have produced a better error already.
+        return;
+    };
+
+    for node in document.nodes() {
+        walk(node, result);
+    }
+}
+
+/// Depth-first walk, checking any node that names a closed block.
+fn walk(node: &kdl::KdlNode, result: &mut ValidationResult) {
+    let name = node.name().value();
+
+    if let Some(block) = CLOSED_BLOCKS.iter().find(|b| b.name == name) {
+        if let Some(children) = node.children() {
+            for child in children.nodes() {
+                let key = child.name().value();
+                if !block.keys.contains(&key) {
+                    result
+                        .add_warning(ValidationWarning::new(unknown_key_message(block.name, key)));
+                }
+            }
+        }
+    }
+
+    if let Some(children) = node.children() {
+        for child in children.nodes() {
+            walk(child, result);
+        }
+    }
+}
+
+/// Build the warning, with a suggestion when one key is clearly meant.
+fn unknown_key_message(block: &str, key: &str) -> String {
+    match closest_key(block, key) {
+        Some(suggestion) => format!(
+            "'{key}' is not a setting in the '{block}' block and is being ignored. \
+             Did you mean '{suggestion}'?"
+        ),
+        None => format!("'{key}' is not a setting in the '{block}' block and is being ignored."),
+    }
+}
+
+/// The nearest known key, when it is near enough to be worth naming.
+fn closest_key(block: &str, key: &str) -> Option<&'static str> {
+    let candidates = CLOSED_BLOCKS.iter().find(|b| b.name == block)?.keys;
+
+    // A third of the length, so short keys need a close match and long ones
+    // tolerate a suffix like `-secs`. Beyond that a suggestion is a guess, and
+    // a wrong suggestion is worse than none.
+    let budget = (key.len() / 3).max(2);
+
+    candidates
+        .iter()
+        .map(|candidate| (*candidate, edit_distance(key, candidate)))
+        .filter(|(_, distance)| *distance <= budget)
+        .min_by_key(|(_, distance)| *distance)
+        .map(|(candidate, _)| candidate)
+}
+
+/// Levenshtein distance, iterative with a single row.
+fn edit_distance(a: &str, b: &str) -> usize {
+    let b_chars: Vec<char> = b.chars().collect();
+    let mut previous: Vec<usize> = (0..=b_chars.len()).collect();
+    let mut current = vec![0; b_chars.len() + 1];
+
+    for (i, a_char) in a.chars().enumerate() {
+        current[0] = i + 1;
+        for (j, b_char) in b_chars.iter().enumerate() {
+            let substitution = previous[j] + usize::from(a_char != *b_char);
+            let insertion = current[j] + 1;
+            let deletion = previous[j + 1] + 1;
+            current[j + 1] = substitution.min(insertion).min(deletion);
+        }
+        std::mem::swap(&mut previous, &mut current);
+    }
+
+    previous[b_chars.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn warnings_for(kdl: &str) -> Vec<String> {
+        let mut result = ValidationResult::new();
+        check_unknown_keys(kdl, &mut result);
+        result.warnings.into_iter().map(|w| w.message).collect()
+    }
+
+    #[test]
+    fn a_valid_block_produces_no_warnings() {
+        let kdl = r#"
+            upstreams {
+                upstream "backend" {
+                    connection-pool {
+                        max-connections 100
+                        max-idle 20
+                        idle-timeout-secs 60
+                        max-lifetime-secs 300
+                    }
+                }
+            }
+        "#;
+        assert!(warnings_for(kdl).is_empty());
+    }
+
+    /// The bug this check exists for: a name one hyphen away from the real one.
+    #[test]
+    fn an_underscore_instead_of_a_hyphen_is_reported_with_a_suggestion() {
+        let kdl = r#"
+            routes {
+                route "api" {
+                    policies {
+                        failure_mode "closed"
+                    }
+                }
+            }
+        "#;
+        let warnings = warnings_for(kdl);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("failure_mode"));
+        assert!(warnings[0].contains("is being ignored"));
+        assert!(
+            warnings[0].contains("Did you mean 'failure-mode'?"),
+            "expected a suggestion, got: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn a_missing_hyphen_is_reported_with_a_suggestion() {
+        let warnings = warnings_for(r#"routes { route "api" { policies { ratelimit { } } } }"#);
+        assert_eq!(warnings.len(), 1);
+        assert!(
+            warnings[0].contains("Did you mean 'rate-limit'?"),
+            "got: {}",
+            warnings[0]
+        );
+    }
+
+    /// The real-world case from #367: the config carried the unit suffix and
+    /// the parser did not.
+    #[test]
+    fn a_unit_suffix_mismatch_is_reported() {
+        let warnings =
+            warnings_for(r#"upstreams { upstream "b" { timeouts { connect-seconds 5 } } }"#);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("connect-seconds"));
+        assert!(warnings[0].contains("Did you mean 'connect-secs'?"));
+    }
+
+    #[test]
+    fn a_key_resembling_nothing_is_reported_without_a_suggestion() {
+        let warnings =
+            warnings_for(r#"upstreams { upstream "b" { connection-pool { zzzzzzzzzzzz 1 } } }"#);
+        assert_eq!(warnings.len(), 1);
+        assert!(
+            !warnings[0].contains("Did you mean"),
+            "got: {}",
+            warnings[0]
+        );
+    }
+
+    /// Blocks that legitimately carry arbitrary keys must stay silent.
+    #[test]
+    fn blocks_outside_the_list_are_not_inspected() {
+        let kdl = r#"
+            routes {
+                route "api" {
+                    api-schema {
+                        properties {
+                            avatar_url "string"
+                            created_at "string"
+                        }
+                    }
+                }
+            }
+        "#;
+        assert!(warnings_for(kdl).is_empty());
+    }
+
+    #[test]
+    fn closed_blocks_are_found_at_any_depth() {
+        let kdl = r#"
+            namespace "team-a" {
+                upstreams {
+                    upstream "backend" {
+                        timeouts { bogus-key 1 }
+                    }
+                }
+            }
+        "#;
+        assert_eq!(warnings_for(kdl).len(), 1);
+    }
+
+    /// Guards the registry against under-listing. If a shipped config uses a
+    /// key this check does not know, operators would get a warning about
+    /// perfectly valid configuration — so that failure belongs here, loudly,
+    /// rather than in someone's terminal.
+    #[test]
+    fn shipped_configs_use_only_known_keys() {
+        let root = concat!(env!("CARGO_MANIFEST_DIR"), "/../..");
+        let mut checked = 0;
+        let mut complaints = Vec::new();
+
+        for dir in ["config", "config/examples"] {
+            let path = std::path::Path::new(root).join(dir);
+            let Ok(entries) = std::fs::read_dir(&path) else {
+                continue;
+            };
+            for entry in entries.filter_map(Result::ok) {
+                let file = entry.path();
+                if file.extension().and_then(|e| e.to_str()) != Some("kdl") {
+                    continue;
+                }
+                let Ok(text) = std::fs::read_to_string(&file) else {
+                    continue;
+                };
+                checked += 1;
+                for warning in warnings_for(&text) {
+                    complaints.push(format!("{}: {warning}", file.display()));
+                }
+            }
+        }
+
+        assert!(checked > 0, "should have found shipped configs to check");
+        assert!(
+            complaints.is_empty(),
+            "shipped configs contain keys this check does not know about. Either the \
+             config is wrong or CLOSED_BLOCKS is under-listed:\n{}",
+            complaints.join("\n")
+        );
+    }
+}

--- a/crates/proxy/src/main.rs
+++ b/crates/proxy/src/main.rs
@@ -335,7 +335,21 @@ fn lint_config(config_path: Option<&str>) -> Result<()> {
         .context("Configuration schema validation failed")?;
 
     // Lint for best practices
-    let result = zentinel_config::validate::lint::lint_config(&config);
+    let mut result = zentinel_config::validate::lint::lint_config(&config);
+
+    // Unknown-key checking needs the source text, not the parsed config: by
+    // the time a Config exists, keys no parser recognised have already been
+    // dropped. Only meaningful for a config read from a file.
+    if let Some(path) = config_path {
+        match std::fs::read_to_string(path) {
+            Ok(source) => {
+                zentinel_config::validate::unknown_keys::check_unknown_keys(&source, &mut result)
+            }
+            Err(e) => {
+                warn!(path = %path, error = %e, "Could not re-read config to check for unknown keys")
+            }
+        }
+    }
 
     // Print results
     if result.warnings.is_empty() {


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #370.** The `policies` key list is only correct once #370 lands — before it, `failure-mode` and friends genuinely *are* ignored, and listing them as valid would suppress warnings about the very bug #370 fixes. Merge #370 first, then this rebases onto main cleanly.

The general fix for #365, after three separate instances of it turned up in the proxy's own shipped configuration this week (#367, #368, #369).

## The problem

A key inside a nested KDL block that no parser recognises is dropped without complaint. No error, no warning, no effect — the proxy runs on the default while the config file says otherwise. Top-level blocks *are* validated, which makes it easy to miss: `bogus-block { }` is rejected with a clear message, so the parser looks strict until you go one level down.

## What this does

```
$ zentinel lint --config zentinel.kdl

  ⚠  'max_idle' is not a setting in the 'connection-pool' block and is being ignored. Did you mean 'max-idle'?
  ⚠  'max-lifetime-seconds' is not a setting in the 'connection-pool' block and is being ignored. Did you mean 'max-lifetime-secs'?
  ⚠  'connect-seconds' is not a setting in the 'timeouts' block and is being ignored. Did you mean 'connect-secs'?
  ⚠  'request_secs' is not a setting in the 'timeouts' block and is being ignored. Did you mean 'request-secs'?
  ⚠  'failure_mode' is not a setting in the 'policies' block and is being ignored. Did you mean 'failure-mode'?
  ⚠  'ratelimit' is not a setting in the 'policies' block and is being ignored. Did you mean 'rate-limit'?
  ⚠  'timeout_secs' is not a setting in the 'policies' block and is being ignored. Did you mean 'timeout-secs'?
```

Suggestions come from edit distance with a length-proportional budget, which covers both shapes seen in practice: separator slips (`failure_mode`, `ratelimit`) and unit-suffix mismatches (`connect-seconds` vs `connect-secs`) — the latter being exactly what #367 was.

It reads the KDL source rather than the parsed `Config`, because by the time a `Config` exists the unknown keys are gone.

## Only closed blocks are checked

Some blocks legitimately hold arbitrary keys — a JSON schema's `properties`, header maps, agent config forwarded verbatim. Warning about those would be noise, and a noisy linter teaches people to skip its output.

So it inspects an explicit list of blocks with fixed key sets: `connection-pool`, `timeouts`, `policies`. Anything else is left alone. Adding a block is a deliberate decision, not a default.

## The failure mode this design has, and the guard for it

Under-listing a key set would warn about *valid* configuration, which is worse than the silence it replaces. `shipped_configs_use_only_known_keys` runs the check across every shipped config and fails if anything is reported, so that mistake lands in the build rather than in an operator's terminal.

**That test earned its place on the first run.** It found `rewrite-path` in `config/examples/static-site.kdl` — a setting that does not exist:

```kdl
// Rewrite all paths to index.html for SPA
policies {
    timeout-secs 10
    rewrite-path "/index.html"       // ← does nothing
}
```

So that example's SPA fallback silently did nothing. Fixed here by expressing it as the `url-rewrite` filter that actually implements it (`replace-full-path`), which is the eighth instance of this bug found this week — and the first one found automatically rather than by hand.

## Scope

Deliberately three blocks, not all of them. The parser mentions 577 distinct strings; a hand-maintained registry of everything would drift and start producing false warnings, which is the one outcome worth avoiding. These three are where real bugs were found. Extending the list later is cheap and the guard test makes it safe.

`cargo test --workspace --all-features`, `clippy --all-targets --all-features -D warnings`, and `cargo doc --all-features` with `-D warnings` are all green.
