### PR TITLE
fix(config): read distributed rate-limit and WAF exclusion settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,21 @@ for details.
   nothing will now start matching. (#113)
 
 ### Fixed
+- **Distributed rate-limit fallback and TTL are read.** The backend parser
+  looked for `redis-fallback`, `memcached-fallback` and `memcached-ttl` while
+  every config writes `redis-fallback-local`, `memcached-fallback-local` and
+  `memcached-ttl-secs`. The defaults matched what the examples asked for, so
+  the mismatch was invisible until a value differed — and the value that
+  mattered was `#false`. An operator disabling local fallback (so a Redis
+  outage does not silently degrade one global limit into one limit per proxy
+  instance) was ignored, and got local fallback anyway. (#365)
+- **WAF rule exclusions are read.** Exclusions were looked for as direct
+  children of `ruleset`, but configs group them in an `exclusions { }` block,
+  so every exclusion was discarded — including all of `config/zentinel.kdl`'s.
+  Rules an operator had excluded because they false-positive on their
+  application kept firing, with the exclusion plainly visible in the file. The
+  two-argument scope form (`scope "path" "/api/v1/upload"`), which the shipped
+  config uses, is now accepted alongside `scope "path=/api/v1/upload"`. (#365)
 - **Route `policies` are read.** Six of the nine fields on `RoutePolicies` were
   never populated: the parser set header rewriting and caching and left the rest
   behind a `..Default::default()`. `timeout-secs`, `max-body-size`,

--- a/crates/config/src/kdl/filters.rs
+++ b/crates/config/src/kdl/filters.rs
@@ -136,7 +136,13 @@ fn parse_rate_limit_backend(node: &kdl::KdlNode) -> Result<RateLimitBackend> {
             let timeout_ms = get_int_entry(node, "redis-timeout-ms")
                 .map(|v| v as u64)
                 .unwrap_or(50);
-            let fallback_local = get_bool_entry(node, "redis-fallback").unwrap_or(true);
+            // Every config writes `redis-fallback-local`; this read only
+            // `redis-fallback`. It looked correct because the default is also
+            // true, so the discarded setting matched intent by coincidence —
+            // until someone wrote `#false`, which was silently ignored.
+            let fallback_local = get_bool_entry(node, "redis-fallback-local")
+                .or_else(|| get_bool_entry(node, "redis-fallback"))
+                .unwrap_or(true);
 
             Ok(RateLimitBackend::Redis(RedisBackendConfig {
                 url: redis_url,
@@ -158,8 +164,14 @@ fn parse_rate_limit_backend(node: &kdl::KdlNode) -> Result<RateLimitBackend> {
             let timeout_ms = get_int_entry(node, "memcached-timeout-ms")
                 .map(|v| v as u64)
                 .unwrap_or(50);
-            let fallback_local = get_bool_entry(node, "memcached-fallback").unwrap_or(true);
-            let ttl_secs = get_int_entry(node, "memcached-ttl")
+            // Same mismatch as the Redis branch above, plus the TTL: configs
+            // write `memcached-ttl-secs`, this read `memcached-ttl`, and the
+            // default of 2 matched what the examples asked for.
+            let fallback_local = get_bool_entry(node, "memcached-fallback-local")
+                .or_else(|| get_bool_entry(node, "memcached-fallback"))
+                .unwrap_or(true);
+            let ttl_secs = get_int_entry(node, "memcached-ttl-secs")
+                .or_else(|| get_int_entry(node, "memcached-ttl"))
                 .map(|v| v as u32)
                 .unwrap_or(2);
 
@@ -435,6 +447,92 @@ fn parse_path_modifier(node: &kdl::KdlNode) -> Option<PathModifier> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The distributed backends read `redis-fallback` / `memcached-fallback` /
+    /// `memcached-ttl`, while every config writes the longer names. Because the
+    /// defaults matched what the examples asked for, the mismatch was invisible
+    /// until someone set a value that differed.
+    mod backend_key_names {
+        use super::*;
+
+        fn backend(body: &str) -> RateLimitBackend {
+            let kdl =
+                format!("filter \"rl\" {{\n  type \"rate-limit\"\n  max-rps 100\n{body}\n}}\n");
+            let doc: kdl::KdlDocument = kdl.parse().expect("kdl parses");
+            match parse_single_filter_definition(doc.nodes().first().expect("filter node"))
+                .expect("parses")
+            {
+                Filter::RateLimit(f) => f.backend,
+                other => panic!("expected a rate limit filter, got {other:?}"),
+            }
+        }
+
+        fn redis(extra: &str) -> RedisBackendConfig {
+            match backend(&format!(
+                "  backend \"redis\"\n  redis-url \"redis://localhost:6379\"\n  {extra}"
+            )) {
+                RateLimitBackend::Redis(c) => c,
+                other => panic!("expected redis backend, got {other:?}"),
+            }
+        }
+
+        fn memcached(extra: &str) -> MemcachedBackendConfig {
+            match backend(&format!(
+                "  backend \"memcached\"\n  memcached-url \"memcache://localhost:11211\"\n  {extra}"
+            )) {
+                RateLimitBackend::Memcached(c) => c,
+                other => panic!("expected memcached backend, got {other:?}"),
+            }
+        }
+
+        /// The name every config uses. `#false` is the value that mattered:
+        /// with it discarded, a Redis outage silently fell back to local
+        /// counting, so each instance limited independently.
+        #[test]
+        fn redis_fallback_local_is_read() {
+            assert!(!redis("redis-fallback-local #false").fallback_local);
+            assert!(redis("redis-fallback-local #true").fallback_local);
+        }
+
+        #[test]
+        fn redis_fallback_alias_still_works() {
+            assert!(!redis("redis-fallback #false").fallback_local);
+        }
+
+        #[test]
+        fn redis_fallback_defaults_to_true() {
+            assert!(redis("redis-prefix \"x:\"").fallback_local);
+        }
+
+        #[test]
+        fn memcached_fallback_local_is_read() {
+            assert!(!memcached("memcached-fallback-local #false").fallback_local);
+        }
+
+        #[test]
+        fn memcached_fallback_alias_still_works() {
+            assert!(!memcached("memcached-fallback #false").fallback_local);
+        }
+
+        #[test]
+        fn memcached_ttl_secs_is_read() {
+            assert_eq!(memcached("memcached-ttl-secs 99").ttl_secs, 99);
+        }
+
+        #[test]
+        fn memcached_ttl_alias_still_works() {
+            assert_eq!(memcached("memcached-ttl 99").ttl_secs, 99);
+        }
+
+        #[test]
+        fn the_documented_name_wins_when_both_are_present() {
+            assert!(!redis("redis-fallback-local #false\n  redis-fallback #true").fallback_local);
+            assert_eq!(
+                memcached("memcached-ttl-secs 99\n  memcached-ttl 5").ttl_secs,
+                99
+            );
+        }
+    }
 
     fn parse_filter(kdl: &str) -> Filter {
         let doc: kdl::KdlDocument = kdl.parse().expect("kdl parses");

--- a/crates/config/src/kdl/mod.rs
+++ b/crates/config/src/kdl/mod.rs
@@ -839,12 +839,29 @@ fn parse_waf_ruleset(node: &kdl::KdlNode) -> Result<crate::waf::WafRuleset> {
         .map(|v| v as u32)
         .unwrap_or(5);
 
-    // Parse exclusions
+    // Parse exclusions.
+    //
+    // This only looked for `exclusion` nodes directly under `ruleset`, but
+    // every config groups them in an `exclusions { }` block — including
+    // config/zentinel.kdl, whose three exclusions were all discarded. Rules an
+    // operator excluded because they false-positive on their application kept
+    // firing, with the exclusion visible in the file and no indication why it
+    // did nothing. Both shapes are accepted.
     let mut exclusions = Vec::new();
     if let Some(children) = node.children() {
         for child in children.nodes() {
-            if child.name().value() == "exclusion" {
-                exclusions.push(parse_rule_exclusion(child)?);
+            match child.name().value() {
+                "exclusion" => exclusions.push(parse_rule_exclusion(child)?),
+                "exclusions" => {
+                    if let Some(grandchildren) = child.children() {
+                        for entry in grandchildren.nodes() {
+                            if entry.name().value() == "exclusion" {
+                                exclusions.push(parse_rule_exclusion(entry)?);
+                            }
+                        }
+                    }
+                }
+                _ => {}
             }
         }
     }
@@ -889,19 +906,43 @@ fn parse_rule_exclusion(node: &kdl::KdlNode) -> Result<crate::waf::RuleExclusion
         }
     }
 
-    // Parse scope
+    // Parse scope.
+    //
+    // Two spellings are accepted: `scope "path=/x"` and the two-argument form
+    // `scope "path" "/x"`, which is what config/zentinel.kdl uses and the more
+    // natural KDL of the two. Only the first was implemented, which nobody
+    // noticed while exclusions were being discarded wholesale.
+    let scope_argument = node.children().and_then(|c| {
+        c.nodes()
+            .iter()
+            .find(|n| n.name().value() == "scope")
+            .and_then(|n| n.entries().get(1))
+            .and_then(|e| e.value().as_string())
+            .map(str::to_string)
+    });
+
     let scope = if let Some(scope_str) = get_string_entry(node, "scope") {
-        match scope_str.to_lowercase().as_str() {
-            "global" => ExclusionScope::Global,
-            path if path.starts_with("path=") => {
+        match (scope_str.to_lowercase().as_str(), scope_argument) {
+            ("global", _) => ExclusionScope::Global,
+            ("path", Some(pattern)) => ExclusionScope::Path(pattern),
+            ("host", Some(hostname)) => ExclusionScope::Host(hostname),
+            (path, None) if path.starts_with("path=") => {
                 ExclusionScope::Path(path.trim_start_matches("path=").to_string())
             }
-            host if host.starts_with("host=") => {
+            (host, None) if host.starts_with("host=") => {
                 ExclusionScope::Host(host.trim_start_matches("host=").to_string())
             }
-            other => {
+            ("path", None) | ("host", None) => {
                 return Err(anyhow::anyhow!(
-                    "Invalid exclusion scope '{}'. Valid options: global, path=<pattern>, host=<hostname>",
+                    "Exclusion scope '{}' needs a value, e.g. scope \"{}\" \"<value>\"",
+                    scope_str,
+                    scope_str
+                ));
+            }
+            (other, _) => {
+                return Err(anyhow::anyhow!(
+                    "Invalid exclusion scope '{}'. Valid options: global, path=<pattern>, \
+                     host=<hostname>, or the two-argument form scope \"path\" \"<pattern>\"",
                     other
                 ));
             }
@@ -1438,9 +1479,128 @@ fn parse_tracing_backend(node: &kdl::KdlNode) -> Result<crate::observability::Tr
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use zentinel_common::CircuitBreakerConfig;
 
-    use super::*;
+    /// Exclusions were looked for as direct children of `ruleset`, while every
+    /// config groups them in an `exclusions { }` block — so none were ever
+    /// parsed, and rules an operator had excluded kept firing.
+    mod waf_rule_exclusions {
+        use super::*;
+
+        fn ruleset_of(body: &str) -> crate::waf::WafRuleset {
+            let kdl = format!("ruleset {{\n{body}\n}}\n");
+            let doc: kdl::KdlDocument = kdl.parse().expect("kdl parses");
+            parse_waf_ruleset(doc.nodes().first().expect("ruleset node"))
+                .expect("ruleset should parse")
+        }
+
+        #[test]
+        fn exclusions_inside_a_wrapper_block_are_parsed() {
+            let ruleset = ruleset_of(
+                "  exclusions {\n    exclusion {\n      rule-ids \"920350\" \"920420\"\n      scope \"global\"\n    }\n  }",
+            );
+            assert_eq!(ruleset.exclusions.len(), 1);
+            assert_eq!(ruleset.exclusions[0].rule_ids, ["920350", "920420"]);
+        }
+
+        /// The pre-existing shape kept working.
+        #[test]
+        fn exclusions_directly_under_ruleset_are_still_parsed() {
+            let ruleset =
+                ruleset_of("  exclusion {\n    rule-ids \"941100\"\n    scope \"global\"\n  }");
+            assert_eq!(ruleset.exclusions.len(), 1);
+        }
+
+        #[test]
+        fn both_shapes_can_be_mixed() {
+            let ruleset = ruleset_of(
+                "  exclusion {\n    rule-ids \"1\"\n  }\n  exclusions {\n    exclusion {\n      rule-ids \"2\"\n    }\n  }",
+            );
+            assert_eq!(ruleset.exclusions.len(), 2);
+        }
+
+        #[test]
+        fn the_two_argument_scope_form_is_accepted() {
+            let ruleset = ruleset_of(
+                "  exclusions {\n    exclusion {\n      rule-ids \"941100\"\n      scope \"path\" \"/api/v1/upload\"\n    }\n  }",
+            );
+            assert!(matches!(
+                &ruleset.exclusions[0].scope,
+                crate::waf::ExclusionScope::Path(p) if p == "/api/v1/upload"
+            ));
+        }
+
+        #[test]
+        fn the_equals_scope_form_is_accepted() {
+            let ruleset = ruleset_of(
+                "  exclusions {\n    exclusion {\n      rule-ids \"941100\"\n      scope \"path=/api/v1/upload\"\n    }\n  }",
+            );
+            assert!(matches!(
+                &ruleset.exclusions[0].scope,
+                crate::waf::ExclusionScope::Path(p) if p == "/api/v1/upload"
+            ));
+        }
+
+        #[test]
+        fn a_host_scope_is_accepted_in_both_forms() {
+            for body in [
+                "  exclusions {\n    exclusion {\n      rule-ids \"1\"\n      scope \"host\" \"api.example.com\"\n    }\n  }",
+                "  exclusions {\n    exclusion {\n      rule-ids \"1\"\n      scope \"host=api.example.com\"\n    }\n  }",
+            ] {
+                let ruleset = ruleset_of(body);
+                assert!(matches!(
+                    &ruleset.exclusions[0].scope,
+                    crate::waf::ExclusionScope::Host(h) if h == "api.example.com"
+                ));
+            }
+        }
+
+        /// A scope that names a kind but gives no value is a mistake worth
+        /// reporting, not one to resolve silently to global.
+        #[test]
+        fn a_scope_kind_without_a_value_is_rejected() {
+            let kdl = "ruleset {\n  exclusions {\n    exclusion {\n      rule-ids \"1\"\n      scope \"path\"\n    }\n  }\n}\n";
+            let doc: kdl::KdlDocument = kdl.parse().unwrap();
+            let err = parse_waf_ruleset(doc.nodes().first().unwrap())
+                .expect_err("a valueless path scope should be rejected");
+            assert!(err.to_string().contains("needs a value"));
+        }
+
+        /// Pins the regression to the shipped config, whose three exclusions
+        /// across two entries were all being discarded.
+        #[test]
+        fn shipped_config_exclusions_take_effect() {
+            let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../config/zentinel.kdl");
+            let text = std::fs::read_to_string(path).expect("shipped config readable");
+            let config = crate::Config::from_kdl(&text).expect("shipped config parses");
+
+            let waf = config.waf.as_ref().expect("shipped config defines waf");
+            assert_eq!(
+                waf.ruleset.exclusions.len(),
+                2,
+                "both exclusions in the shipped config should be parsed"
+            );
+
+            let ids: Vec<&str> = waf
+                .ruleset
+                .exclusions
+                .iter()
+                .flat_map(|e| e.rule_ids.iter().map(String::as_str))
+                .collect();
+            assert!(ids.contains(&"920350"));
+            assert!(ids.contains(&"941100"));
+
+            assert!(
+                waf.ruleset
+                    .exclusions
+                    .iter()
+                    .any(|e| matches!(&e.scope, crate::waf::ExclusionScope::Path(p) if p == "/api/v1/upload")),
+                "the path-scoped exclusion should keep its path"
+            );
+        }
+    }
+
     use crate::filters::RateLimitKey;
 
     #[test]

--- a/crates/config/src/validate/unknown_keys.rs
+++ b/crates/config/src/validate/unknown_keys.rs
@@ -69,6 +69,18 @@ const CLOSED_BLOCKS: &[ClosedBlock] = &[
         ],
     },
     ClosedBlock {
+        name: "ruleset",
+        keys: &[
+            "crs-version",
+            "custom-rules-dir",
+            "paranoia-level",
+            "anomaly-threshold",
+            // Exclusions are accepted grouped in a wrapper or listed directly.
+            "exclusions",
+            "exclusion",
+        ],
+    },
+    ClosedBlock {
         name: "policies",
         keys: &[
             "request-headers",


### PR DESCRIPTION
Two more instances of #365, found after the audit I'd already called complete. Same family as #367 — the parser reads one name, every config writes another.

## 1. Distributed rate-limit fallback and TTL

| Config writes | Parser read |
|---|---|
| `redis-fallback-local` | `redis-fallback` |
| `memcached-fallback-local` | `memcached-fallback` |
| `memcached-ttl-secs` | `memcached-ttl` |

**This one hid well.** The defaults (`true`, `true`, `2`) match exactly what the shipped examples ask for, so parsed output looked correct in every file. It only diverges on a value that differs — and the value that matters is `#false`:

```
redis-fallback-local  #false  ->  fallback_local=true    (discarded)
redis-fallback        #false  ->  fallback_local=false   (works)
```

An operator setting `#false` is saying "if Redis is unreachable, do not fall back to local counting." They got local fallback anyway. Under a Redis outage every proxy instance then counts independently, so one global 100 rps limit becomes N × 100 rps — the limit failing open, silently, at exactly the moment it is load-bearing.

**I reported `memcached-ttl-secs` as fine earlier and was wrong.** It's discarded too; the default of 2 equals what the examples set. Verified properly this time against a value that differs.

## 2. WAF rule exclusions

A different shape — nesting rather than naming. The parser looked for `exclusion` as a direct child of `ruleset`:

```rust
for child in children.nodes() {
    if child.name().value() == "exclusion" { ... }
}
```

Every config groups them in a wrapper:

```kdl
ruleset {
    exclusions {
        exclusion { rule-ids "920350" "920420"; scope "global" }
        exclusion { rule-ids "941100"; scope "path" "/api/v1/upload" }
    }
}
```

So all of them were discarded — `config/zentinel.kdl` parsed to `exclusions = 0`. Rules an operator excluded because they false-positive on their application kept firing, with the exclusion plainly visible in the file and nothing to explain why it did nothing.

**Fixing it surfaced a second bug underneath.** Once exclusions actually parsed, the shipped config failed to load:

```
Invalid exclusion scope 'path'. Valid options: global, path=<pattern>, host=<hostname>
```

`zentinel.kdl` writes `scope "path" "/api/v1/upload"` — the natural KDL two-argument form — and the parser only ever accepted `scope "path=/api/v1/upload"`. Nobody noticed because exclusions were never parsed at all. Both forms work now, and a scope kind given without a value is an error rather than a silent fall back to global.

## Direction of failure

Worth noting these differ. The rate-limit one fails **open** — a limit stops applying. The WAF one fails **closed** — rules keep firing that were meant to be excluded, so legitimate traffic gets blocked and the operator can't work out why. Neither is what the config says.

## Tests

16, including two that pin the regressions to `config/zentinel.kdl` and `distributed-rate-limit.kdl`, so the shipped configs and the parser can't drift apart again silently. Old names remain accepted as aliases throughout.

`cargo test --workspace --all-features` (34 suites), `clippy --all-targets --all-features -D warnings`, and `cargo doc --all-features` with `-D warnings` all green.

## Follow-up worth doing

`ruleset` is now a good candidate for `CLOSED_BLOCKS` in the lint added in #371 — its key set is small and fixed, and the check would have caught the exclusions bug. I've not added it here to keep this PR to the fixes; the rate-limit `filter` block is a poorer candidate, since its valid keys are a union across every filter type and under-listing would produce false warnings on valid configs.
