### PR TITLE
fix(config)!: remove dead buffer-requests/buffer-responses (#366)

### DIFF
--- a/config/examples/ai-guardrails.kdl
+++ b/config/examples/ai-guardrails.kdl
@@ -155,8 +155,6 @@ routes {
         policies {
             timeout-secs 300
             max-body-size "1MB"
-            buffer-requests #true   // Required for request inspection
-            buffer-responses #true  // Required for response inspection
             failure-mode "closed"
         }
     }
@@ -200,8 +198,6 @@ routes {
         policies {
             timeout-secs 300
             max-body-size "1MB"
-            buffer-requests #true
-            buffer-responses #true
         }
     }
 
@@ -249,8 +245,6 @@ routes {
         policies {
             timeout-secs 300
             max-body-size "512KB"  // Smaller limit for security
-            buffer-requests #true
-            buffer-responses #true
             failure-mode "closed"
         }
     }
@@ -286,7 +280,6 @@ routes {
         policies {
             timeout-secs 60
             max-body-size "10MB"  // Large batches
-            buffer-requests #true
         }
     }
 

--- a/config/examples/inference-routing.kdl
+++ b/config/examples/inference-routing.kdl
@@ -163,7 +163,6 @@ routes {
             timeout-secs 300
             max-body-size "1MB"
             failure-mode "closed"
-            buffer-requests #true  // Required for token counting
         }
     }
 

--- a/config/examples/namespaces.kdl
+++ b/config/examples/namespaces.kdl
@@ -335,7 +335,6 @@ namespace "storefront" {
                 policies {
                     timeout-secs 60
                     failure-mode "closed"
-                    buffer-requests #true
                 }
             }
         }

--- a/config/examples/shadow-traffic.kdl
+++ b/config/examples/shadow-traffic.kdl
@@ -306,7 +306,6 @@ routes {
         policies {
             timeout-secs 60
             max-body-size "50MB"
-            buffer-requests #true
         }
     }
 

--- a/config/zentinel.kdl
+++ b/config/zentinel.kdl
@@ -192,8 +192,6 @@ routes {
 
         policies {
             timeout-secs 3600  // 1 hour for WebSocket
-            buffer-requests #false
-            buffer-responses #false
         }
     }
 

--- a/crates/config/docs/schema.md
+++ b/crates/config/docs/schema.md
@@ -223,8 +223,6 @@ Request routing configuration.
 | `max-body-size` | `string` | - | Body size limit (e.g., `"10MB"`) |
 | `rate-limit` | `RateLimitPolicy` | - | Rate limit policy |
 | `failure-mode` | `string` | `"closed"` | Failure mode: `open` or `closed` |
-| `buffer-requests` | `bool` | `false` | Buffer request body |
-| `buffer-responses` | `bool` | `false` | Buffer response body |
 | `cache` | `RouteCacheConfig` | - | HTTP caching config (see [Cache](#routecacheconfig)) |
 
 ### RouteCacheConfig

--- a/crates/config/src/kdl/routes.rs
+++ b/crates/config/src/kdl/routes.rs
@@ -163,11 +163,6 @@ pub fn parse_routes(node: &kdl::KdlNode) -> Result<Vec<RouteConfig>> {
                     max_body_size: settings.max_body_size,
                     rate_limit: settings.rate_limit,
                     failure_mode: settings.failure_mode,
-                    // Not parsed: nothing in the proxy reads these, and there
-                    // is no KDL key for them. See #366 — they want either
-                    // implementing or removing, not wiring to a dead end.
-                    buffer_requests: false,
-                    buffer_responses: false,
                 };
 
                 routes.push(RouteConfig {

--- a/crates/config/src/routes.rs
+++ b/crates/config/src/routes.rs
@@ -212,14 +212,11 @@ pub struct RoutePolicies {
     #[serde(default = "default_failure_mode")]
     pub failure_mode: FailureMode,
 
-    /// Enable request buffering
-    #[serde(default)]
-    pub buffer_requests: bool,
-
-    /// Enable response buffering
-    #[serde(default)]
-    pub buffer_responses: bool,
-
+    // `buffer_requests` and `buffer_responses` were removed here (#366). They
+    // had no KDL key, were read by nothing in the proxy, and could therefore
+    // never be true for any configuration a person could write — while their
+    // names promised control over body buffering. Agents that inspect bodies
+    // do not need a flag; the proxy already buffers what it forwards.
     /// HTTP caching configuration
     #[serde(default)]
     pub cache: Option<RouteCacheConfig>,

--- a/crates/config/src/validate/lint.rs
+++ b/crates/config/src/validate/lint.rs
@@ -183,14 +183,13 @@ fn check_resource_bounds(config: &Config, result: &mut ValidationResult) {
     for route in &config.routes {
         let policies = &route.policies;
 
-        // A rule for "buffers bodies but sets no max-body-size" was removed
-        // here. It could never fire: `buffer_requests` and `buffer_responses`
-        // have no KDL key and are read by nothing in the proxy, so they are
-        // always false for any config a person can write. Its tests passed
-        // only because they set the fields directly. A linter reporting
-        // coverage it does not have is worse than one check short — restore
-        // this once #366 decides whether those fields get implemented or
-        // removed.
+        // A rule for "buffers bodies but sets no max-body-size" used to live
+        // here, keyed on `buffer_requests` / `buffer_responses`. It could never
+        // fire — those fields had no KDL key and were read by nothing, so they
+        // were always false for any config a person could write, and the rule's
+        // tests passed only because they set the fields directly. #366 removed
+        // the fields; if body buffering is ever implemented as real
+        // configuration, this rule is worth restoring with it.
         if let Some(max_body) = policies.max_body_size {
             if max_body.0 > GENEROUS_BODY_SIZE {
                 result.add_warning(ValidationWarning::new(format!(
@@ -602,26 +601,26 @@ mod resource_bound_tests {
         assert!(mentions(&config, "can never be reached"));
     }
 
-    /// Guards the removal above: `buffer_requests` cannot be set from any
-    /// config, so a rule keyed on it can never fire for a real user. The two
-    /// tests that used to live here set the field directly and so passed
-    /// while the rule was dead. If #366 wires these fields up, this test
-    /// starts failing and the rule can come back with it.
+    /// #366 removed `buffer_requests` / `buffer_responses`, so the guard test
+    /// that asserted they stayed unreachable no longer has fields to assert on.
+    /// What replaces it is the unknown-key check: with the keys gone from
+    /// `CLOSED_BLOCKS`, writing one in a `policies` block is now reported
+    /// rather than silently accepted.
     #[test]
-    fn buffering_flags_are_still_unreachable_from_config() {
-        let kdl = "system {\n  workers 2\n}\n\
-                   listeners {\n  listener \"http\" {\n    address \"127.0.0.1:8080\"\n  }\n}\n\
-                   upstreams {\n  upstream \"b\" {\n    target \"127.0.0.1:9000\"\n  }\n}\n\
-                   routes {\n  route \"r\" {\n    matches {\n      path-prefix \"/\"\n    }\n\
-                   \x20   upstream \"b\"\n    policies {\n      buffer-requests #true\n\
-                   \x20     buffer-responses #true\n    }\n  }\n}\n";
-        let config = Config::from_kdl(kdl).expect("config should parse");
-        let policies = &config.routes[0].policies;
+    fn buffering_keys_are_reported_rather_than_silently_accepted() {
+        let mut result = ValidationResult::new();
+        crate::validate::unknown_keys::check_unknown_keys(
+            "routes {\n  route \"r\" {\n    policies {\n      buffer-requests #true\n    }\n  }\n}\n",
+            &mut result,
+        );
 
         assert!(
-            !policies.buffer_requests && !policies.buffer_responses,
-            "buffering became settable from config — see #366, and restore the \
-             lint rule that was removed alongside these tests"
+            result
+                .warnings
+                .iter()
+                .any(|w| w.message.contains("buffer-requests")),
+            "expected 'buffer-requests' to be reported as an unknown key, got: {:?}",
+            result.warnings
         );
     }
 

--- a/crates/config/src/validate/unknown_keys.rs
+++ b/crates/config/src/validate/unknown_keys.rs
@@ -106,11 +106,9 @@ const CLOSED_BLOCKS: &[ClosedBlock] = &[
             "max-body-size",
             "failure-mode",
             "rate-limit",
-            // Parsed by nothing today, but named in configs and tracked in
-            // #366. Listing them keeps this check quiet about a known gap
-            // rather than reporting it as a typo.
-            "buffer-requests",
-            "buffer-responses",
+            // "buffer-requests" / "buffer-responses" were listed here to keep
+            // this check quiet about a known gap. #366 removed the fields, so
+            // they are now reported like any other key nothing reads.
         ],
     },
 ];

--- a/crates/config/src/validation.rs
+++ b/crates/config/src/validation.rs
@@ -2151,8 +2151,6 @@ mod tests {
                 max_body_size: None,
                 rate_limit: None,
                 failure_mode: FailureMode::Closed,
-                buffer_requests: false,
-                buffer_responses: false,
                 cache: None,
             },
             filters: vec![],

--- a/crates/sim/docs/api.md
+++ b/crates/sim/docs/api.md
@@ -275,8 +275,6 @@ pub struct AppliedPolicies {
     pub failure_mode: String,
     pub rate_limit: Option<RateLimitInfo>,
     pub cache: Option<CacheInfo>,
-    pub buffer_requests: bool,
-    pub buffer_responses: bool,
 }
 ```
 

--- a/crates/sim/src/lib.rs
+++ b/crates/sim/src/lib.rs
@@ -215,8 +215,6 @@ fn extract_policies(route: &MatchedRoute, config: &Config) -> AppliedPolicies {
                 enabled: c.enabled,
                 ttl_secs: c.default_ttl_secs,
             }),
-            buffer_requests: rc.policies.buffer_requests,
-            buffer_responses: rc.policies.buffer_responses,
         }
     } else {
         AppliedPolicies::default()

--- a/crates/sim/src/types.rs
+++ b/crates/sim/src/types.rs
@@ -200,12 +200,9 @@ pub struct AppliedPolicies {
 
     /// Cache configuration
     pub cache: Option<CacheInfo>,
-
-    /// Whether request buffering is enabled
-    pub buffer_requests: bool,
-
-    /// Whether response buffering is enabled
-    pub buffer_responses: bool,
+    // Buffering flags were reported here until #366. They mirrored
+    // RoutePolicies fields that no configuration could set, so the simulator
+    // was always reporting `false` regardless of what the config said.
 }
 
 /// Rate limit information

--- a/tests/test-inline-openapi.kdl
+++ b/tests/test-inline-openapi.kdl
@@ -43,7 +43,6 @@ routes {
         }
 
         policies {
-            buffer-requests #true
             max-body-size "1MB"
             timeout-secs 30
         }


### PR DESCRIPTION
Closes #366, taking option 1 from the issue.

`RoutePolicies` exposed `buffer_requests` and `buffer_responses` as public
fields. No KDL key set them, nothing in the proxy read them, and they could
therefore never be anything but `false` for any configuration a person could
write — while their names promised control over body buffering.

## Thirteen configs set them anyway

Across seven shipped files, including `config/zentinel.kdl`. The worst of them
is `ai-guardrails.kdl`:

```kdl
buffer-requests #true   // Required for request inspection
buffer-responses #true  // Required for response inspection
```

Neither claim is true. Agents that inspect bodies never needed a flag, and
`max-body-size` — already set on that route — is the real bound. A user reading
that example would reasonably conclude inspection depends on a setting that does
nothing.

## What changed

| | |
|---|---|
| `RoutePolicies` | both fields removed |
| 7 shipped configs | 13 lines removed |
| `crates/sim` | mirrored fields removed |
| `schema.md`, `sim/docs/api.md` | rows removed |
| `lint.rs` | guard test replaced |

The #128 lint rule keyed on these fields had already been removed as unreachable,
leaving a guard test asserting the fields stayed unsettable. With the fields gone
that test has nothing to assert, so it is replaced by one checking the behaviour
that now covers the gap: with the keys dropped from `CLOSED_BLOCKS`,
`buffer-requests` in a `policies` block is *reported* rather than silently
accepted. #386 is what makes that possible.

## BREAKING

Removes two public fields from `zentinel_config::RoutePolicies`, and JSON/TOML
configs setting them will no longer deserialize. **No behaviour changes** —
neither field had any effect. Precedent for a schema break in a patch: 26.08_2.

## One thing I could not verify

`crates/sim` mirrored both fields and is updated here, but I could not
compile-check it: **it does not build on `main`** for unrelated reasons — it
references `RouteConfig::circuit_breaker`, which does not exist. It is excluded
from the workspace, so no CI job compiles it. Filed as #387.

The edits here are mechanically straightforward (two field reads and two field
declarations), but they are unverified, and I would rather say so than imply a
green build I did not get.

332 lib tests + 3 `shipped_examples` pass; `cargo check --workspace` clean;
clippy clean.