### PR TITLE
fix: make the websocket example work, and drop an unreachable lint rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,20 @@ for details.
   nothing will now start matching. (#113)
 
 ### Fixed
+- **The WebSocket example enables WebSocket.** It wrote `websocket { enabled
+  #true … }` as a block, while a route reads `websocket` as a scalar boolean —
+  so every route in the example demonstrating WebSocket proxying parsed to
+  `websocket = false` and proxied none. The example now uses `websocket #true`
+  and `websocket-inspection #true`, and the keepalive, message-size and
+  per-IP-connection settings it carried are kept as comments, since none of
+  them exist in the schema. Its header no longer advertises them. (#369)
+- **`zentinel lint` no longer claims a check it cannot perform.** The
+  "buffers bodies but sets no max-body-size" rule could never fire —
+  `buffer-requests` and `buffer-responses` have no KDL key and are read by
+  nothing, so they are always false for any config a person can write. The
+  rule is removed rather than left reporting coverage that does not exist; a
+  test now guards that those fields are still unreachable, so it fails if
+  #366 wires them up. (#366)
 - **Distributed rate-limit fallback and TTL are read.** The backend parser
   looked for `redis-fallback`, `memcached-fallback` and `memcached-ttl` while
   every config writes `redis-fallback-local`, `memcached-fallback-local` and

--- a/config/examples/websocket.kdl
+++ b/config/examples/websocket.kdl
@@ -1,11 +1,12 @@
 // Example: WebSocket Proxy Configuration
 //
 // WebSocket proxying with:
-// - Frame inspection for security
-// - Rate limiting (messages per second)
-// - Connection limits per IP
-// - Ping/pong keepalive
+// - Frame inspection for security (via a websocket-inspector agent)
 // - Token authentication
+//
+// Note: per-route keepalive, message-size and per-IP connection limits are
+// not currently configurable. The settings for them are kept below as
+// comments so the intent survives; see zentinelproxy/zentinel#369.
 
 system {
     worker-threads 0
@@ -87,13 +88,11 @@ routes {
         upstream "ws-backend"
         filters "auth" "ws-inspector"
 
-        websocket {
-            enabled #true
-            ping-interval-secs 30
-            ping-timeout-secs 10
-            max-message-size-bytes 65536
-            max-connections-per-ip 10
-        }
+        websocket #true
+        websocket-inspection #true
+        // Not yet configurable (#369): ping-interval-secs 30,
+        // ping-timeout-secs 10, max-message-size-bytes 65536,
+        // max-connections-per-ip 10
 
         policies {
             timeout-secs 3600  // Long timeout for persistent connections
@@ -112,12 +111,10 @@ routes {
         upstream "socketio-backend"
         filters "auth"
 
-        websocket {
-            enabled #true
-            ping-interval-secs 25
-            ping-timeout-secs 10
-            max-message-size-bytes 1048576  // 1MB for larger payloads
-        }
+        websocket #true
+        // Not yet configurable (#369): ping-interval-secs 25,
+        // ping-timeout-secs 10, max-message-size-bytes 1048576 (1MB for
+        // larger payloads)
 
         policies {
             timeout-secs 3600
@@ -135,13 +132,11 @@ routes {
         upstream "chat-backend"
         filters "auth" "ws-inspector"
 
-        websocket {
-            enabled #true
-            ping-interval-secs 30
-            ping-timeout-secs 10
-            max-message-size-bytes 16384
-            max-connections-per-ip 5
-        }
+        websocket #true
+        websocket-inspection #true
+        // Not yet configurable (#369): ping-interval-secs 30,
+        // ping-timeout-secs 10, max-message-size-bytes 16384,
+        // max-connections-per-ip 5
 
         policies {
             timeout-secs 7200  // 2 hour sessions

--- a/crates/config/src/kdl/routes.rs
+++ b/crates/config/src/kdl/routes.rs
@@ -1897,6 +1897,36 @@ mod tests {
     /// and hold their defaults no matter what the config said. Each test below
     /// uses a value that differs from the default, so a field falling back to
     /// its default fails the test rather than passing by coincidence.
+    /// The WebSocket example exists to demonstrate WebSocket proxying, and for
+    /// some time demonstrated none: it wrote `websocket { enabled #true … }`
+    /// as a block while the parser reads `websocket` as a scalar bool, so every
+    /// route in it parsed to `websocket = false` (#369).
+    #[test]
+    fn the_websocket_example_actually_enables_websocket() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../config/examples/websocket.kdl"
+        );
+        let text = std::fs::read_to_string(path).expect("example should be readable");
+        let config = crate::Config::from_kdl(&text).expect("example should parse");
+
+        let ws_routes: Vec<&crate::RouteConfig> =
+            config.routes.iter().filter(|r| r.websocket).collect();
+
+        assert!(
+            ws_routes.len() >= 3,
+            "the WebSocket example should enable websocket on its websocket routes, \
+             found {} of {}",
+            ws_routes.len(),
+            config.routes.len()
+        );
+
+        assert!(
+            config.routes.iter().any(|r| r.websocket_inspection),
+            "the example advertises frame inspection and should enable it on at least one route"
+        );
+    }
+
     mod route_policies_are_parsed {
         use super::*;
 

--- a/crates/config/src/validate/lint.rs
+++ b/crates/config/src/validate/lint.rs
@@ -183,18 +183,14 @@ fn check_resource_bounds(config: &Config, result: &mut ValidationResult) {
     for route in &config.routes {
         let policies = &route.policies;
 
-        // A buffered body is held in memory for the life of the request, so an
-        // unbounded one is a per-request allocation the client chooses.
-        if (policies.buffer_requests || policies.buffer_responses)
-            && policies.max_body_size.is_none()
-        {
-            result.add_warning(ValidationWarning::new(format!(
-                "Route '{}' buffers bodies but sets no max-body-size, so one request \
-                 can allocate as much memory as it asks for.",
-                route.id
-            )));
-        }
-
+        // A rule for "buffers bodies but sets no max-body-size" was removed
+        // here. It could never fire: `buffer_requests` and `buffer_responses`
+        // have no KDL key and are read by nothing in the proxy, so they are
+        // always false for any config a person can write. Its tests passed
+        // only because they set the fields directly. A linter reporting
+        // coverage it does not have is worse than one check short — restore
+        // this once #366 decides whether those fields get implemented or
+        // removed.
         if let Some(max_body) = policies.max_body_size {
             if max_body.0 > GENEROUS_BODY_SIZE {
                 result.add_warning(ValidationWarning::new(format!(
@@ -604,32 +600,27 @@ mod resource_bound_tests {
         assert!(mentions(&config, "can never be reached"));
     }
 
-    /// Buffering without a size limit is the combination that turns one
-    /// request into as much memory as it asks for.
+    /// Guards the removal above: `buffer_requests` cannot be set from any
+    /// config, so a rule keyed on it can never fire for a real user. The two
+    /// tests that used to live here set the field directly and so passed
+    /// while the rule was dead. If #366 wires these fields up, this test
+    /// starts failing and the rule can come back with it.
     #[test]
-    fn buffering_without_a_body_limit_is_reported() {
-        let mut config = Config::default_for_testing();
-        for route in &mut config.routes {
-            route.policies.buffer_requests = true;
-            route.policies.max_body_size = None;
-        }
-        assert!(mentions(
-            &config,
-            "buffers bodies but sets no max-body-size"
-        ));
-    }
+    fn buffering_flags_are_still_unreachable_from_config() {
+        let kdl = "system {\n  workers 2\n}\n\
+                   listeners {\n  listener \"http\" {\n    address \"127.0.0.1:8080\"\n  }\n}\n\
+                   upstreams {\n  upstream \"b\" {\n    target \"127.0.0.1:9000\"\n  }\n}\n\
+                   routes {\n  route \"r\" {\n    matches {\n      path-prefix \"/\"\n    }\n\
+                   \x20   upstream \"b\"\n    policies {\n      buffer-requests #true\n\
+                   \x20     buffer-responses #true\n    }\n  }\n}\n";
+        let config = Config::from_kdl(kdl).expect("config should parse");
+        let policies = &config.routes[0].policies;
 
-    #[test]
-    fn buffering_with_a_body_limit_is_not_reported() {
-        let mut config = Config::default_for_testing();
-        for route in &mut config.routes {
-            route.policies.buffer_requests = true;
-            route.policies.max_body_size = Some(ByteSize::from_mb(10));
-        }
-        assert!(!mentions(
-            &config,
-            "buffers bodies but sets no max-body-size"
-        ));
+        assert!(
+            !policies.buffer_requests && !policies.buffer_responses,
+            "buffering became settable from config — see #366, and restore the \
+             lint rule that was removed alongside these tests"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Takes #369 and #366 as far as they go without pre-empting the decisions they're actually waiting on. **Neither issue is closed by this.**

## #369 — the WebSocket example proxied no WebSocket

It wrote its per-route config as a block:

```kdl
websocket {
    enabled #true
    ping-interval-secs 30
    max-connections-per-ip 10
}
```

A route reads `websocket` as a scalar boolean. Written as a block it parses to `false`, so every route in the example whose entire purpose is demonstrating WebSocket proxying had WebSocket switched off.

Now uses `websocket #true`, plus `websocket-inspection #true` on the two routes the example pairs with an inspector agent. The keepalive, message-size and per-IP-connection settings are **kept as comments** rather than deleted — none of them exist in the schema, but the intent is worth preserving for whoever implements them. The header comment no longer advertises them as working features.

A test pins the example, so it can't quietly stop working again:

```rust
assert!(ws_routes.len() >= 3, "the WebSocket example should enable websocket on its websocket routes");
```

**Still open:** whether those settings get implemented. This only stops the example lying about them.

## #366 — a lint rule that could never fire

```rust
if (policies.buffer_requests || policies.buffer_responses) && policies.max_body_size.is_none()
```

`buffer-requests` and `buffer-responses` have no KDL key and are read by nothing in the proxy, so both are false for every config a person can write. The rule was unreachable. Its two tests passed only because they set the fields directly, which is exactly how it went unnoticed.

Removed, rather than left reporting coverage the linter doesn't have. The replacement test asserts the fields are *still* unreachable from config:

```rust
assert!(!policies.buffer_requests && !policies.buffer_responses,
        "buffering became settable from config — see #366, and restore the lint rule");
```

So if #366 wires them up, this fails and points at the rule to bring back.

**Still open:** whether those fields get implemented or deleted. Deleting is a breaking change to a public type, which is why I haven't.

## Verification

`cargo test --workspace --all-features` (34 suites), clippy and fmt all green. `zentinel test` and `zentinel lint` both clean on the corrected example.
