### PR TITLE
chore: bump workspace version to 0.6.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8182,7 +8182,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8223,7 +8223,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8245,7 +8245,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8324,7 +8324,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8505,7 +8505,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8596,7 +8596,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8613,7 +8613,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.27"
+version = "0.6.28"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/config-inspect/Cargo.lock
+++ b/crates/config-inspect/Cargo.lock
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config-inspect"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "insta",

--- a/crates/config-inspect/Cargo.toml
+++ b/crates/config-inspect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-config-inspect"
-version = "0.6.27"
+version = "0.6.28"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/playground-wasm/Cargo.lock
+++ b/crates/playground-wasm/Cargo.lock
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config-inspect"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "serde",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-playground-wasm"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "console_error_panic_hook",
  "serde",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-sim"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "regex",
  "serde",

--- a/crates/playground-wasm/Cargo.toml
+++ b/crates/playground-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-playground-wasm"
-version = "0.6.27"
+version = "0.6.28"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/sim/Cargo.lock
+++ b/crates/sim/Cargo.lock
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-sim"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "insta",
  "proptest",

--- a/crates/sim/Cargo.toml
+++ b/crates/sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-sim"
-version = "0.6.27"
+version = "0.6.28"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Post-release bump following `26.08_5`.

The Release workflow publishes the tag version **+1**, so `26.08_5` shipped
crate version **0.6.28**. Main is left at `0.6.27` because the workflow's direct
push is blocked by branch protection — and its `gh pr create` has now failed six
consecutive releases, so this PR is opened by hand as usual.

## Verified on crates.io

All four published crates at `0.6.28`, checked against the registry API rather
than the workflow's own status:

| Crate | Version |
|---|---|
| `zentinel-common` | 0.6.28 |
| `zentinel-config` | 0.6.28 |
| `zentinel-agent-protocol` | 0.6.28 |
| `zentinel-proxy` | 0.6.28 |

And the dependency fix this release exists for, confirmed in the published
metadata:

```
zentinel-proxy 0.6.28 → zentinel-pingora-core ^0.8.1
zentinel-proxy 0.6.27 → pingora-core ^0.8.1          ← would not compile
```

## Contents

- Four manifests bumped 0.6.27 → 0.6.28 (workflow commit)
- Four `Cargo.lock` files, same bump — 18 version lines, nothing else

The workflow bumps manifests only; without the lockfiles the two disagree and
`--locked` builds fail.

Note the bump reached `crates/sim`, `config-inspect` and `playground-wasm` this
time. That is a side effect of #390 aligning their versions with the workspace —
previously they drifted (sim was 0.6.8, the other two 0.5.4) because nothing
bumped them.

The workflow's branch was safe to reuse here: its parent is exactly
`origin/main`, so nothing would be reverted. That is worth checking each time
rather than assuming — `chore/bump-0.6.26` was cut from an older commit and
would have reverted ~7,700 lines.