### PR TITLE
chore: bump workspace version to 0.6.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8273,7 +8273,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8314,7 +8314,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8336,7 +8336,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8415,7 +8415,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8446,7 +8446,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8537,7 +8537,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8554,7 +8554,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.26"
+version = "0.6.27"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Post-release version bump following `26.08_4`.

The Release workflow publishes the tag version **+1**, so `26.08_4` shipped crate
version `0.6.27`. Main is left at `0.6.26` because the workflow's direct push to
`main` is blocked by branch protection — this PR carries that bump.

## Verified on crates.io

All four published crates are at `0.6.27` (checked against the registry API, not
the job status):

| Crate | Version |
|---|---|
| `zentinel-common` | 0.6.27 |
| `zentinel-config` | 0.6.27 |
| `zentinel-agent-protocol` | 0.6.27 |
| `zentinel-proxy` | 0.6.27 |

`zentinel-wasm-runtime`, `zentinel-gateway` and `zentinel-stack` are not in the
workflow's publish list and have never been published.

## Contents

- `Cargo.toml` — `[workspace.package] version` 0.6.26 → 0.6.27 (workflow commit)
- `Cargo.lock` — the same bump for the 7 workspace members

The workflow bumps only the manifest; without the lockfile change the two
disagree and `--locked` builds fail. `cargo update --workspace` touched the 7
members and left all 192 external dependencies unchanged.