### PR TITLE
fix(build): unstick config-inspect and playground-wasm dependency pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,11 +177,15 @@ jobs:
   # and workspace feature unification would pull `runtime` back in via
   # zentinel-proxy. So they need their own build rather than membership.
   #
-  # Covers the two that build on a native target today. `crates/config-inspect`
-  # and `crates/playground-wasm` are NOT covered: both still require
-  # zentinel-config/common `^0.5.4` while the workspace is well past that, so
-  # they cannot resolve dependencies at all. Add them here once those pins are
-  # fixed.
+  # Covers all four excluded crates. config-inspect and playground-wasm were
+  # added once their dependency pins were fixed — they had required
+  # zentinel-config/common `^0.5.4` against a workspace at 0.6.27, so they
+  # failed at dependency resolution before compiling anything.
+  #
+  # Internal deps in these crates are pinned as `0.6`, not an exact patch, so a
+  # workspace patch release cannot strand them again. A 0.7 bump still will,
+  # deliberately: excluded crates cannot use `version.workspace = true`, so
+  # something has to notice.
   excluded-crates:
     name: Excluded Crates
     runs-on: ubuntu-latest
@@ -208,11 +212,24 @@ jobs:
       - name: Check formatting (excluded crates)
         run: |
           cargo fmt --manifest-path crates/sim/Cargo.toml --check
+          cargo fmt --manifest-path crates/config-inspect/Cargo.toml --check
+          cargo fmt --manifest-path crates/playground-wasm/Cargo.toml --check
           cargo fmt --manifest-path agents/wasm-allowlist/Cargo.toml --check
 
       - name: Test zentinel-sim
         working-directory: crates/sim
         run: cargo test --all-targets
+
+      - name: Test zentinel-config-inspect
+        working-directory: crates/config-inspect
+        run: cargo test --all-targets
+
+      # Native check only. The real artifact is built for wasm32 by wasm-pack
+      # outside CI; this catches the breakage that actually happened — a change
+      # in zentinel-config that the crate no longer compiles against.
+      - name: Check zentinel-playground-wasm
+        working-directory: crates/playground-wasm
+        run: cargo check --all-targets
 
       - name: Check agents/wasm-allowlist
         working-directory: agents/wasm-allowlist

--- a/crates/config-inspect/Cargo.lock
+++ b/crates/config-inspect/Cargo.lock
@@ -43,9 +43,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -483,13 +483,14 @@ dependencies = [
 
 [[package]]
 name = "kdl"
-version = "6.5.0"
+version = "6.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a29e7b50079ff44549f68c0becb1c73d7f6de2a4ea952da77966daf3d4761e"
+checksum = "082ddf81b2acd76fe04412655d17befedfff1837db772f8e74c38050d25ed670"
 dependencies = [
  "miette",
- "num",
- "winnow 0.6.24",
+ "num-traits",
+ "serde",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -574,70 +575,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
-]
-
-[[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -890,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -1035,9 +972,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1045,32 +982,32 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.14",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 0.7.14",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tracing"
@@ -1153,12 +1090,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "validator"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
+checksum = "c3d68c6633c483df6780cc5277a417c7c2d1bceee2649d06c8ab6b0fd2dd3c81"
 dependencies = [
  "idna",
- "once_cell",
  "regex",
  "serde",
  "serde_derive",
@@ -1495,18 +1431,18 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"
@@ -1627,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.5.4"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1641,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.5.4"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1661,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config-inspect"
-version = "0.5.4"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "insta",

--- a/crates/config-inspect/Cargo.toml
+++ b/crates/config-inspect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-config-inspect"
-version = "0.5.4"
+version = "0.6.27"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"
@@ -17,8 +17,8 @@ path = "src/bin/zentinel-inspect.rs"
 
 [dependencies]
 # Local crates (WASM-compatible - disable runtime features)
-zentinel-config = { path = "../config", version = "0.5.4", default-features = false }
-zentinel-common = { path = "../common", version = "0.5.4", default-features = false }
+zentinel-config = { path = "../config", version = "0.6", default-features = false }
+zentinel-common = { path = "../common", version = "0.6", default-features = false }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/config-inspect/src/graph.rs
+++ b/crates/config-inspect/src/graph.rs
@@ -40,7 +40,6 @@ pub struct RouteNode {
     pub priority: String,
     pub match_summary: String,
     pub service_type: String,
-    pub has_circuit_breaker: bool,
     pub has_retry: bool,
     pub websocket: bool,
     pub cache_exclusions: Option<String>,
@@ -72,6 +71,11 @@ pub struct UpstreamNode {
     pub targets: Vec<String>,
     pub load_balancing: String,
     pub has_health_check: bool,
+    /// Circuit breakers are configured per upstream. This used to sit on
+    /// `RouteNode`, read from a `RouteConfig` field that has never existed, so
+    /// the graph reported breaker coverage against the wrong node type — and
+    /// `config-inspect` did not compile at all.
+    pub has_circuit_breaker: bool,
 }
 
 /// A directed edge between two nodes in the topology.
@@ -153,7 +157,6 @@ fn build_route_nodes(routes: &[RouteConfig]) -> Vec<RouteNode> {
                 priority: r.priority.to_string(),
                 match_summary: summarize_matches(&r.matches),
                 service_type: format!("{:?}", r.service_type),
-                has_circuit_breaker: r.circuit_breaker.is_some(),
                 has_retry: r.retry_policy.is_some(),
                 websocket: r.websocket,
                 cache_exclusions,
@@ -217,6 +220,7 @@ fn build_upstream_nodes(
                 .collect(),
             load_balancing: format!("{:?}", u.load_balancing),
             has_health_check: u.health_check.is_some(),
+            has_circuit_breaker: u.circuit_breaker.is_some(),
         })
         .collect();
     nodes.sort_by(|a, b| a.id.cmp(&b.id));

--- a/crates/config-inspect/src/heuristics.rs
+++ b/crates/config-inspect/src/heuristics.rs
@@ -81,7 +81,10 @@ fn check_orphan_upstreams(config: &Config, warnings: &mut Vec<Warning>) {
             warnings.push(Warning {
                 severity: Severity::Warn,
                 code: "ORPHAN_UPSTREAM".to_string(),
-                message: format!("Upstream '{}' is defined but not referenced by any route", upstream_id),
+                message: format!(
+                    "Upstream '{}' is defined but not referenced by any route",
+                    upstream_id
+                ),
                 context: vec![upstream_id.clone()],
             });
         }
@@ -104,7 +107,10 @@ fn check_orphan_agents(config: &Config, warnings: &mut Vec<Warning>) {
             warnings.push(Warning {
                 severity: Severity::Warn,
                 code: "ORPHAN_AGENT".to_string(),
-                message: format!("Agent '{}' is defined but not referenced by any filter", agent.id),
+                message: format!(
+                    "Agent '{}' is defined but not referenced by any filter",
+                    agent.id
+                ),
                 context: vec![agent.id.clone()],
             });
         }
@@ -124,7 +130,10 @@ fn check_orphan_filters(config: &Config, warnings: &mut Vec<Warning>) {
             warnings.push(Warning {
                 severity: Severity::Info,
                 code: "ORPHAN_FILTER".to_string(),
-                message: format!("Filter '{}' is defined but not referenced by any route", filter_id),
+                message: format!(
+                    "Filter '{}' is defined but not referenced by any route",
+                    filter_id
+                ),
                 context: vec![filter_id.clone()],
             });
         }
@@ -195,8 +204,8 @@ fn check_single_target(config: &Config, warnings: &mut Vec<Warning>) {
 
 /// Catch-all routes (no match conditions) that aren't lowest priority.
 fn check_catch_all_priority(config: &Config, warnings: &mut Vec<Warning>) {
-    use zentinel_config::routes::ServiceType;
     use zentinel_common::types::Priority;
+    use zentinel_config::routes::ServiceType;
 
     for route in &config.routes {
         if route.matches.is_empty()

--- a/crates/config-inspect/src/render/dot.rs
+++ b/crates/config-inspect/src/render/dot.rs
@@ -42,9 +42,6 @@ pub fn render(topology: &Topology) -> String {
         out.push_str("        color=\"#666666\";\n");
         for r in &topology.routes {
             let mut extras = Vec::new();
-            if r.has_circuit_breaker {
-                extras.push("CB");
-            }
             if r.has_retry {
                 extras.push("Retry");
             }
@@ -128,7 +125,15 @@ pub fn render(topology: &Topology) -> String {
             } else {
                 String::new()
             };
-            let hc = if u.has_health_check { " [HC]" } else { "" };
+            // CB moved here from the route node: circuit breakers are per
+            // upstream. See #387.
+            let mut hc = String::new();
+            if u.has_health_check {
+                hc.push_str(" [HC]");
+            }
+            if u.has_circuit_breaker {
+                hc.push_str(" [CB]");
+            }
             out.push_str(&format!(
                 "        U_{} [label=\"{}\\n{}{}\\n{}{}\", shape=cylinder, style=filled, fillcolor=\"#fce4ec\"];\n",
                 sanitize(&u.id),

--- a/crates/config-inspect/src/render/json.rs
+++ b/crates/config-inspect/src/render/json.rs
@@ -7,14 +7,12 @@ use crate::graph::Topology;
 
 /// Render a topology as pretty-printed JSON.
 pub fn render(topology: &Topology) -> String {
-    serde_json::to_string_pretty(topology).unwrap_or_else(|e| {
-        format!("{{\"error\": \"Failed to serialize topology: {}\"}}", e)
-    })
+    serde_json::to_string_pretty(topology)
+        .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize topology: {}\"}}", e))
 }
 
 /// Render a topology as compact JSON.
 pub fn render_compact(topology: &Topology) -> String {
-    serde_json::to_string(topology).unwrap_or_else(|e| {
-        format!("{{\"error\": \"Failed to serialize topology: {}\"}}", e)
-    })
+    serde_json::to_string(topology)
+        .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize topology: {}\"}}", e))
 }

--- a/crates/config-inspect/src/render/mermaid.rs
+++ b/crates/config-inspect/src/render/mermaid.rs
@@ -89,7 +89,15 @@ pub fn render(topology: &Topology) -> String {
             } else {
                 String::new()
             };
-            let hc = if u.has_health_check { " ✓HC" } else { "" };
+            // CB moved here from the route node: circuit breakers are per
+            // upstream. See #387.
+            let mut hc = String::new();
+            if u.has_health_check {
+                hc.push_str(" ✓HC");
+            }
+            if u.has_circuit_breaker {
+                hc.push_str(" ✓CB");
+            }
             out.push_str(&format!(
                 "        U_{id}[[\"{id}\\n{targets}{more}\\n{lb}{hc}\"]]\n",
                 id = sanitize(&u.id),
@@ -117,7 +125,8 @@ pub fn render(topology: &Topology) -> String {
         out.push('\n');
         out.push_str("    %% Warnings:\n");
         for w in &topology.warnings {
-            out.push_str(&format!("    %% [{severity}] {code}: {msg}\n",
+            out.push_str(&format!(
+                "    %% [{severity}] {code}: {msg}\n",
                 severity = w.severity,
                 code = w.code,
                 msg = w.message,
@@ -140,9 +149,6 @@ fn node_ref_id(nr: &NodeRef) -> String {
 
 fn build_route_extras(r: &crate::graph::RouteNode) -> String {
     let mut extras = Vec::new();
-    if r.has_circuit_breaker {
-        extras.push("CB");
-    }
     if r.has_retry {
         extras.push("Retry");
     }

--- a/crates/config-inspect/src/render/text.rs
+++ b/crates/config-inspect/src/render/text.rs
@@ -29,11 +29,14 @@ pub fn render(topology: &Topology) -> String {
     out.push_str(&"-".repeat(30));
     out.push('\n');
     for r in &topology.routes {
-        let extras = if r.has_circuit_breaker || r.has_retry || r.websocket {
+        let extras = if r.has_retry || r.websocket {
             let mut flags = Vec::new();
-            if r.has_circuit_breaker { flags.push("CB"); }
-            if r.has_retry { flags.push("retry"); }
-            if r.websocket { flags.push("WS"); }
+            if r.has_retry {
+                flags.push("retry");
+            }
+            if r.websocket {
+                flags.push("WS");
+            }
             format!(" [{}]", flags.join(", "))
         } else {
             String::new()
@@ -101,7 +104,15 @@ pub fn render(topology: &Topology) -> String {
         out.push_str(&"-".repeat(30));
         out.push('\n');
         for u in &topology.upstreams {
-            let hc = if u.has_health_check { " [HC]" } else { "" };
+            // CB moved here from the route node: circuit breakers are per
+            // upstream. See #387.
+            let mut hc = String::new();
+            if u.has_health_check {
+                hc.push_str(" [HC]");
+            }
+            if u.has_circuit_breaker {
+                hc.push_str(" [CB]");
+            }
             out.push_str(&format!(
                 "  {} ({}, {}){}\n",
                 u.id,

--- a/crates/config-inspect/src/shadow.rs
+++ b/crates/config-inspect/src/shadow.rs
@@ -95,12 +95,30 @@ fn check_path_shadow(
 /// Check if the higher route has conditions that the lower route doesn't,
 /// which would mean it's more restrictive (not a true shadow).
 fn has_extra_restrictions(higher: &RouteConfig, lower: &RouteConfig) -> bool {
-    let higher_has_host = higher.matches.iter().any(|m| matches!(m, MatchCondition::Host(_)));
-    let lower_has_host = lower.matches.iter().any(|m| matches!(m, MatchCondition::Host(_)));
-    let higher_has_method = higher.matches.iter().any(|m| matches!(m, MatchCondition::Method(_)));
-    let lower_has_method = lower.matches.iter().any(|m| matches!(m, MatchCondition::Method(_)));
-    let higher_has_header = higher.matches.iter().any(|m| matches!(m, MatchCondition::Header { .. }));
-    let lower_has_header = lower.matches.iter().any(|m| matches!(m, MatchCondition::Header { .. }));
+    let higher_has_host = higher
+        .matches
+        .iter()
+        .any(|m| matches!(m, MatchCondition::Host(_)));
+    let lower_has_host = lower
+        .matches
+        .iter()
+        .any(|m| matches!(m, MatchCondition::Host(_)));
+    let higher_has_method = higher
+        .matches
+        .iter()
+        .any(|m| matches!(m, MatchCondition::Method(_)));
+    let lower_has_method = lower
+        .matches
+        .iter()
+        .any(|m| matches!(m, MatchCondition::Method(_)));
+    let higher_has_header = higher
+        .matches
+        .iter()
+        .any(|m| matches!(m, MatchCondition::Header { .. }));
+    let lower_has_header = lower
+        .matches
+        .iter()
+        .any(|m| matches!(m, MatchCondition::Header { .. }));
 
     // If higher route has a condition type that lower doesn't, it's more restrictive
     (higher_has_host && !lower_has_host)
@@ -155,7 +173,6 @@ mod tests {
             filters: vec![],
             builtin_handler: None,
             waf_enabled: false,
-            circuit_breaker: None,
             retry_policy: None,
             static_files: None,
             api_schema: None,
@@ -173,8 +190,16 @@ mod tests {
     #[test]
     fn prefix_shadows_longer_prefix() {
         let routes = vec![
-            route("api", Priority::HIGH, vec![MatchCondition::PathPrefix("/api".into())]),
-            route("api-users", Priority::NORMAL, vec![MatchCondition::PathPrefix("/api/users".into())]),
+            route(
+                "api",
+                Priority::HIGH,
+                vec![MatchCondition::PathPrefix("/api".into())],
+            ),
+            route(
+                "api-users",
+                Priority::NORMAL,
+                vec![MatchCondition::PathPrefix("/api/users".into())],
+            ),
         ];
         let shadowed = find_shadowed_routes(&routes);
         assert_eq!(shadowed.len(), 1);
@@ -185,8 +210,16 @@ mod tests {
     #[test]
     fn same_priority_does_not_shadow() {
         let routes = vec![
-            route("api", Priority::NORMAL, vec![MatchCondition::PathPrefix("/api".into())]),
-            route("api-users", Priority::NORMAL, vec![MatchCondition::PathPrefix("/api/users".into())]),
+            route(
+                "api",
+                Priority::NORMAL,
+                vec![MatchCondition::PathPrefix("/api".into())],
+            ),
+            route(
+                "api-users",
+                Priority::NORMAL,
+                vec![MatchCondition::PathPrefix("/api/users".into())],
+            ),
         ];
         let shadowed = find_shadowed_routes(&routes);
         assert!(shadowed.is_empty());
@@ -203,7 +236,11 @@ mod tests {
                     MatchCondition::Host("internal.example.com".into()),
                 ],
             ),
-            route("api", Priority::NORMAL, vec![MatchCondition::PathPrefix("/api".into())]),
+            route(
+                "api",
+                Priority::NORMAL,
+                vec![MatchCondition::PathPrefix("/api".into())],
+            ),
         ];
         let shadowed = find_shadowed_routes(&routes);
         assert!(shadowed.is_empty());

--- a/crates/playground-wasm/Cargo.lock
+++ b/crates/playground-wasm/Cargo.lock
@@ -43,9 +43,9 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arc-swap"
-version = "1.8.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -457,13 +457,14 @@ dependencies = [
 
 [[package]]
 name = "kdl"
-version = "6.5.0"
+version = "6.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a29e7b50079ff44549f68c0becb1c73d7f6de2a4ea952da77966daf3d4761e"
+checksum = "082ddf81b2acd76fe04412655d17befedfff1837db772f8e74c38050d25ed670"
 dependencies = [
  "miette",
- "num",
- "winnow 0.6.24",
+ "num-traits",
+ "serde",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -567,70 +568,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -894,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -1026,9 +963,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.2+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1dfefef6a142e93f346b64c160934eb13b5594b84ab378133ac6815cb2bd57f"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1036,32 +973,32 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.14",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 0.7.14",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tracing"
@@ -1138,12 +1075,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "validator"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
+checksum = "c3d68c6633c483df6780cc5277a417c7c2d1bceee2649d06c8ab6b0fd2dd3c81"
 dependencies = [
  "idna",
- "once_cell",
  "regex",
  "serde",
  "serde_derive",
@@ -1437,18 +1373,18 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "writeable"
@@ -1487,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.5.4"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1501,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.5.4"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1521,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config-inspect"
-version = "0.5.4"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "serde",
@@ -1533,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-playground-wasm"
-version = "0.5.4"
+version = "0.6.27"
 dependencies = [
  "console_error_panic_hook",
  "serde",
@@ -1548,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-sim"
-version = "0.5.4"
+version = "0.6.27"
 dependencies = [
  "regex",
  "serde",

--- a/crates/playground-wasm/Cargo.toml
+++ b/crates/playground-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-playground-wasm"
-version = "0.5.4"
+version = "0.6.27"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"
@@ -16,9 +16,9 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 # Local crates
-zentinel-sim = { path = "../sim", version = "0.5.4" }
-zentinel-config = { path = "../config", version = "0.5.4", default-features = false }
-zentinel-config-inspect = { path = "../config-inspect", version = "0.5.4" }
+zentinel-sim = { path = "../sim", version = "0.6" }
+zentinel-config = { path = "../config", version = "0.6", default-features = false }
+zentinel-config-inspect = { path = "../config-inspect", version = "0.6" }
 
 # WASM bindings
 wasm-bindgen = "0.2"

--- a/crates/playground-wasm/src/lib.rs
+++ b/crates/playground-wasm/src/lib.rs
@@ -54,9 +54,9 @@
 use wasm_bindgen::prelude::*;
 
 use zentinel_sim::{
-    validate as sim_validate, simulate as sim_simulate, get_effective_config,
-    simulate_sequence as sim_simulate_sequence, simulate_with_agents as sim_simulate_with_agents,
-    MockAgentResponse, SimulatedRequest, TimestampedRequest,
+    get_effective_config, simulate as sim_simulate, simulate_sequence as sim_simulate_sequence,
+    simulate_with_agents as sim_simulate_with_agents, validate as sim_validate, MockAgentResponse,
+    SimulatedRequest, TimestampedRequest,
 };
 
 /// Initialize panic hook for better error messages in the console
@@ -90,17 +90,25 @@ pub fn validate(config_kdl: &str) -> JsValue {
     // Convert to a serializable format
     let response = ValidationResponse {
         valid: result.valid,
-        errors: result.errors.iter().map(|e| ErrorInfo {
-            message: e.message.clone(),
-            severity: format!("{:?}", e.severity).to_lowercase(),
-            line: e.location.as_ref().map(|l| l.line),
-            column: e.location.as_ref().map(|l| l.column),
-            hint: e.hint.clone(),
-        }).collect(),
-        warnings: result.warnings.iter().map(|w| WarningInfo {
-            code: w.code.clone(),
-            message: w.message.clone(),
-        }).collect(),
+        errors: result
+            .errors
+            .iter()
+            .map(|e| ErrorInfo {
+                message: e.message.clone(),
+                severity: format!("{:?}", e.severity).to_lowercase(),
+                line: e.location.as_ref().map(|l| l.line),
+                column: e.location.as_ref().map(|l| l.column),
+                hint: e.hint.clone(),
+            })
+            .collect(),
+        warnings: result
+            .warnings
+            .iter()
+            .map(|w| WarningInfo {
+                code: w.code.clone(),
+                message: w.message.clone(),
+            })
+            .collect(),
         effective_config: if result.valid {
             result.effective_config.as_ref().map(get_effective_config)
         } else {
@@ -136,25 +144,36 @@ pub fn simulate(config_kdl: &str, request_json: &str) -> JsValue {
     if !validation.valid {
         return serde_wasm_bindgen::to_value(&SimulationError {
             error: "Invalid configuration".to_string(),
-            details: validation.errors.iter().map(|e| e.message.clone()).collect(),
-        }).unwrap_or(JsValue::NULL);
+            details: validation
+                .errors
+                .iter()
+                .map(|e| e.message.clone())
+                .collect(),
+        })
+        .unwrap_or(JsValue::NULL);
     }
 
     let config = match validation.effective_config {
         Some(c) => c,
-        None => return serde_wasm_bindgen::to_value(&SimulationError {
-            error: "Failed to parse configuration".to_string(),
-            details: vec![],
-        }).unwrap_or(JsValue::NULL),
+        None => {
+            return serde_wasm_bindgen::to_value(&SimulationError {
+                error: "Failed to parse configuration".to_string(),
+                details: vec![],
+            })
+            .unwrap_or(JsValue::NULL)
+        }
     };
 
     // Parse request
     let request: SimulatedRequest = match serde_json::from_str(request_json) {
         Ok(r) => r,
-        Err(e) => return serde_wasm_bindgen::to_value(&SimulationError {
-            error: "Invalid request JSON".to_string(),
-            details: vec![e.to_string()],
-        }).unwrap_or(JsValue::NULL),
+        Err(e) => {
+            return serde_wasm_bindgen::to_value(&SimulationError {
+                error: "Invalid request JSON".to_string(),
+                details: vec![e.to_string()],
+            })
+            .unwrap_or(JsValue::NULL)
+        }
     };
 
     // Run simulation
@@ -173,8 +192,13 @@ pub fn get_normalized_config(config_kdl: &str) -> JsValue {
     if !validation.valid {
         return serde_wasm_bindgen::to_value(&SimulationError {
             error: "Invalid configuration".to_string(),
-            details: validation.errors.iter().map(|e| e.message.clone()).collect(),
-        }).unwrap_or(JsValue::NULL);
+            details: validation
+                .errors
+                .iter()
+                .map(|e| e.message.clone())
+                .collect(),
+        })
+        .unwrap_or(JsValue::NULL);
     }
 
     match validation.effective_config {
@@ -237,7 +261,11 @@ pub fn simulate_stateful(config_kdl: &str, requests_json: &str) -> JsValue {
     if !validation.valid {
         return serde_wasm_bindgen::to_value(&SimulationError {
             error: "Invalid configuration".to_string(),
-            details: validation.errors.iter().map(|e| e.message.clone()).collect(),
+            details: validation
+                .errors
+                .iter()
+                .map(|e| e.message.clone())
+                .collect(),
         })
         .unwrap_or(JsValue::NULL);
     }
@@ -326,7 +354,11 @@ pub fn simulate_with_agents(
     if !validation.valid {
         return serde_wasm_bindgen::to_value(&SimulationError {
             error: "Invalid configuration".to_string(),
-            details: validation.errors.iter().map(|e| e.message.clone()).collect(),
+            details: validation
+                .errors
+                .iter()
+                .map(|e| e.message.clone())
+                .collect(),
         })
         .unwrap_or(JsValue::NULL);
     }
@@ -478,9 +510,10 @@ pub fn lint_config(config_kdl: &str) -> JsValue {
     };
 
     let topology = zentinel_config_inspect::inspect(&config);
-    let has_errors = topology.warnings.iter().any(|w| {
-        matches!(w.severity, zentinel_config_inspect::Severity::Error)
-    });
+    let has_errors = topology
+        .warnings
+        .iter()
+        .any(|w| matches!(w.severity, zentinel_config_inspect::Severity::Error));
 
     let warnings: Vec<LintWarning> = topology
         .warnings

--- a/crates/sim/Cargo.lock
+++ b/crates/sim/Cargo.lock
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-sim"
-version = "0.6.8"
+version = "0.6.27"
 dependencies = [
  "insta",
  "proptest",

--- a/crates/sim/Cargo.toml
+++ b/crates/sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-sim"
-version = "0.6.8"
+version = "0.6.27"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"
@@ -13,8 +13,8 @@ categories = ["simulation", "wasm", "network-programming"]
 
 [dependencies]
 # Local crates (WASM-compatible - disable runtime features)
-zentinel-config = { path = "../config", version = "0.6.8", default-features = false }
-zentinel-common = { path = "../common", version = "0.6.8", default-features = false }
+zentinel-config = { path = "../config", version = "0.6", default-features = false }
+zentinel-common = { path = "../common", version = "0.6", default-features = false }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Follow-up to #389. Both crates required `zentinel-config`/`common` `^0.5.4`
against a workspace at `0.6.27`, so they failed at **dependency resolution** —
before compiling a single line.

Root cause: excluded crates cannot use `version.workspace = true`, so their
versions are hand-written and the release bump never touches them.

## Pins

Internal deps are now `"0.6"` rather than an exact patch, so a workspace patch
release cannot strand them again. A `0.7` bump still will, deliberately —
something has to notice.

| Crate | Was | Now |
|---|---|---|
| `sim` | 0.6.8 | 0.6.27 |
| `config-inspect` | 0.5.4 | 0.6.27 |
| `playground-wasm` | 0.5.4 | 0.6.27 |

`playground-wasm` depends on `config-inspect`, so that one had to move too.

## Fixing the pins exposed the same defect again

With dependencies resolving, `config-inspect` still failed to compile — it read
`route.circuit_breaker`, the `RouteConfig` field that has never existed. Third
place this assumption has turned up, after six shipped configs (#386) and the
simulator (#389).

**`has_circuit_breaker` moved from `RouteNode` to `UpstreamNode` rather than
being deleted.** All three renderers surface it (`dot`, `mermaid`, `text`) and
`UpstreamNode` carried no breaker information at all, so deleting it would have
removed circuit breakers from the topology output entirely. Instead they now
appear against the node that actually has them:

```
  backend (127.0.0.1:9000, RoundRobin) [HC] [CB]
```

Route flags drop to `[retry, WS]`.

## CI

The `Excluded Crates` job from #389 now covers **all four** excluded crates
rather than two.

`playground-wasm` gets a native `cargo check` only. The shipped artifact is
built for `wasm32` by wasm-pack outside CI — but a native check catches what
actually broke these crates, which was drift in `zentinel-config`, not anything
WASM-specific.

## Verified, and one thing not

Every command the job runs, run locally: fmt clean on all four, **sim 43 tests**,
**config-inspect 6 tests**, playground-wasm and wasm-allowlist check clean,
`cargo check --workspace --all-targets` clean.

**The wasm32 build is not verified.** `cargo check --target wasm32-unknown-unknown`
fails in my environment with `can't find crate for 'core'` even with the target
installed for the pinned 1.95.0 toolchain and its rust-std present. That looks
like a local toolchain problem rather than a code one, but I could not prove it,
so I am not claiming the WASM build works — only that the crate compiles
natively and its dependencies resolve.