### PR TITLE
fix(config): reject client-auth without a ca-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ for details.
 
 ## [Unreleased]
 
-> **Five behaviour changes to check before upgrading.** `retry-policy.max-attempts`
+> **Six behaviour changes to check before upgrading.** `retry-policy.max-attempts`
 > now retries requests rather than backend selection, host matching in routes is
 > now case-insensitive — a route written `host "Example.com"` previously matched
 > nothing and now matches `example.com` — and `connection-pool.max-lifetime-secs`
@@ -124,6 +124,16 @@ for details.
   nothing will now start matching. (#113)
 
 ### Fixed
+- **`client-auth` without `ca-file` is now rejected instead of silently serving
+  ordinary TLS.** Client certificates cannot be verified without a CA to verify
+  them against, and the proxy logged a warning and carried on with client
+  authentication disabled. An operator could configure mutual TLS, pass
+  `zentinel test` and `zentinel validate`, start the proxy, and be accepting
+  unauthenticated clients — with one startup warning as the only signal. For
+  internal traffic where mTLS is often the only authentication, that is the
+  whole control. **A config with `client-auth` and no `ca-file` will now fail
+  to start**; it was never getting mutual TLS, so the failure reveals a
+  misconfiguration rather than creating one.
 - **`ReverseConnectionConfig::require_auth` now authenticates.** It checked that
   a registering agent sent *a* token, never that the token was correct, so any
   non-empty string authenticated. Tokens are now compared in constant time

--- a/crates/config/src/validation.rs
+++ b/crates/config/src/validation.rs
@@ -626,6 +626,24 @@ fn validate_acme_domains(config: &Config, errors: &mut Vec<String>) {
     let mut domain_source: HashMap<String, String> = HashMap::new();
 
     for listener in &config.listeners {
+        // Mutual TLS with nothing to verify against is not mutual TLS. The
+        // proxy used to log a warning and serve without client
+        // authentication, so an operator could configure mTLS, pass
+        // `zentinel validate`, start the proxy, and be accepting
+        // unauthenticated clients while believing otherwise. Rejecting here
+        // means the mistake surfaces before traffic does.
+        if let Some(ref tls) = listener.tls {
+            if tls.client_auth && tls.ca_file.is_none() {
+                errors.push(format!(
+                    "Listener '{}' sets client-auth but no ca-file. Client certificates \
+                     cannot be verified without a CA to verify them against, so this would \
+                     serve ordinary TLS while appearing to require client certificates. \
+                     Add ca-file, or remove client-auth.",
+                    listener.id
+                ));
+            }
+        }
+
         // 1. Root-level ACME for listener
         if let Some(ref tls) = listener.tls {
             if let Some(ref acme) = tls.acme {
@@ -1187,6 +1205,69 @@ mod tests {
         UpstreamConfig, UpstreamTarget, UpstreamTimeouts,
     };
     use zentinel_common::types::LoadBalancingAlgorithm;
+
+    /// mTLS with no CA to verify against is not mTLS. The proxy used to warn
+    /// and serve without client authentication, so a config requesting mutual
+    /// TLS could pass validation, start, and accept unauthenticated clients.
+    mod client_auth_requires_a_ca {
+        use super::*;
+
+        fn config_with_tls(tls_body: &str) -> String {
+            format!(
+                "system {{\n  workers 2\n}}\n\
+                 listeners {{\n  listener \"https\" {{\n    address \"127.0.0.1:8443\"\n\
+                 \x20   tls {{\n{tls_body}\n    }}\n  }}\n}}\n\
+                 upstreams {{\n  upstream \"b\" {{\n    target \"127.0.0.1:9000\"\n  }}\n}}\n\
+                 routes {{\n  route \"r\" {{\n    matches {{\n      path-prefix \"/\"\n    }}\n\
+                 \x20   upstream \"b\"\n  }}\n}}\n"
+            )
+        }
+
+        const CERTS: &str = "      cert-file \"/tmp/x.crt\"\n      key-file \"/tmp/x.key\"";
+
+        #[test]
+        fn client_auth_without_a_ca_file_is_rejected() {
+            let kdl = config_with_tls(&format!("{CERTS}\n      client-auth #true"));
+            let config = Config::from_kdl(&kdl).expect("should parse");
+            let err = config
+                .validate()
+                .expect_err("mTLS without a CA must not validate");
+            let message = err.to_string();
+            assert!(
+                message.contains("client-auth") && message.contains("ca-file"),
+                "error should name both settings, got: {message}"
+            );
+        }
+
+        #[test]
+        fn client_auth_with_a_ca_file_is_accepted() {
+            let kdl = config_with_tls(&format!(
+                "{CERTS}\n      client-auth #true\n      ca-file \"/tmp/ca.crt\""
+            ));
+            let config = Config::from_kdl(&kdl).expect("should parse");
+            assert!(
+                config.validate().is_ok(),
+                "mTLS with a CA should validate: {:?}",
+                config.validate()
+            );
+        }
+
+        /// Ordinary one-way TLS is untouched.
+        #[test]
+        fn tls_without_client_auth_is_accepted() {
+            let kdl = config_with_tls(CERTS);
+            let config = Config::from_kdl(&kdl).expect("should parse");
+            assert!(config.validate().is_ok());
+        }
+
+        /// A CA with no client-auth is harmless — it just goes unused.
+        #[test]
+        fn a_ca_file_without_client_auth_is_accepted() {
+            let kdl = config_with_tls(&format!("{CERTS}\n      ca-file \"/tmp/ca.crt\""));
+            let config = Config::from_kdl(&kdl).expect("should parse");
+            assert!(config.validate().is_ok());
+        }
+    }
 
     #[test]
     fn listener_referencing_unknown_namespace_fails_validation() {

--- a/crates/proxy/src/tls.rs
+++ b/crates/proxy/src/tls.rs
@@ -1787,10 +1787,18 @@ pub fn build_server_config_with_resolver(
                 .with_client_cert_verifier(verifier)
                 .with_cert_resolver(resolver.clone())
         } else {
-            warn!("client_auth enabled but no ca_file specified, disabling client auth");
-            builder
-                .with_no_client_auth()
-                .with_cert_resolver(resolver.clone())
+            // Config validation rejects this combination, so reaching here
+            // means a Config was built in code rather than parsed. Failing is
+            // still the right answer: quietly serving without client
+            // authentication is the outcome an operator asking for mTLS would
+            // least expect, and a warning in the startup log is not a
+            // proportionate signal for it.
+            return Err(TlsError::ConfigBuild(
+                "client_auth is enabled but no ca_file is configured. Client certificates \
+                 cannot be verified without a CA, and serving without client authentication \
+                 would contradict the configuration."
+                    .to_string(),
+            ));
         }
     } else {
         builder


### PR DESCRIPTION
> [!WARNING]
> **A config with `client-auth` and no `ca-file` will now fail to start.** Those deployments were never getting mutual TLS, so this reveals a misconfiguration rather than creating one — but it will stop a proxy that currently starts.

Found by sweeping for the pattern behind #374: settings that name an enforcement they don't perform.

## What was wrong

`client-auth #true` with no `ca-file` was handled like this:

```rust
warn!("client_auth enabled but no ca_file specified, disabling client auth");
builder.with_no_client_auth()
```

Client certificates cannot be verified without a CA to verify them against — so rather than fail, the proxy disabled client authentication and served ordinary TLS.

**Verified end to end before the fix:**

```
parsed OK: client_auth=true ca_file=None
validate(): ACCEPTED — mTLS requested with no CA
```

An operator could write `client-auth #true`, forget or mistype `ca-file`, pass `zentinel test`, pass `zentinel validate`, start the proxy, and be accepting unauthenticated clients while believing certificates were required. The only signal was one warning line at startup — not a proportionate signal for silently dropping an authentication requirement.

Severity is worth stating plainly: for internal service-to-service traffic, mTLS is frequently the *only* authentication. Dropping it doesn't weaken defence in depth, it removes the control.

## The fix

Two layers, deliberately:

- **Config validation rejects it**, so the mistake surfaces before traffic does, with an actionable message naming both settings.
- **The TLS builder errors rather than degrading.** Validation makes that unreachable for parsed configs, but a `Config` built in code shouldn't be able to reach a state where the proxy quietly contradicts it. This is the same reasoning as #375's refuse-to-bind: a security control that degrades to nothing on misconfiguration is worse than one that fails.

```
$ zentinel test --config mtls.kdl
Error: Listener 'https' sets client-auth but no ca-file. Client certificates cannot be
verified without a CA to verify them against, so this would serve ordinary TLS while
appearing to require client certificates. Add ca-file, or remove client-auth.
```

## What the sweep found otherwise

Worth recording the negative results, since they bound the concern:

- `validate_requests`, `validate_responses`, `strict_mode` — all wired, all settable from KDL, and **all tested on the rejecting path** (three `assert!(result.is_err())` in `validation.rs`). Genuinely fine.
- `require_auth` — #374, fixed in #375.
- `client_auth` — this PR.

So the pattern is real but not pervasive. Two instances, both now fixed.

## Tests

Four: rejected without a CA, accepted with one, ordinary TLS unaffected, and a CA without `client-auth` accepted (harmless, just unused).

`cargo test --workspace --all-features` (34 suites), clippy and fmt green.
