### PR TITLE
fix(config): check unknown keys in route and system blocks (#365)

### DIFF
--- a/config/examples/api-schema-validation.kdl
+++ b/config/examples/api-schema-validation.kdl
@@ -8,7 +8,7 @@
 
 // Server Configuration
 system {
-    workers 4
+    worker-threads 4
     daemon #false
 }
 

--- a/config/examples/inference-routing.kdl
+++ b/config/examples/inference-routing.kdl
@@ -284,13 +284,6 @@ routes {
             failure-mode "open"  // Fail open for local inference
         }
 
-        circuit-breaker {
-            failure-threshold 5
-            success-threshold 2
-            timeout-seconds 60
-            half-open-max-requests 3
-        }
-
         // retry-policy currently implements max-attempts only; per-attempt
         // timeouts, backoff tuning and status-code retries are tracked in #279.
         retry-policy {

--- a/config/examples/load-balancer.kdl
+++ b/config/examples/load-balancer.kdl
@@ -35,13 +35,6 @@ routes {
 
         upstream "app-cluster"
 
-        circuit-breaker {
-            failure-threshold 5
-            success-threshold 2
-            timeout-seconds 60
-            half-open-max-requests 3
-        }
-
         // retry-policy currently implements max-attempts only; per-attempt
         // timeouts, backoff tuning and status-code retries are tracked in #279.
         retry-policy {

--- a/config/examples/mixed-services.kdl
+++ b/config/examples/mixed-services.kdl
@@ -108,11 +108,6 @@ routes {
             failure-mode "closed"
         }
 
-        circuit-breaker {
-            failure-threshold 3
-            success-threshold 2
-            timeout-seconds 30
-        }
     }
 
     // User service - standard CRUD, moderate timeouts
@@ -137,11 +132,6 @@ routes {
             max-body-size "5MB"
         }
 
-        circuit-breaker {
-            failure-threshold 5
-            success-threshold 2
-            timeout-seconds 60
-        }
     }
 
     // Order service - critical business logic, longer timeouts
@@ -162,11 +152,6 @@ routes {
             failure-mode "closed"
         }
 
-        circuit-breaker {
-            failure-threshold 3
-            success-threshold 2
-            timeout-seconds 120
-        }
     }
 
     // Product service - read-heavy, can tolerate failures
@@ -213,11 +198,6 @@ routes {
             max-body-size "1MB"
         }
 
-        circuit-breaker {
-            failure-threshold 10
-            success-threshold 3
-            timeout-seconds 60
-        }
     }
 
     // Webhook service - async processing, fire-and-forget

--- a/config/examples/multiple-upstreams-health-check.kdl
+++ b/config/examples/multiple-upstreams-health-check.kdl
@@ -34,13 +34,6 @@ routes {
 
         upstream "backend"
 
-        circuit-breaker {
-            failure-threshold 5
-            success-threshold 2
-            timeout-seconds 60
-            half-open-max-requests 3
-        }
-
         // retry-policy currently implements max-attempts only; per-attempt
         // timeouts, backoff tuning and status-code retries are tracked in #279.
         retry-policy {

--- a/config/zentinel.kdl
+++ b/config/zentinel.kdl
@@ -131,15 +131,9 @@ routes {
         filters "auth" "rate-limit"
         waf-enabled #true
 
-        circuit-breaker {
-            failure-threshold 5
-            success-threshold 2
-            timeout-seconds 30
-            half-open-max-requests 3
-        }
-
-        // retry-policy currently supports max-attempts only; per-attempt
-        // timeouts and backoff tuning are not yet implemented.
+        // max-attempts counts request retries, not peer selections. Nothing is
+        // retried on a status code unless retryable-status-codes says so, and
+        // POST is never replayed without retry-non-idempotent.
         retry-policy {
             max-attempts 3
         }

--- a/crates/config/src/kdl/mod.rs
+++ b/crates/config/src/kdl/mod.rs
@@ -16,8 +16,8 @@ mod filters;
 mod helpers;
 mod namespace;
 mod retrypolicy_helper;
-mod routes;
-mod server;
+pub(crate) mod routes;
+pub(crate) mod server;
 mod upstreams;
 
 use tracing::{debug, trace, warn};

--- a/crates/config/src/kdl/routes.rs
+++ b/crates/config/src/kdl/routes.rs
@@ -20,7 +20,7 @@ use super::helpers::{
 
 /// Recognized child node names inside a `route` block.
 /// Any child node not in this set will produce a warning during parsing.
-const RECOGNIZED_ROUTE_CHILDREN: &[&str] = &[
+pub(crate) const RECOGNIZED_ROUTE_CHILDREN: &[&str] = &[
     "matches",
     "priority",
     "upstream",

--- a/crates/config/src/kdl/server.rs
+++ b/crates/config/src/kdl/server.rs
@@ -19,6 +19,25 @@ use std::time::Duration;
 use super::helpers::{get_bool_entry, get_first_arg_string, get_int_entry, get_string_entry};
 
 /// Parse server configuration block
+/// Every key `parse_server_config` reads.
+///
+/// Kept beside the parser so that adding a setting below without listing it
+/// here is a visible omission rather than a silent one. The unknown-key lint
+/// reads this list; under-listing it produces false warnings on valid configs.
+pub(crate) const RECOGNIZED_SYSTEM_KEYS: &[&str] = &[
+    "worker-threads",
+    "max-connections",
+    "graceful-shutdown-timeout-secs",
+    "daemon",
+    "pid-file",
+    "user",
+    "group",
+    "working-directory",
+    "trace-id-format",
+    "auto-reload",
+    "route-cache-size",
+];
+
 pub fn parse_server_config(node: &kdl::KdlNode) -> Result<ServerConfig> {
     trace!("Parsing server configuration block");
 

--- a/crates/config/src/validate/unknown_keys.rs
+++ b/crates/config/src/validate/unknown_keys.rs
@@ -80,6 +80,22 @@ const CLOSED_BLOCKS: &[ClosedBlock] = &[
             "exclusion",
         ],
     },
+    // `route` and `system` both keep their key list beside their parser, so
+    // that adding a setting and forgetting the list is visible at the point of
+    // the change rather than here.
+    ClosedBlock {
+        name: "route",
+        keys: crate::kdl::routes::RECOGNIZED_ROUTE_CHILDREN,
+    },
+    ClosedBlock {
+        name: "system",
+        keys: crate::kdl::server::RECOGNIZED_SYSTEM_KEYS,
+    },
+    ClosedBlock {
+        // Deprecated spelling of `system`, parsed by the same function.
+        name: "server",
+        keys: crate::kdl::server::RECOGNIZED_SYSTEM_KEYS,
+    },
     ClosedBlock {
         name: "policies",
         keys: &[
@@ -303,6 +319,94 @@ mod tests {
     /// key this check does not know, operators would get a warning about
     /// perfectly valid configuration — so that failure belongs here, loudly,
     /// rather than in someone's terminal.
+    /// `workers` shipped in two configs and was read by nothing, so both ran on
+    /// the default worker count while the file said 4 and 1.
+    ///
+    /// No suggestion is offered here, and that is worth recording rather than
+    /// asserting away: `workers` is not a typo of `worker-threads`, it is a
+    /// different, shorter name for the same idea, and it is too far away for
+    /// the edit-distance heuristic to reach. The warning still names the key
+    /// and says it is ignored, which is the part that matters.
+    #[test]
+    fn the_workers_key_that_shipped_in_two_configs_is_reported() {
+        let kdl = r#"
+            system {
+                workers 4
+                daemon #false
+            }
+        "#;
+        let warnings = warnings_for(kdl);
+        assert_eq!(warnings.len(), 1, "got: {warnings:?}");
+        assert!(warnings[0].contains("workers"));
+        assert!(warnings[0].contains("is being ignored"));
+    }
+
+    #[test]
+    fn a_valid_system_block_produces_no_warnings() {
+        let kdl = r#"
+            system {
+                worker-threads 4
+                max-connections 10000
+                graceful-shutdown-timeout-secs 30
+                daemon #false
+                pid-file "/var/run/zentinel.pid"
+                user "zentinel"
+                group "zentinel"
+                working-directory "/var/lib/zentinel"
+                trace-id-format "uuid"
+                auto-reload #false
+                route-cache-size 1024
+            }
+        "#;
+        assert!(warnings_for(kdl).is_empty(), "{:?}", warnings_for(kdl));
+    }
+
+    /// `server` is the deprecated spelling and is parsed by the same function,
+    /// so it has to be checked against the same keys.
+    #[test]
+    fn the_deprecated_server_block_is_checked_too() {
+        let kdl = r#"
+            server {
+                worker_threads 4
+            }
+        "#;
+        let warnings = warnings_for(kdl);
+        assert_eq!(warnings.len(), 1, "got: {warnings:?}");
+        assert!(warnings[0].contains("worker_threads"));
+    }
+
+    #[test]
+    fn an_unknown_directive_in_a_route_is_reported() {
+        let kdl = r#"
+            routes {
+                route "api" {
+                    path_prefix "/api"
+                    upstream "backend"
+                }
+            }
+        "#;
+        let warnings = warnings_for(kdl);
+        assert_eq!(warnings.len(), 1, "got: {warnings:?}");
+        assert!(warnings[0].contains("path_prefix"));
+    }
+
+    #[test]
+    fn a_valid_route_produces_no_warnings() {
+        let kdl = r#"
+            routes {
+                route "api" {
+                    matches {
+                        path-prefix "/api"
+                    }
+                    upstream "backend"
+                    priority 10
+                    waf-enabled #true
+                }
+            }
+        "#;
+        assert!(warnings_for(kdl).is_empty(), "{:?}", warnings_for(kdl));
+    }
+
     #[test]
     fn shipped_configs_use_only_known_keys() {
         let root = concat!(env!("CARGO_MANIFEST_DIR"), "/../..");

--- a/tests/test-inline-openapi.kdl
+++ b/tests/test-inline-openapi.kdl
@@ -4,7 +4,7 @@
 // with schema validation for user creation endpoint.
 
 system {
-    workers 1
+    worker-threads 1
     daemon #false
 }
 


### PR DESCRIPTION
The unknown-key lint shipped in 0.6.27 covers four blocks. #365's own
reproduction table also names `route` and `system`, which still accept and
discard anything — its module doc says "*Part of* #365" for that reason.

Extending it to those two immediately surfaced **two live instances of the
defect the lint exists to catch**.

## `workers` — two configs running on the default worker count

`config/examples/api-schema-validation.kdl` and `tests/test-inline-openapi.kdl`
both set `workers`. Nothing reads it; the parser reads `worker-threads`.

Probed rather than grepped, against a non-default value:

```
workers 4        -> worker_threads = 0   (the default)
worker-threads 4 -> worker_threads = 4
```

## `circuit-breaker` in route blocks — 8 places, 6 configs

Including the flagship `config/zentinel.kdl`. Circuit breaking is parsed for
**upstreams** (`upstreams.rs:137`) and **agents** (`kdl/mod.rs:528`);
`RouteConfig` has no such field, so every one of these did nothing.

Route's existing `tracing::warn!` for unrecognized children *already fired for
these on every startup with the shipped default config* — the symptom was
visible and went unread, which is a decent argument for surfacing it through
`zentinel lint` instead.

Removed from routes. The two genuine agent-level blocks (`zentinel.kdl:307`,
`mixed-services.kdl:44`) and the upstream-level ones are untouched — each site
was checked for its enclosing block rather than matched by name.

> Per-route circuit breaking may well be worth having. This PR does not add it;
> it stops six configs from claiming it exists.

## Shape of the fix

Both key lists live beside the parser that defines them, so adding a setting and
forgetting to list it is visible at the point of the change rather than here:

- `RECOGNIZED_ROUTE_CHILDREN` already existed for route's startup warning, and
  is now also the lint's source of truth — one list, two consumers, instead of
  a copy that drifts.
- `RECOGNIZED_SYSTEM_KEYS` is new, next to `parse_server_config`.
- `server`, the deprecated spelling of `system`, is parsed by the same function
  and so is checked against the same keys.

## Tests

Six new, and one worth calling out: `the_workers_key_that_shipped_in_two_configs_is_reported`
asserts the warning but deliberately **does not** assert a suggestion. `workers`
is not a typo of `worker-threads`, it is a shorter name for the same idea, and
it is too far away for the edit-distance heuristic. Recording that honestly
beats asserting a suggestion that does not fire.

`shipped_configs_use_only_known_keys` is what caught both bugs above.

Note for reviewers: these tests only compile with `--features validation`, so
`cargo test -p zentinel-config` alone runs none of them. Workspace builds unify
the feature via `zentinel-proxy`, so CI does run them.

332 lib tests + 3 `shipped_examples` tests pass; clippy clean.