### PR TITLE
fix(proxy): actually enforce MCP and A2A route policy

### DIFF
--- a/crates/proxy/src/agentic/mod.rs
+++ b/crates/proxy/src/agentic/mod.rs
@@ -27,3 +27,159 @@
 pub mod a2a;
 pub mod jsonrpc;
 pub mod mcp;
+
+use zentinel_config::agentic::{
+    A2aConfig, McpConfig, UninspectableBody as ConfigUninspectable, UnknownMethods as ConfigUnknown,
+};
+use zentinel_config::RouteConfig;
+
+/// What a route's agentic policy decided about a request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    /// Forward it, carrying what was resolved **from the body** for audit.
+    Allow {
+        /// MCP method, if this route carries an `mcp` block.
+        mcp_method: Option<String>,
+        /// MCP tool or resource.
+        mcp_target: Option<String>,
+        /// A2A method, if this route carries an `a2a` block.
+        a2a_method: Option<String>,
+    },
+    /// Refuse it.
+    Deny {
+        /// Written to be read by an operator, not parsed.
+        reason: String,
+        /// Metrics label: `mcp_policy` or `a2a_policy`.
+        kind: &'static str,
+    },
+}
+
+/// Apply a route's MCP and A2A policy to a request.
+///
+/// Returns `None` when the route declares neither, which is the common case and
+/// must stay free.
+///
+/// This is deliberately a function of [`RouteConfig`] rather than of the
+/// already-converted policy types. The gap that made this module dead code for
+/// a release was between configuration and enforcement, so that is the boundary
+/// worth testing across.
+pub fn decide(route: &RouteConfig, headers: &[(String, String)], body: &[u8]) -> Option<Outcome> {
+    if route.mcp.is_none() && route.a2a.is_none() {
+        return None;
+    }
+
+    let mut mcp_method = None;
+    let mut mcp_target = None;
+    let mut a2a_method = None;
+
+    if let Some(cfg) = route.mcp.as_ref() {
+        match mcp::evaluate(&mcp::Policy::from(cfg), headers, body) {
+            mcp::Decision::Allow { method, target } => {
+                mcp_method = method;
+                mcp_target = target;
+            }
+            mcp::Decision::Deny { reason } => {
+                return Some(Outcome::Deny {
+                    reason: reason.to_string(),
+                    kind: "mcp_policy",
+                })
+            }
+        }
+    }
+
+    if let Some(cfg) = route.a2a.as_ref() {
+        match a2a::evaluate(&a2a::Policy::from(cfg), body) {
+            a2a::Decision::Allow { method } => a2a_method = method,
+            a2a::Decision::Deny { reason } => {
+                return Some(Outcome::Deny {
+                    reason: reason.to_string(),
+                    kind: "a2a_policy",
+                })
+            }
+        }
+    }
+
+    Some(Outcome::Allow {
+        mcp_method,
+        mcp_target,
+        a2a_method,
+    })
+}
+
+impl From<&McpConfig> for mcp::Policy {
+    fn from(c: &McpConfig) -> Self {
+        Self {
+            allowed_methods: c.allowed_methods.iter().cloned().collect(),
+            denied_methods: c.denied_methods.iter().cloned().collect(),
+            allowed_targets: c.allowed_tools.iter().cloned().collect(),
+            denied_targets: c.denied_tools.iter().cloned().collect(),
+            require_validated_version: c.require_validated_version,
+            validate_param_headers: c.validate_param_headers,
+            on_uninspectable: match c.on_uninspectable_body {
+                ConfigUninspectable::Deny => mcp::UninspectableBody::Deny,
+                ConfigUninspectable::Allow => mcp::UninspectableBody::Allow,
+            },
+        }
+    }
+}
+
+impl From<&A2aConfig> for a2a::Policy {
+    fn from(c: &A2aConfig) -> Self {
+        Self {
+            allowed_methods: c.allowed_methods.iter().cloned().collect(),
+            denied_methods: c.denied_methods.iter().cloned().collect(),
+            unknown_methods: match c.unknown_methods {
+                ConfigUnknown::Allow => a2a::UnknownMethods::Allow,
+                ConfigUnknown::Deny => a2a::UnknownMethods::Deny,
+            },
+            deny_uninspectable: c.deny_uninspectable_body,
+        }
+    }
+}
+
+#[cfg(test)]
+mod conversion_tests {
+    use super::*;
+
+    /// Every field must cross the config boundary. A policy that silently keeps
+    /// a default here is the same defect this module exists to prevent, one
+    /// layer up: the config would say "deny" and the proxy would allow.
+    #[test]
+    fn mcp_config_crosses_the_boundary_with_non_default_values() {
+        let cfg = McpConfig {
+            allowed_methods: vec!["tools/call".into()],
+            denied_methods: vec!["resources/read".into()],
+            allowed_tools: vec!["get_weather".into()],
+            denied_tools: vec!["execute_sql".into()],
+            require_validated_version: false,
+            validate_param_headers: false,
+            on_uninspectable_body: ConfigUninspectable::Allow,
+        };
+        let p = mcp::Policy::from(&cfg);
+
+        assert!(p.allowed_methods.contains("tools/call"));
+        assert!(p.denied_methods.contains("resources/read"));
+        assert!(p.allowed_targets.contains("get_weather"));
+        assert!(p.denied_targets.contains("execute_sql"));
+        // Both of these default to true; asserting the false case is the point.
+        assert!(!p.require_validated_version);
+        assert!(!p.validate_param_headers);
+        assert_eq!(p.on_uninspectable, mcp::UninspectableBody::Allow);
+    }
+
+    #[test]
+    fn a2a_config_crosses_the_boundary_with_non_default_values() {
+        let cfg = A2aConfig {
+            allowed_methods: vec!["GetTask".into()],
+            denied_methods: vec!["SendMessage".into()],
+            unknown_methods: ConfigUnknown::Deny,
+            deny_uninspectable_body: false,
+        };
+        let p = a2a::Policy::from(&cfg);
+
+        assert!(p.allowed_methods.contains("GetTask"));
+        assert!(p.denied_methods.contains("SendMessage"));
+        assert_eq!(p.unknown_methods, a2a::UnknownMethods::Deny);
+        assert!(!p.deny_uninspectable);
+    }
+}

--- a/crates/proxy/src/proxy/context.rs
+++ b/crates/proxy/src/proxy/context.rs
@@ -170,6 +170,26 @@ pub struct RequestContext {
     /// Agent IDs to use for body inspection
     pub(crate) body_inspection_agents: Vec<String>,
 
+    // === Agentic protocol policy (MCP / A2A) ===
+    /// Request body accumulated for MCP/A2A policy evaluation.
+    ///
+    /// Separate from `body_buffer`, which serves agent inspection and is
+    /// governed by the WAF's streaming mode. Policy here is resolved from the
+    /// JSON-RPC envelope and must see the whole envelope before the request
+    /// reaches an upstream, whatever the agent configuration happens to be.
+    pub(crate) agentic_body: Vec<u8>,
+    /// Set when the body exceeded what the evaluator will parse, so evaluation
+    /// treats it as uninspectable rather than judging a truncated prefix.
+    pub(crate) agentic_body_oversize: bool,
+    /// MCP method resolved **from the body**, for metrics and audit. Recording
+    /// the header value instead would describe what a client claimed rather
+    /// than what the upstream will execute.
+    pub(crate) mcp_method: Option<String>,
+    /// MCP tool or resource resolved from the body.
+    pub(crate) mcp_target: Option<String>,
+    /// A2A method resolved from the body.
+    pub(crate) a2a_method: Option<String>,
+
     // === Body Decompression ===
     /// Whether decompression is enabled for body inspection
     pub(crate) decompression_enabled: bool,
@@ -369,6 +389,11 @@ impl RequestContext {
             body_inspection_enabled: false,
             body_bytes_inspected: 0,
             body_buffer: Vec::new(),
+            agentic_body: Vec::new(),
+            agentic_body_oversize: false,
+            mcp_method: None,
+            mcp_target: None,
+            a2a_method: None,
             body_inspection_agents: Vec::new(),
             decompression_enabled: false,
             body_content_encoding: None,

--- a/crates/proxy/src/proxy/http_trait.rs
+++ b/crates/proxy/src/proxy/http_trait.rs
@@ -1650,12 +1650,17 @@ impl ProxyHttp for ZentinelProxy {
     /// - **Stream mode**: Send each chunk immediately to agents as it arrives
     async fn request_body_filter(
         &self,
-        _session: &mut Session,
+        session: &mut Session,
         body: &mut Option<Bytes>,
         end_of_stream: bool,
         ctx: &mut Self::CTX,
     ) -> Result<(), Box<Error>> {
         use zentinel_config::BodyStreamingMode;
+
+        // MCP / A2A policy. Runs before agent inspection because it decides
+        // whether the request may be made at all, from data already in hand;
+        // agents decide whether its contents are safe.
+        self.evaluate_agentic_policy(session, body.as_ref(), end_of_stream, ctx)?;
 
         // Handle WebSocket frame inspection (client -> server)
         if ctx.is_websocket_upgrade {
@@ -3819,6 +3824,98 @@ impl ProxyHttp for ZentinelProxy {
 // =============================================================================
 
 impl ZentinelProxy {
+    /// Enforce a route's MCP or A2A policy against the request body.
+    ///
+    /// Policy is resolved from the JSON-RPC envelope, never from the mirrored
+    /// `Mcp-*` headers — those are only consulted to confirm they agree with
+    /// the body, and a request that disagrees with itself is refused. See
+    /// [`crate::agentic::mcp`] for why.
+    ///
+    /// The body is accumulated across chunks and judged once, at end of stream,
+    /// so that a decision is never made on a partial envelope. Nothing has been
+    /// forwarded upstream at that point.
+    fn evaluate_agentic_policy(
+        &self,
+        session: &Session,
+        chunk: Option<&Bytes>,
+        end_of_stream: bool,
+        ctx: &mut RequestContext,
+    ) -> Result<(), Box<Error>> {
+        use crate::agentic::{self, jsonrpc};
+
+        let Some(route) = ctx.route_config.clone() else {
+            return Ok(());
+        };
+        if route.mcp.is_none() && route.a2a.is_none() {
+            return Ok(());
+        }
+
+        // Accumulate, but never past what the evaluator will parse. Beyond that
+        // the body is uninspectable, and the policy says what to do about that
+        // — judging a truncated prefix would be worse than either answer.
+        if let Some(chunk) = chunk {
+            let remaining = jsonrpc::MAX_ENVELOPE_BYTES.saturating_sub(ctx.agentic_body.len());
+            if chunk.len() > remaining {
+                ctx.agentic_body_oversize = true;
+                ctx.agentic_body.extend_from_slice(&chunk[..remaining]);
+            } else {
+                ctx.agentic_body.extend_from_slice(chunk);
+            }
+        }
+
+        if !end_of_stream {
+            return Ok(());
+        }
+
+        // An oversize body is deliberately handed on as-is: it is past the
+        // parse bound, so the evaluator will classify it uninspectable and the
+        // route's own setting decides.
+        let headers: Vec<(String, String)> = session
+            .req_header()
+            .headers
+            .iter()
+            .filter_map(|(k, v)| {
+                v.to_str()
+                    .ok()
+                    .map(|v| (k.as_str().to_ascii_lowercase(), v.to_string()))
+            })
+            .collect();
+
+        match agentic::decide(&route, &headers, &ctx.agentic_body) {
+            None => {}
+            Some(agentic::Outcome::Allow {
+                mcp_method,
+                mcp_target,
+                a2a_method,
+            }) => {
+                trace!(
+                    correlation_id = %ctx.trace_id,
+                    route_id = ?ctx.route_id,
+                    mcp_method = ?mcp_method,
+                    mcp_target = ?mcp_target,
+                    a2a_method = ?a2a_method,
+                    "Agentic request permitted"
+                );
+                ctx.mcp_method = mcp_method;
+                ctx.mcp_target = mcp_target;
+                ctx.a2a_method = a2a_method;
+            }
+            Some(agentic::Outcome::Deny { reason, kind }) => {
+                warn!(
+                    correlation_id = %ctx.trace_id,
+                    route_id = ?ctx.route_id,
+                    policy = kind,
+                    reason = %reason,
+                    "Agentic request denied"
+                );
+                self.metrics.record_blocked_request(kind);
+                return Err(Error::explain(ErrorType::HTTPStatus(403), reason));
+            }
+        }
+
+        Ok(())
+    }
+
     /// Process a single body chunk in streaming mode.
     async fn process_body_chunk_streaming(
         &self,

--- a/crates/proxy/tests/agentic_policy_test.rs
+++ b/crates/proxy/tests/agentic_policy_test.rs
@@ -1,0 +1,334 @@
+//! MCP and A2A policy, driven from configuration.
+//!
+//! # Why this file exists
+//!
+//! `crates/proxy/src/agentic/` carries 73 unit tests and every one of them
+//! builds a `Policy` by hand and calls `evaluate()`. All of them passed for a
+//! full release during which **nothing in the proxy ever called `evaluate()`**:
+//! `RouteConfig::mcp` was parsed, validated, and read by no one. A route saying
+//! `tools { allow "get_weather" }` permitted every tool there is.
+//!
+//! That is the same shape as three other defects found the same week — a test
+//! that constructs the object under test cannot notice that nothing constructs
+//! it in production.
+//!
+//! So these tests start from KDL and end at a decision, crossing every boundary
+//! the defect hid in: parse → `RouteConfig` → `Policy` → `Outcome`.
+
+use zentinel_config::Config;
+use zentinel_proxy::agentic::{decide, Outcome};
+
+/// A config with one MCP route and one ordinary route.
+fn config_with(mcp_block: &str) -> Config {
+    let kdl = format!(
+        r#"
+        system {{
+            worker-threads 2
+        }}
+        listeners {{
+            listener "http" {{
+                address "127.0.0.1:8080"
+            }}
+        }}
+        upstreams {{
+            upstream "backend" {{
+                target "127.0.0.1:9000"
+            }}
+        }}
+        routes {{
+            route "mcp" {{
+                matches {{
+                    path-prefix "/mcp"
+                }}
+                upstream "backend"
+{mcp_block}
+            }}
+            route "plain" {{
+                matches {{
+                    path-prefix "/"
+                }}
+                upstream "backend"
+            }}
+        }}
+        "#
+    );
+    Config::from_kdl(&kdl).expect("config should parse")
+}
+
+fn route<'a>(config: &'a Config, id: &str) -> &'a zentinel_config::RouteConfig {
+    config
+        .routes
+        .iter()
+        .find(|r| r.id == id)
+        .unwrap_or_else(|| panic!("route {id} should exist"))
+}
+
+const TOOLS_BLOCK: &str = r#"
+                mcp {
+                    tools {
+                        allow "get_weather"
+                        deny "execute_sql"
+                    }
+                }
+"#;
+
+fn call(tool: &str) -> Vec<u8> {
+    format!(r#"{{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{{"name":"{tool}"}}}}"#)
+        .into_bytes()
+}
+
+fn mcp_headers(name: &str) -> Vec<(String, String)> {
+    vec![
+        ("mcp-protocol-version".to_string(), "2026-07-28".to_string()),
+        ("mcp-method".to_string(), "tools/call".to_string()),
+        ("mcp-name".to_string(), name.to_string()),
+    ]
+}
+
+/// The headline case. Before the wiring existed this returned `Allow`, because
+/// nothing consulted the route's policy at all.
+#[test]
+fn a_tool_outside_the_allowlist_is_denied_from_config() {
+    let config = config_with(TOOLS_BLOCK);
+    let outcome = decide(
+        route(&config, "mcp"),
+        &mcp_headers("delete_everything"),
+        &call("delete_everything"),
+    );
+
+    match outcome {
+        Some(Outcome::Deny { reason, kind }) => {
+            assert_eq!(kind, "mcp_policy");
+            assert!(
+                reason.contains("delete_everything"),
+                "reason should name the tool, got: {reason}"
+            );
+        }
+        other => panic!("expected Deny, got {other:?}"),
+    }
+}
+
+#[test]
+fn an_allowlisted_tool_is_permitted_and_reports_what_the_body_said() {
+    let config = config_with(TOOLS_BLOCK);
+    let outcome = decide(
+        route(&config, "mcp"),
+        &mcp_headers("get_weather"),
+        &call("get_weather"),
+    );
+
+    match outcome {
+        Some(Outcome::Allow {
+            mcp_method,
+            mcp_target,
+            ..
+        }) => {
+            assert_eq!(mcp_method.as_deref(), Some("tools/call"));
+            assert_eq!(mcp_target.as_deref(), Some("get_weather"));
+        }
+        other => panic!("expected Allow, got {other:?}"),
+    }
+}
+
+/// The desync the module exists for: a header naming a permitted tool over a
+/// body calling a denied one. Resolving policy from the header would forward
+/// this.
+#[test]
+fn a_header_that_disagrees_with_the_body_is_denied() {
+    let config = config_with(TOOLS_BLOCK);
+    let outcome = decide(
+        route(&config, "mcp"),
+        &mcp_headers("get_weather"),
+        &call("execute_sql"),
+    );
+
+    match outcome {
+        Some(Outcome::Deny { reason, kind }) => {
+            assert_eq!(kind, "mcp_policy");
+            assert!(
+                reason.contains("get_weather") && reason.contains("execute_sql"),
+                "reason should name both sides, got: {reason}"
+            );
+        }
+        other => panic!("expected Deny, got {other:?}"),
+    }
+}
+
+/// A revision predating mandatory header/body agreement is refused by default,
+/// or the check is optional at the caller's discretion.
+#[test]
+fn an_unvalidated_protocol_version_is_denied_by_default() {
+    let config = config_with(TOOLS_BLOCK);
+    let mut headers = mcp_headers("get_weather");
+    headers[0].1 = "2025-06-18".to_string();
+
+    let outcome = decide(route(&config, "mcp"), &headers, &call("get_weather"));
+    assert!(
+        matches!(outcome, Some(Outcome::Deny { .. })),
+        "expected Deny, got {outcome:?}"
+    );
+}
+
+/// `require-validated-version #false` has to actually reach the evaluator —
+/// asserting the default would prove nothing about the config boundary.
+#[test]
+fn require_validated_version_false_reaches_the_evaluator() {
+    let config = config_with(
+        r#"
+                mcp {
+                    require-validated-version #false
+                    tools {
+                        allow "get_weather"
+                    }
+                }
+"#,
+    );
+    let mut headers = mcp_headers("get_weather");
+    headers[0].1 = "2025-06-18".to_string();
+
+    let outcome = decide(route(&config, "mcp"), &headers, &call("get_weather"));
+    assert!(
+        matches!(outcome, Some(Outcome::Allow { .. })),
+        "an old revision should be accepted once the check is off, got {outcome:?}"
+    );
+}
+
+/// A body that cannot be parsed cannot be checked against an allowlist, so the
+/// default refuses it.
+#[test]
+fn an_unparseable_body_is_denied_by_default() {
+    let config = config_with(TOOLS_BLOCK);
+    let outcome = decide(
+        route(&config, "mcp"),
+        &mcp_headers("get_weather"),
+        b"this is not json",
+    );
+    assert!(
+        matches!(outcome, Some(Outcome::Deny { .. })),
+        "expected Deny, got {outcome:?}"
+    );
+}
+
+#[test]
+fn on_uninspectable_body_allow_reaches_the_evaluator() {
+    let config = config_with(
+        r#"
+                mcp {
+                    on-uninspectable-body "allow"
+                }
+"#,
+    );
+    let outcome = decide(
+        route(&config, "mcp"),
+        &mcp_headers("get_weather"),
+        b"this is not json",
+    );
+    assert!(
+        matches!(outcome, Some(Outcome::Allow { .. })),
+        "expected Allow once the route opts in, got {outcome:?}"
+    );
+}
+
+/// The common case has to stay free: a route with neither block is not
+/// inspected at all.
+#[test]
+fn a_route_without_an_agentic_block_is_not_evaluated() {
+    let config = config_with(TOOLS_BLOCK);
+    let outcome = decide(
+        route(&config, "plain"),
+        &mcp_headers("anything"),
+        &call("anything"),
+    );
+    assert_eq!(outcome, None);
+}
+
+// ============================================================================
+// A2A
+// ============================================================================
+
+fn a2a_config(block: &str) -> Config {
+    config_with(block)
+}
+
+fn a2a_call(method: &str) -> Vec<u8> {
+    format!(r#"{{"jsonrpc":"2.0","id":1,"method":"{method}"}}"#).into_bytes()
+}
+
+#[test]
+fn a_denied_a2a_method_is_refused_from_config() {
+    let config = a2a_config(
+        r#"
+                a2a {
+                    methods {
+                        deny "SendMessage"
+                    }
+                }
+"#,
+    );
+    let outcome = decide(route(&config, "mcp"), &[], &a2a_call("SendMessage"));
+
+    match outcome {
+        Some(Outcome::Deny { reason, kind }) => {
+            assert_eq!(kind, "a2a_policy");
+            assert!(reason.contains("SendMessage"), "got: {reason}");
+        }
+        other => panic!("expected Deny, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_permitted_a2a_method_reports_what_the_body_said() {
+    let config = a2a_config(
+        r#"
+                a2a {
+                    methods {
+                        deny "SendMessage"
+                    }
+                }
+"#,
+    );
+    let outcome = decide(route(&config, "mcp"), &[], &a2a_call("GetTask"));
+
+    match outcome {
+        Some(Outcome::Allow { a2a_method, .. }) => {
+            assert_eq!(a2a_method.as_deref(), Some("GetTask"));
+        }
+        other => panic!("expected Allow, got {other:?}"),
+    }
+}
+
+/// A2A is young; refusing every method added after this proxy was built would
+/// make it an obstacle to upgrading agents. The default forwards them.
+#[test]
+fn unknown_a2a_methods_are_forwarded_by_default() {
+    let config = a2a_config(
+        r#"
+                a2a {
+                    methods {
+                        deny "SendMessage"
+                    }
+                }
+"#,
+    );
+    let outcome = decide(route(&config, "mcp"), &[], &a2a_call("SomeFutureMethod"));
+    assert!(
+        matches!(outcome, Some(Outcome::Allow { .. })),
+        "expected Allow, got {outcome:?}"
+    );
+}
+
+#[test]
+fn unknown_methods_deny_reaches_the_evaluator() {
+    let config = a2a_config(
+        r#"
+                a2a {
+                    unknown-methods "deny"
+                }
+"#,
+    );
+    let outcome = decide(route(&config, "mcp"), &[], &a2a_call("SomeFutureMethod"));
+    assert!(
+        matches!(outcome, Some(Outcome::Deny { .. })),
+        "expected Deny once the route opts in, got {outcome:?}"
+    );
+}


### PR DESCRIPTION
`RouteConfig::mcp` and `RouteConfig::a2a` were parsed, validated, had unknown
keys rejected — and read by nothing. The agentic module's only appearance
outside itself was `pub mod agentic;` in `lib.rs`. There was **no call site**
for `mcp::evaluate` or `a2a::evaluate` anywhere in the request path.

So this permitted every tool there is:

```kdl
mcp {
    tools { allow "get_weather" }
}
```

Shipped that way in **0.6.27**, and documented as working in
`content/configuration/agentic.md`.

This is the defect the module was written to prevent, one layer up: the
configuration says a control is enforced, and it is not.

## What changed

Enforcement runs in `request_body_filter`. Policy resolves from the JSON-RPC
envelope, so the body is accumulated across chunks and judged **once**, at end
of stream — never on a partial envelope, and before anything reaches an
upstream.

Accumulation stops at `jsonrpc::MAX_ENVELOPE_BYTES`. Past that the body is
uninspectable and the route's `on-uninspectable-body` setting decides, rather
than a truncated prefix being judged as though it were the whole request.

A denial returns **403** with the operator-readable reason. An allowed request
records the method and tool resolved **from the body**, so metrics and audit
describe what the upstream will execute rather than what a header claimed.

## Why 73 tests did not catch it

Every one of them builds a `Policy` by hand and calls `evaluate()`. **A test
that constructs the object under test cannot notice that nothing constructs it
in production.** That is the same shape as three other defects found this month:
the #128 lint rule (set the struct field directly), `accepts_valid_auth_token`
(never sent a wrong token), and the simulator's circuit breaker (called
`CircuitBreaker::new` and never `init_from_config`).

So policy is now a function of `RouteConfig` rather than of an
already-converted `Policy`, and `tests/agentic_policy_test.rs` drives it from
KDL:

```
parse → RouteConfig → Policy → Outcome
```

12 tests across that path. Every setting is asserted against a value that
**differs from its default** — `require-validated-version #false`,
`on-uninspectable-body "allow"`, `unknown-methods "deny"` — because three bugs
this month hid behind defaults that happened to match.

## A gap I could not close

**Nothing automatically proves `request_body_filter` still calls the helper.**

I expected `dead_code` to fire if the call were deleted, so I tested it:
commented out the call, forced a rebuild, ran `clippy -D warnings`. It does not
fire. I am not claiming a guard I could not demonstrate.

Closing this needs a test that issues a real request through a running proxy.
No harness here supports that today — `tls_handshake_test.rs` comes closest but
builds the TLS objects directly rather than booting the proxy. Worth doing;
larger than this fix.

## Verified

`cargo clippy --workspace --all-targets --all-features -D warnings` clean, fmt
clean, **679 proxy lib tests** and **12 new integration tests** pass.

## Follow-up

The docs and the published blog post both describe this as working, and have
since 0.6.27. They are accurate as of this PR, but were not before it — worth
deciding whether that warrants a note.
