### PR TITLE
chore: bump workspace version to 0.6.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8273,7 +8273,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8314,7 +8314,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8336,7 +8336,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8415,7 +8415,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8446,7 +8446,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8537,7 +8537,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8554,7 +8554,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.25"
+version = "0.6.26"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
The post-release bump for 26.08_3 that never landed. **Prerequisite for cutting the next release.**

## Why this matters now

| | |
|---|---|
| `main` Cargo.toml | 0.6.25 |
| Latest on crates.io | **0.6.26** |

The Release workflow publishes `Cargo.toml version + 1`. Tagging from main as it stands would try to publish **0.6.26 a second time**, and since `cargo publish` runs per crate in dependency order, that failure would land partway through with some crates already uploaded.

## Why not the orphan branch

The workflow force-pushed `chore/bump-0.6.26` after the last release, and that is normally what gets merged here. **It is not safe to merge now.** It was created from the 26.08_3 release commit (2026-08-22) and contains none of the work that landed since — diffing it against main shows **7,717 deletions**, including the entire `crates/proxy/src/agentic/` module, the unknown-key lint, and every config parser fix from this week.

This PR makes the same one-line change from current main instead. `chore/bump-0.6.25` and `chore/bump-0.6.26` should both be deleted so nobody merges them by habit.

## Contents

Workspace version 0.6.25 → 0.6.26, plus `cargo update --workspace` so the lockfile agrees. Seven crates inherit the workspace version. `cargo check --workspace` clean.