### PR TITLE
fix(sim): make zentinel-sim compile, and give excluded crates CI (#387)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,3 +166,54 @@ jobs:
       # `binary-uds` shipped hanging every agent call but one (#359, #360).
       - name: Run unit tests
         run: cargo test --workspace --lib --all-features
+
+  # Crates in the workspace `exclude` list are built by nothing above, so they
+  # can break without any job going red. zentinel-sim did exactly that: it
+  # stopped compiling and stayed that way, because `cargo check --workspace`
+  # never looks at it (#387).
+  #
+  # They are excluded for a real reason — sim and playground-wasm depend on
+  # zentinel-config with `default-features = false` to stay WASM-compatible,
+  # and workspace feature unification would pull `runtime` back in via
+  # zentinel-proxy. So they need their own build rather than membership.
+  #
+  # Covers the two that build on a native target today. `crates/config-inspect`
+  # and `crates/playground-wasm` are NOT covered: both still require
+  # zentinel-config/common `^0.5.4` while the workspace is well past that, so
+  # they cannot resolve dependencies at all. Add them here once those pins are
+  # fixed.
+  excluded-crates:
+    name: Excluded Crates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-excluded
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      # The root `fmt` job runs `cargo fmt --all` at the workspace, which by
+      # definition does not reach an excluded crate. sim had drifted across
+      # five files as a result.
+      - name: Check formatting (excluded crates)
+        run: |
+          cargo fmt --manifest-path crates/sim/Cargo.toml --check
+          cargo fmt --manifest-path agents/wasm-allowlist/Cargo.toml --check
+
+      - name: Test zentinel-sim
+        working-directory: crates/sim
+        run: cargo test --all-targets
+
+      - name: Check agents/wasm-allowlist
+        working-directory: agents/wasm-allowlist
+        run: cargo check --all-targets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,7 +1450,7 @@ dependencies = [
  "asn1-rs 0.6.2",
  "displaydoc",
  "nom 7.1.3",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "rusticata-macros",
 ]
@@ -1464,7 +1464,7 @@ dependencies = [
  "asn1-rs 0.7.1",
  "displaydoc",
  "nom 7.1.3",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "rusticata-macros",
 ]
@@ -1909,7 +1909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33fee0259ffdc3d7bd64438b6b08437884d4df5700f9cb8a23b079c3958ae578"
 dependencies = [
  "num",
- "num-bigint",
+ "num-bigint 0.4.8",
 ]
 
 [[package]]
@@ -3703,7 +3703,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -3778,7 +3778,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
 ]

--- a/agents/wasm-allowlist/Cargo.lock
+++ b/agents/wasm-allowlist/Cargo.lock
@@ -33,14 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zentinel-wasm-allowlist"
-version = "0.2.5"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +91,14 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "zentinel-wasm-allowlist"
+version = "0.4.1"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "zmij"

--- a/agents/wasm-allowlist/src/lib.rs
+++ b/agents/wasm-allowlist/src/lib.rs
@@ -37,9 +37,15 @@ pub struct AgentConfig {
     pub message: String,
 }
 
-fn default_mode() -> String { "denylist".to_string() }
-fn default_status() -> u16 { 403 }
-fn default_message() -> String { "Access Denied".to_string() }
+fn default_mode() -> String {
+    "denylist".to_string()
+}
+fn default_status() -> u16 {
+    403
+}
+fn default_message() -> String {
+    "Access Denied".to_string()
+}
 
 impl Default for AgentConfig {
     fn default() -> Self {
@@ -57,10 +63,7 @@ impl Default for AgentConfig {
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum Decision {
     Allow,
-    Block {
-        status: u16,
-        body: Option<String>,
-    },
+    Block { status: u16, body: Option<String> },
 }
 
 /// Agent response.

--- a/crates/sim/Cargo.lock
+++ b/crates/sim/Cargo.lock
@@ -468,13 +468,14 @@ dependencies = [
 
 [[package]]
 name = "kdl"
-version = "6.5.0"
+version = "6.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a29e7b50079ff44549f68c0becb1c73d7f6de2a4ea952da77966daf3d4761e"
+checksum = "082ddf81b2acd76fe04412655d17befedfff1837db772f8e74c38050d25ed670"
 dependencies = [
  "miette",
- "num",
- "winnow 0.6.24",
+ "num-traits",
+ "serde",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -553,70 +554,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
-]
-
-[[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -1200,12 +1137,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "validator"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
+checksum = "c3d68c6633c483df6780cc5277a417c7c2d1bceee2649d06c8ab6b0fd2dd3c81"
 dependencies = [
  "idna",
- "once_cell",
  "regex",
  "serde",
  "serde_derive",
@@ -1508,9 +1444,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -1564,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.8"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1578,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.8"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/crates/sim/src/agents.rs
+++ b/crates/sim/src/agents.rs
@@ -390,7 +390,10 @@ pub fn simulate_with_agents(
                 || mock.audit.confidence.is_some()
                 || !mock.audit.reason_codes.is_empty()
             {
-                audit_trail.push(AuditEntry::from_audit_info(&mock.audit, &agent_hook.agent_id));
+                audit_trail.push(AuditEntry::from_audit_info(
+                    &mock.audit,
+                    &agent_hook.agent_id,
+                ));
             }
 
             // Check if this decision should short-circuit
@@ -640,8 +643,8 @@ mod tests {
 
     #[test]
     fn test_header_mutation_remove() {
-        let request = SimulatedRequest::new("GET", "example.com", "/api")
-            .with_header("X-Remove-Me", "value");
+        let request =
+            SimulatedRequest::new("GET", "example.com", "/api").with_header("X-Remove-Me", "value");
         let mut transformed = TransformedRequest::from(&request);
 
         let mutations = vec![HeaderMutation::Remove {

--- a/crates/sim/src/lib.rs
+++ b/crates/sim/src/lib.rs
@@ -25,22 +25,22 @@ mod trace;
 mod types;
 mod upstream;
 
-pub use matcher::{RouteMatcher, RouteMatchError};
-pub use trace::{MatchStep, MatchStepResult, ConditionDetail};
-pub use types::{
-    AgentHook, AppliedPolicies, MatchedRoute, RouteDecision, SimulatedRequest,
-    UpstreamSelection, ValidationError, ValidationResult, ValidationSeverity, Warning,
-};
-pub use upstream::{simulate_upstream_selection, LoadBalancerSimulation};
-pub use stateful::{
-    simulate_sequence, CacheSnapshot, CircuitBreakerSnapshot, FinalState, RequestResult,
-    SimulationSummary, StatefulSimulationResult, StateTransition, TimestampedRequest,
-    TokenBucketSnapshot,
-};
 pub use agents::{
     simulate_with_agents, AgentChainStep, AgentDecision, AgentSimulationResult, AuditEntry,
     AuditInfo, BlockResponse, ChallengeInfo, HeaderMutation, MockAgentResponse, TransformedRequest,
 };
+pub use matcher::{RouteMatchError, RouteMatcher};
+pub use stateful::{
+    simulate_sequence, CacheSnapshot, CircuitBreakerSnapshot, FinalState, RequestResult,
+    SimulationSummary, StateTransition, StatefulSimulationResult, TimestampedRequest,
+    TokenBucketSnapshot,
+};
+pub use trace::{ConditionDetail, MatchStep, MatchStepResult};
+pub use types::{
+    AgentHook, AppliedPolicies, MatchedRoute, RouteDecision, SimulatedRequest, UpstreamSelection,
+    ValidationError, ValidationResult, ValidationSeverity, Warning,
+};
+pub use upstream::{simulate_upstream_selection, LoadBalancerSimulation};
 
 use zentinel_config::Config;
 
@@ -206,11 +206,15 @@ fn extract_policies(route: &MatchedRoute, config: &Config) -> AppliedPolicies {
             timeout_secs: rc.policies.timeout_secs,
             max_body_size: rc.policies.max_body_size.map(|b| b.to_string()),
             failure_mode: format!("{:?}", rc.policies.failure_mode).to_lowercase(),
-            rate_limit: rc.policies.rate_limit.as_ref().map(|rl| types::RateLimitInfo {
-                requests_per_second: rl.requests_per_second,
-                burst: rl.burst,
-                key: format!("{:?}", rl.key),
-            }),
+            rate_limit: rc
+                .policies
+                .rate_limit
+                .as_ref()
+                .map(|rl| types::RateLimitInfo {
+                    requests_per_second: rl.requests_per_second,
+                    burst: rl.burst,
+                    key: format!("{:?}", rl.key),
+                }),
             cache: rc.policies.cache.as_ref().map(|c| types::CacheInfo {
                 enabled: c.enabled,
                 ttl_secs: c.default_ttl_secs,
@@ -241,10 +245,11 @@ fn extract_agent_hooks(route: &MatchedRoute, config: &Config) -> Vec<AgentHook> 
                     hooks.push(AgentHook {
                         agent_id: agent_filter.agent.clone(),
                         hook: "on_request_headers".to_string(),
-                        timeout_ms: agent_filter.timeout_ms.unwrap_or(
-                            agent_config.map(|a| a.timeout_ms).unwrap_or(1000)
-                        ),
-                        failure_mode: agent_filter.failure_mode
+                        timeout_ms: agent_filter
+                            .timeout_ms
+                            .unwrap_or(agent_config.map(|a| a.timeout_ms).unwrap_or(1000)),
+                        failure_mode: agent_filter
+                            .failure_mode
                             .map(|fm| format!("{:?}", fm).to_lowercase())
                             .unwrap_or_else(|| "closed".to_string()),
                         body_inspection: None,
@@ -260,7 +265,7 @@ fn extract_agent_hooks(route: &MatchedRoute, config: &Config) -> Vec<AgentHook> 
                 hooks.push(AgentHook {
                     agent_id: "waf".to_string(),
                     hook: "on_request_headers".to_string(),
-                    timeout_ms: 500, // Default WAF timeout
+                    timeout_ms: 500,                    // Default WAF timeout
                     failure_mode: "closed".to_string(), // WAF should fail closed by default
                     body_inspection: None,
                 });
@@ -298,9 +303,7 @@ fn generate_warnings(
     if let Some(rc) = route_config {
         // Shadow config on POST without body buffering
         if let Some(ref shadow) = rc.shadow {
-            if !shadow.buffer_body
-                && ["POST", "PUT", "PATCH"].contains(&request.method.as_str())
-            {
+            if !shadow.buffer_body && ["POST", "PUT", "PATCH"].contains(&request.method.as_str()) {
                 warnings.push(Warning {
                     code: "SHADOW_NO_BODY_BUFFER".to_string(),
                     message: format!(

--- a/crates/sim/src/matcher.rs
+++ b/crates/sim/src/matcher.rs
@@ -6,7 +6,6 @@
 
 use regex::Regex;
 
-use zentinel_common::types::Priority;
 use zentinel_config::{MatchCondition, RouteConfig};
 
 use crate::trace::{ConditionDetail, MatchStep};
@@ -206,16 +205,24 @@ impl CompiledRoute {
         let mut score = 0;
         for matcher in matchers {
             score += match matcher {
-                CompiledMatcher::Path(_) => 1000,     // Exact path most specific
+                CompiledMatcher::Path(_) => 1000, // Exact path most specific
                 CompiledMatcher::PathRegex { .. } => 500,
                 CompiledMatcher::PathPrefix(_) => 100,
                 CompiledMatcher::Host(_) => 50,
                 CompiledMatcher::Header { value, .. } => {
-                    if value.is_some() { 30 } else { 20 }
+                    if value.is_some() {
+                        30
+                    } else {
+                        20
+                    }
                 }
                 CompiledMatcher::Method(_) => 10,
                 CompiledMatcher::QueryParam { value, .. } => {
-                    if value.is_some() { 25 } else { 15 }
+                    if value.is_some() {
+                        25
+                    } else {
+                        15
+                    }
                 }
             };
         }
@@ -228,11 +235,7 @@ impl CompiledRoute {
     }
 
     /// Evaluate this route and return match result with condition details
-    fn evaluate(
-        &self,
-        request: &SimulatedRequest,
-        path: &str,
-    ) -> (bool, Vec<ConditionDetail>) {
+    fn evaluate(&self, request: &SimulatedRequest, path: &str) -> (bool, Vec<ConditionDetail>) {
         let mut all_matched = true;
         let mut conditions = Vec::new();
 
@@ -414,6 +417,8 @@ impl HostMatcher {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Only the tests construct routes, so this is not needed by the crate proper.
+    use zentinel_common::types::Priority;
     use zentinel_config::{MatchCondition, RouteConfig, ServiceType};
 
     fn create_route(id: &str, matches: Vec<MatchCondition>) -> RouteConfig {
@@ -427,7 +432,6 @@ mod tests {
             filters: vec![],
             builtin_handler: None,
             waf_enabled: false,
-            circuit_breaker: None,
             retry_policy: None,
             static_files: None,
             api_schema: None,
@@ -446,7 +450,10 @@ mod tests {
     fn test_path_prefix_matching() {
         let routes = vec![
             create_route("api", vec![MatchCondition::PathPrefix("/api".to_string())]),
-            create_route("static", vec![MatchCondition::PathPrefix("/static".to_string())]),
+            create_route(
+                "static",
+                vec![MatchCondition::PathPrefix("/static".to_string())],
+            ),
         ];
 
         let matcher = RouteMatcher::new(&routes, None).unwrap();
@@ -461,8 +468,14 @@ mod tests {
     #[test]
     fn test_exact_path_matching() {
         let routes = vec![
-            create_route("exact", vec![MatchCondition::Path("/api/v1/users".to_string())]),
-            create_route("prefix", vec![MatchCondition::PathPrefix("/api".to_string())]),
+            create_route(
+                "exact",
+                vec![MatchCondition::Path("/api/v1/users".to_string())],
+            ),
+            create_route(
+                "prefix",
+                vec![MatchCondition::PathPrefix("/api".to_string())],
+            ),
         ];
 
         let matcher = RouteMatcher::new(&routes, None).unwrap();
@@ -530,15 +543,18 @@ mod tests {
         let without_auth = SimulatedRequest::new("GET", "example.com", "/api");
         assert!(matcher.match_request(&without_auth).is_none());
 
-        let with_auth =
-            SimulatedRequest::new("GET", "example.com", "/api").with_header("Authorization", "Bearer token");
+        let with_auth = SimulatedRequest::new("GET", "example.com", "/api")
+            .with_header("Authorization", "Bearer token");
         assert!(matcher.match_request(&with_auth).is_some());
     }
 
     #[test]
     fn test_match_trace() {
         let routes = vec![
-            create_route("static", vec![MatchCondition::PathPrefix("/static".to_string())]),
+            create_route(
+                "static",
+                vec![MatchCondition::PathPrefix("/static".to_string())],
+            ),
             create_route("api", vec![MatchCondition::PathPrefix("/api".to_string())]),
         ];
 
@@ -586,10 +602,12 @@ mod tests {
 
     #[test]
     fn test_priority_ordering() {
-        let mut low_priority = create_route("low", vec![MatchCondition::PathPrefix("/".to_string())]);
+        let mut low_priority =
+            create_route("low", vec![MatchCondition::PathPrefix("/".to_string())]);
         low_priority.priority = Priority::LOW;
 
-        let mut high_priority = create_route("high", vec![MatchCondition::PathPrefix("/".to_string())]);
+        let mut high_priority =
+            create_route("high", vec![MatchCondition::PathPrefix("/".to_string())]);
         high_priority.priority = Priority::HIGH;
 
         // Add in wrong order to verify sorting

--- a/crates/sim/src/stateful.rs
+++ b/crates/sim/src/stateful.rs
@@ -565,14 +565,18 @@ impl CircuitBreakerState {
         Self::default()
     }
 
-    /// Initialize circuit breakers from config
+    /// Initialize circuit breakers from config.
+    ///
+    /// Breakers are per **upstream**, which is where the proxy actually has
+    /// them. This used to read `route.circuit_breaker` — a field `RouteConfig`
+    /// has never had, so the simulator did not compile (#387) and, before that,
+    /// modelled a feature the proxy does not implement. The module header has
+    /// said "per upstream" throughout.
     fn init_from_config(&mut self, config: &Config) {
-        // Per-route circuit breakers
-        for route in &config.routes {
-            if let Some(ref cb) = route.circuit_breaker {
-                let key = format!("route:{}", route.id);
+        for (name, upstream) in &config.upstreams {
+            if let Some(ref cb) = upstream.circuit_breaker {
                 self.breakers.insert(
-                    key,
+                    Self::key(name),
                     CircuitBreaker::new(
                         cb.failure_threshold,
                         cb.success_threshold,
@@ -583,14 +587,19 @@ impl CircuitBreakerState {
         }
     }
 
-    /// Check circuit breaker for a route
+    /// Map an upstream name to its breaker key.
+    fn key(upstream: &str) -> String {
+        format!("upstream:{upstream}")
+    }
+
+    /// Check the circuit breaker guarding an upstream.
     fn check(
         &mut self,
-        route_id: &str,
+        upstream: &str,
         timestamp: f64,
         request_index: usize,
     ) -> (bool, Option<StateTransition>) {
-        let key = format!("route:{}", route_id);
+        let key = Self::key(upstream);
 
         if let Some(cb) = self.breakers.get_mut(&key) {
             let before = cb.snapshot();
@@ -797,8 +806,7 @@ pub fn simulate_sequence(
         let route = matched_route.as_ref().unwrap();
 
         // 2. Check rate limit
-        let (allowed, rl_transition) =
-            rate_limits.check_and_consume(&route.id, timestamp, idx);
+        let (allowed, rl_transition) = rate_limits.check_and_consume(&route.id, timestamp, idx);
 
         if let Some(t) = rl_transition {
             transitions.push(t);
@@ -831,17 +839,21 @@ pub fn simulate_sequence(
             cache_misses += 1;
         }
 
-        // 4. Check circuit breaker (only if not cache hit)
+        // 4. Check the circuit breaker guarding this route's upstream (only if
+        //    not a cache hit). A route with no upstream — static files, a
+        //    builtin handler — reaches no upstream and so cannot be blocked by
+        //    one.
         let mut circuit_open = false;
         if !is_cache_hit {
-            let (blocked, cb_transition) =
-                circuit_breakers.check(&route.id, timestamp, idx);
-            if let Some(t) = cb_transition {
-                transitions.push(t);
-            }
-            if blocked {
-                circuit_open = true;
-                circuit_blocked_count += 1;
+            if let Some(ref upstream_id) = route.upstream {
+                let (blocked, cb_transition) = circuit_breakers.check(upstream_id, timestamp, idx);
+                if let Some(t) = cb_transition {
+                    transitions.push(t);
+                }
+                if blocked {
+                    circuit_open = true;
+                    circuit_blocked_count += 1;
+                }
             }
         }
 
@@ -1000,6 +1012,64 @@ mod tests {
         // Success in half-open should close
         cb.record_success();
         assert_eq!(cb.state, CircuitState::Closed);
+    }
+
+    /// The state-machine test above builds a `CircuitBreaker` directly, so it
+    /// passed throughout the period when `init_from_config` read a `RouteConfig`
+    /// field that did not exist (#387). This one goes through a real config, so
+    /// it fails if the wiring breaks again.
+    #[test]
+    fn breakers_are_built_from_upstreams_not_routes() {
+        let kdl = r#"
+            system {
+                worker-threads 2
+            }
+            listeners {
+                listener "http" {
+                    address "127.0.0.1:8080"
+                }
+            }
+            upstreams {
+                upstream "guarded" {
+                    target "127.0.0.1:9000"
+                    circuit-breaker {
+                        failure-threshold 2
+                        success-threshold 1
+                        timeout-seconds 10
+                    }
+                }
+                upstream "unguarded" {
+                    target "127.0.0.1:9001"
+                }
+            }
+            routes {
+                route "r" {
+                    matches {
+                        path-prefix "/"
+                    }
+                    upstream "guarded"
+                }
+            }
+        "#;
+        let config = Config::from_kdl(kdl).expect("config should parse");
+
+        let mut state = CircuitBreakerState::new();
+        state.init_from_config(&config);
+
+        let snapshot = state.snapshot();
+        assert!(
+            snapshot.contains_key("upstream:guarded"),
+            "expected a breaker keyed by upstream name, got: {:?}",
+            snapshot.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !snapshot.contains_key("upstream:unguarded"),
+            "an upstream without a circuit-breaker block should get no breaker"
+        );
+        assert!(
+            !snapshot.keys().any(|k| k.starts_with("route:")),
+            "breakers are per upstream; the proxy has no per-route circuit breaker"
+        );
     }
 
     #[test]

--- a/crates/sim/src/trace.rs
+++ b/crates/sim/src/trace.rs
@@ -156,7 +156,10 @@ impl ConditionDetail {
             explanation: if matched {
                 Some(format!("Path '{}' matches regex '{}'", path, pattern))
             } else {
-                Some(format!("Path '{}' does not match regex '{}'", path, pattern))
+                Some(format!(
+                    "Path '{}' does not match regex '{}'",
+                    path, pattern
+                ))
             },
         }
     }
@@ -294,9 +297,7 @@ mod tests {
 
     #[test]
     fn test_match_step_no_match() {
-        let conditions = vec![
-            ConditionDetail::path_prefix("/api", "/other", false),
-        ];
+        let conditions = vec![ConditionDetail::path_prefix("/api", "/other", false)];
 
         let step = MatchStep::no_match("api-route".to_string(), conditions);
 

--- a/crates/sim/src/types.rs
+++ b/crates/sim/src/types.rs
@@ -67,7 +67,8 @@ impl SimulatedRequest {
 
     /// Add a query parameter
     pub fn with_query_param(mut self, name: &str, value: &str) -> Self {
-        self.query_params.insert(name.to_string(), value.to_string());
+        self.query_params
+            .insert(name.to_string(), value.to_string());
         self
     }
 
@@ -130,7 +131,12 @@ impl SimulatedRequest {
 
     /// Generate a cache key for this request (used internally)
     pub fn cache_key(&self) -> String {
-        format!("{}:{}:{}", self.method, self.host, self.path_without_query())
+        format!(
+            "{}:{}:{}",
+            self.method,
+            self.host,
+            self.path_without_query()
+        )
     }
 }
 

--- a/crates/sim/src/upstream.rs
+++ b/crates/sim/src/upstream.rs
@@ -3,9 +3,9 @@
 //! Simulates load balancer behavior to show which upstream target
 //! would be selected for a given request.
 
+use xxhash_rust::xxh3::xxh3_64;
 use zentinel_common::types::LoadBalancingAlgorithm;
 use zentinel_config::{Config, UpstreamConfig};
-use xxhash_rust::xxh3::xxh3_64;
 
 use crate::types::{SimulatedRequest, UpstreamSelection};
 
@@ -126,7 +126,10 @@ fn select_target(
             // Weighted selection based on weights
             let total_weight: u32 = targets.iter().map(|t| t.weight).sum();
             if total_weight == 0 {
-                return (0, "Weighted: all weights are zero, using first target".to_string());
+                return (
+                    0,
+                    "Weighted: all weights are zero, using first target".to_string(),
+                );
             }
 
             let hash = xxh3_64(request.cache_key().as_bytes());
@@ -325,7 +328,10 @@ fn select_target(
             // Weighted least connections combines weights with connection counts
             let total_weight: u32 = targets.iter().map(|t| t.weight).sum();
             if total_weight == 0 {
-                return (0, "Weighted least connections: all weights zero, using first target".to_string());
+                return (
+                    0,
+                    "Weighted least connections: all weights zero, using first target".to_string(),
+                );
             }
 
             let hash = xxh3_64(request.cache_key().as_bytes());
@@ -347,7 +353,10 @@ fn select_target(
                 }
             }
 
-            (0, "Weighted least connections: fallback to first target".to_string())
+            (
+                0,
+                "Weighted least connections: fallback to first target".to_string(),
+            )
         }
 
         LoadBalancingAlgorithm::Sticky => {
@@ -408,6 +417,7 @@ mod tests {
             timeouts: Default::default(),
             tls: None,
             http_version: Default::default(),
+            circuit_breaker: None,
         }
     }
 


### PR DESCRIPTION
Closes #387.

`zentinel-sim` did not build on `main`, and had not for some time. It sits in the
workspace `exclude` list, so no CI job compiled it and nothing ever went red.

## The cause was not a stale reference

`CircuitBreakerState::init_from_config` built its breaker map from
`route.circuit_breaker`, keyed `route:{id}`, and `check()` looked up the same key.
**`RouteConfig` has never had that field.** Circuit breakers are parsed for
upstreams (`upstreams.rs:137`) and agents (`kdl/mod.rs:528`).

So the simulator was modelling a feature the proxy does not implement — while its
own module header said, throughout:

```rust
/// - Circuit breakers (per upstream)
```

Breakers now come from `config.upstreams`, keyed `upstream:{name}`, and the call
site resolves the route's upstream. A route with no upstream — static files, a
builtin handler — reaches no upstream and so cannot be blocked by one.

This is the same assumption #386 removed from six shipped configs, in code rather
than configuration.

## The test that let it happen

```rust
let mut cb = CircuitBreaker::new(2, 1, 10);   // constructed directly
```

The existing test exercises the state machine and never touches
`init_from_config`, so it passed happily throughout. That is the same shape as the
#128 lint rule (tests set the struct field directly) and `accepts_valid_auth_token`
(asserted a control existed, never that it worked).

Replaced with one that goes through `Config::from_kdl` and asserts breakers are
keyed by upstream, that an upstream without a `circuit-breaker` block gets none,
and that no `route:` key is produced.

## Why exclusion stays, and what replaces it

`sim` depends on `zentinel-config` with `default-features = false` to stay
WASM-compatible. As a workspace member, feature unification would pull `runtime`
straight back in via `zentinel-proxy`. **The exclusion is correct** — what was
missing is a build.

New `Excluded Crates` job covers `crates/sim` and `agents/wasm-allowlist`, the two
excluded crates that build on a native target. Both had also drifted out of
rustfmt, which follows from the root `fmt` job running `--all` against a workspace
that by definition does not contain them.

**Not covered, deliberately:** `crates/config-inspect` and `crates/playground-wasm`
both still require `zentinel-config`/`common` `^0.5.4` while the workspace is at
`0.6.27`, so they fail at dependency resolution before compiling anything. That is
a separate problem — the excluded crates carry hand-written versions
(sim `0.6.8`, the other two `0.5.4`) because they cannot use
`version.workspace = true`. The job comment says so rather than quietly covering
two of four.

## Verified

Every command the new job runs, run locally: both fmt checks clean, **43 sim tests
pass** (was: did not compile), `wasm-allowlist` checks clean.
`cargo check --workspace --all-targets` still clean.

This also retroactively verifies the `crates/sim` edits in #388, which shipped
unverified because the crate would not build.