### PR TITLE
fix(proxy): resolve listeners by local address, not config string

### DIFF
--- a/crates/proxy/src/proxy/http_trait.rs
+++ b/crates/proxy/src/proxy/http_trait.rs
@@ -31,9 +31,20 @@ use crate::routing::RequestInfo;
 use super::context::{FallbackReason, RequestContext};
 use super::fallback::FallbackEvaluator;
 use super::fallback_metrics::get_fallback_metrics;
+use super::listener_addr::listener_for_addr;
 use super::model_routing;
 use super::model_routing_metrics::get_model_routing_metrics;
 use super::ZentinelProxy;
+
+/// The IP socket address behind a Pingora endpoint, if it has one.
+///
+/// Unix-domain listeners carry no `SocketAddr` to resolve against a configured
+/// bind address, so they simply do not match any listener.
+fn to_socket_addr(
+    addr: &pingora::protocols::l4::socket::SocketAddr,
+) -> Option<std::net::SocketAddr> {
+    addr.as_inet().copied()
+}
 
 /// Helper type for rate limiting when we don't need header access
 struct NoHeaderAccessor;
@@ -57,8 +68,11 @@ impl ZentinelProxy {
         if matchers.is_empty() {
             return None;
         }
-        let addr = session.downstream_session.server_addr()?.to_string();
-        matchers.get(&addr).cloned()
+        // `server_addr()` is `getsockname()` on the accepted connection, so a
+        // wildcard-bound listener reports the concrete interface here and never
+        // the configured `0.0.0.0`. The lookup resolves that.
+        let addr = to_socket_addr(session.downstream_session.server_addr()?)?;
+        matchers.get(addr).cloned()
     }
 }
 
@@ -899,22 +913,26 @@ impl ProxyHttp for ZentinelProxy {
             "Starting request filter phase"
         );
 
-        // Apply per-listener timeouts from config
-        if let Some(server_addr) = session.downstream_session.server_addr() {
-            let server_addr_str = server_addr.to_string();
+        // Apply per-listener timeouts from config. Resolved against the local
+        // address the same way namespace matchers are, so these reach
+        // wildcard-bound listeners too.
+        if let Some(local_addr) = session
+            .downstream_session
+            .server_addr()
+            .and_then(to_socket_addr)
+        {
             let config = ctx
                 .config
                 .get_or_insert_with(|| self.config_manager.current());
-            for listener in &config.listeners {
-                if listener.address == server_addr_str {
-                    // Apply downstream read timeout
-                    session.downstream_session.set_read_timeout(Some(
-                        std::time::Duration::from_secs(listener.request_timeout_secs),
-                    ));
-                    // Store keepalive for response phase
-                    ctx.listener_keepalive_timeout_secs = Some(listener.keepalive_timeout_secs);
-                    break;
-                }
+            if let Some(listener) = listener_for_addr(&config.listeners, local_addr) {
+                let request_timeout_secs = listener.request_timeout_secs;
+                let keepalive_timeout_secs = listener.keepalive_timeout_secs;
+                // Apply downstream read timeout
+                session
+                    .downstream_session
+                    .set_read_timeout(Some(std::time::Duration::from_secs(request_timeout_secs)));
+                // Store keepalive for response phase
+                ctx.listener_keepalive_timeout_secs = Some(keepalive_timeout_secs);
             }
         }
 

--- a/crates/proxy/src/proxy/listener_addr.rs
+++ b/crates/proxy/src/proxy/listener_addr.rs
@@ -1,0 +1,298 @@
+//! Matching an accepted connection back to the listener that configured it.
+//!
+//! Listeners are configured by bind address (`0.0.0.0:443`, `127.0.0.1:9000`).
+//! At request time all we have is the accepted connection's local address, which
+//! Pingora reports from `getsockname()`. Those two are *not* interchangeable: a
+//! connection accepted on a wildcard bind reports the concrete interface it
+//! landed on (`203.0.113.5:443`), never `0.0.0.0:443`. Comparing the configured
+//! string against the local address therefore silently never matches for
+//! wildcard binds, which is how per-listener settings came to be ignored on
+//! exactly the listeners that face the internet.
+//!
+//! Everything here works on parsed [`SocketAddr`]s rather than strings.
+//! `ListenerConfig::address` is validated as a `SocketAddr` at load time
+//! (`validate_socket_addr`), so parsing is total for any config that passed
+//! validation.
+
+use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+
+use zentinel_config::ListenerConfig;
+
+use crate::routing::RouteMatcher;
+
+/// Collapse an IPv4-mapped IPv6 address (`::ffff:a.b.c.d`) to its IPv4 form.
+///
+/// A dual-stack `[::]` bind reports IPv4 peers in mapped form, so without this
+/// the same connection compares unequal depending on which family the socket
+/// was opened with.
+fn canonical_ip(ip: IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => IpAddr::V4(v4),
+            None => IpAddr::V6(v6),
+        },
+        v4 => v4,
+    }
+}
+
+/// [`canonical_ip`] applied to a whole socket address.
+fn canonical_addr(addr: SocketAddr) -> SocketAddr {
+    SocketAddr::new(canonical_ip(addr.ip()), addr.port())
+}
+
+/// Whether a connection with local address `local` arrived on a listener bound
+/// to `configured`.
+///
+/// Exact addresses compare by equality. A wildcard bind matches any local
+/// address on the same port, restricted to the families that bind can actually
+/// accept: `0.0.0.0` is an `AF_INET` socket and only ever sees IPv4, while
+/// `[::]` is dual-stack on every platform we support and sees both.
+pub(crate) fn listener_addr_matches(configured: SocketAddr, local: SocketAddr) -> bool {
+    if configured.port() != local.port() {
+        return false;
+    }
+
+    let cfg_ip = canonical_ip(configured.ip());
+    let local_ip = canonical_ip(local.ip());
+
+    if cfg_ip == local_ip {
+        return true;
+    }
+
+    match cfg_ip {
+        IpAddr::V6(v6) if v6.is_unspecified() => true,
+        IpAddr::V4(v4) if v4.is_unspecified() => local_ip.is_ipv4(),
+        _ => false,
+    }
+}
+
+/// The listener a connection with local address `local` arrived on.
+///
+/// Concrete binds take precedence over wildcard binds on the same port, so a
+/// config that pairs `127.0.0.1:8080` with `0.0.0.0:8080` resolves loopback
+/// traffic to the specific listener. Listeners whose address does not parse are
+/// skipped rather than panicking; validation rejects those at load time, so this
+/// only guards a config that bypassed it.
+pub(crate) fn listener_for_addr(
+    listeners: &[ListenerConfig],
+    local: SocketAddr,
+) -> Option<&ListenerConfig> {
+    let mut wildcard = None;
+
+    for listener in listeners {
+        let Ok(configured) = listener.address.parse::<SocketAddr>() else {
+            continue;
+        };
+        if !listener_addr_matches(configured, local) {
+            continue;
+        }
+        if configured.ip().is_unspecified() {
+            wildcard.get_or_insert(listener);
+        } else {
+            return Some(listener);
+        }
+    }
+
+    wildcard
+}
+
+/// Namespace route matchers indexed by the listener they belong to.
+///
+/// Split by bind kind so the common case stays a hash lookup: concrete binds
+/// resolve in `exact`, and only a miss falls through to the wildcard scan, which
+/// is bounded by the number of wildcard-bound namespaced listeners (typically
+/// one or two).
+#[derive(Default)]
+pub(crate) struct ListenerMatchers {
+    /// Concrete binds, keyed by canonicalized address.
+    exact: HashMap<SocketAddr, Arc<RouteMatcher>>,
+    /// Wildcard binds, in config order. No `getsockname()` result ever equals
+    /// one of these, so they can only be resolved by [`listener_addr_matches`].
+    wildcard: Vec<(SocketAddr, Arc<RouteMatcher>)>,
+}
+
+impl ListenerMatchers {
+    /// Register `matcher` for the listener bound to `address`.
+    ///
+    /// Returns `false` if `address` does not parse, in which case nothing is
+    /// registered.
+    pub(crate) fn insert(&mut self, address: &str, matcher: Arc<RouteMatcher>) -> bool {
+        let Ok(addr) = address.parse::<SocketAddr>() else {
+            return false;
+        };
+        if addr.ip().is_unspecified() {
+            self.wildcard.push((addr, matcher));
+        } else {
+            self.exact.insert(canonical_addr(addr), matcher);
+        }
+        true
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.exact.is_empty() && self.wildcard.is_empty()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.exact.len() + self.wildcard.len()
+    }
+
+    /// Matcher for a connection whose local address is `local`, if its listener
+    /// is bound to a namespace route set.
+    ///
+    /// Concrete binds win over wildcard binds on the same port.
+    pub(crate) fn get(&self, local: SocketAddr) -> Option<&Arc<RouteMatcher>> {
+        if let Some(matcher) = self.exact.get(&canonical_addr(local)) {
+            return Some(matcher);
+        }
+        self.wildcard
+            .iter()
+            .find(|(configured, _)| listener_addr_matches(*configured, local))
+            .map(|(_, matcher)| matcher)
+    }
+
+    /// Whether a listener bound to `address` is registered. Test/introspection
+    /// helper: this compares the *configured* address, not a local address.
+    #[cfg(test)]
+    pub(crate) fn contains_configured(&self, address: &str) -> bool {
+        let Ok(addr) = address.parse::<SocketAddr>() else {
+            return false;
+        };
+        if addr.ip().is_unspecified() {
+            self.wildcard.iter().any(|(cfg, _)| *cfg == addr)
+        } else {
+            self.exact.contains_key(&canonical_addr(addr))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(s: &str) -> SocketAddr {
+        s.parse().expect("test address parses")
+    }
+
+    #[test]
+    fn concrete_bind_matches_only_itself() {
+        assert!(listener_addr_matches(
+            addr("127.0.0.1:9000"),
+            addr("127.0.0.1:9000")
+        ));
+        assert!(!listener_addr_matches(
+            addr("127.0.0.1:9000"),
+            addr("203.0.113.5:9000")
+        ));
+    }
+
+    #[test]
+    fn port_must_always_agree() {
+        assert!(!listener_addr_matches(
+            addr("0.0.0.0:443"),
+            addr("203.0.113.5:8443")
+        ));
+        assert!(!listener_addr_matches(addr("[::]:443"), addr("[::1]:8443")));
+    }
+
+    /// The regression: a `0.0.0.0` bind is reported by `getsockname()` as the
+    /// concrete interface the connection landed on.
+    #[test]
+    fn ipv4_wildcard_matches_any_ipv4_local_addr() {
+        for local in ["203.0.113.5:443", "127.0.0.1:443", "10.0.0.7:443"] {
+            assert!(
+                listener_addr_matches(addr("0.0.0.0:443"), addr(local)),
+                "0.0.0.0:443 should match {local}"
+            );
+        }
+    }
+
+    #[test]
+    fn ipv4_wildcard_does_not_match_ipv6_local_addr() {
+        assert!(!listener_addr_matches(
+            addr("0.0.0.0:443"),
+            addr("[2001:db8::1]:443")
+        ));
+    }
+
+    #[test]
+    fn ipv6_wildcard_is_dual_stack() {
+        assert!(listener_addr_matches(
+            addr("[::]:443"),
+            addr("[2001:db8::1]:443")
+        ));
+        // Dual-stack sockets report IPv4 peers in mapped form...
+        assert!(listener_addr_matches(
+            addr("[::]:443"),
+            addr("[::ffff:203.0.113.5]:443")
+        ));
+        // ...and plain IPv4 must resolve identically.
+        assert!(listener_addr_matches(
+            addr("[::]:443"),
+            addr("203.0.113.5:443")
+        ));
+    }
+
+    #[test]
+    fn ipv4_mapped_local_addr_resolves_to_concrete_ipv4_bind() {
+        assert!(listener_addr_matches(
+            addr("203.0.113.5:443"),
+            addr("[::ffff:203.0.113.5]:443")
+        ));
+    }
+
+    #[test]
+    fn concrete_listener_wins_over_wildcard_on_same_port() {
+        let listeners = vec![
+            listener("public", "0.0.0.0:8080"),
+            listener("admin", "127.0.0.1:8080"),
+        ];
+        assert_eq!(
+            listener_for_addr(&listeners, addr("127.0.0.1:8080")).map(|l| l.id.as_str()),
+            Some("admin")
+        );
+        assert_eq!(
+            listener_for_addr(&listeners, addr("203.0.113.5:8080")).map(|l| l.id.as_str()),
+            Some("public")
+        );
+    }
+
+    #[test]
+    fn no_listener_on_that_port_resolves_to_none() {
+        let listeners = vec![listener("public", "0.0.0.0:8080")];
+        assert!(listener_for_addr(&listeners, addr("203.0.113.5:9999")).is_none());
+    }
+
+    /// Validation rejects these at load time; the guard exists so a config that
+    /// reached us another way degrades to "no match" instead of panicking.
+    #[test]
+    fn unparseable_address_is_skipped_not_panicked() {
+        let mut broken = listener("broken", "127.0.0.1:8080");
+        broken.address = "not-an-address".to_string();
+        assert!(listener_for_addr(&[broken], addr("127.0.0.1:8080")).is_none());
+    }
+
+    fn listener(id: &str, address: &str) -> ListenerConfig {
+        let kdl = format!(
+            r#"
+            schema-version "1.0"
+            system {{ worker-threads 0 }}
+            listeners {{
+                listener "{id}" {{ address "{address}" }}
+            }}
+            routes {{
+                route "r" {{
+                    matches {{ path "/" }}
+                    service-type "builtin"
+                    builtin-handler "health"
+                }}
+            }}
+            "#
+        );
+        zentinel_config::Config::from_kdl(&kdl)
+            .expect("config parses")
+            .listeners
+            .remove(0)
+    }
+}

--- a/crates/proxy/src/proxy/mod.rs
+++ b/crates/proxy/src/proxy/mod.rs
@@ -13,6 +13,7 @@ mod fallback_metrics;
 pub(crate) mod filters;
 mod handlers;
 mod http_trait;
+mod listener_addr;
 mod model_routing;
 mod model_routing_metrics;
 
@@ -53,10 +54,12 @@ use crate::reload::{
     ConfigManager, GracefulReloadCoordinator, ReloadEvent, RouteValidator, UpstreamValidator,
 };
 use crate::routing::RouteMatcher;
+
 use crate::scoped_routing::ScopedRouteMatcher;
 use crate::static_files::StaticFileServer;
 use crate::upstream::{ActiveHealthChecker, HealthCheckRunner, UpstreamPool};
 use crate::validation::SchemaValidator;
+use listener_addr::ListenerMatchers;
 
 use zentinel_common::TraceIdFormat;
 use zentinel_config::{Config, FlattenedConfig};
@@ -68,10 +71,11 @@ pub struct ZentinelProxy {
     /// Route matcher (global routes only, for backward compatibility)
     pub(super) route_matcher: Arc<RwLock<RouteMatcher>>,
     /// Per-listener route matchers for listeners bound to a namespace route set,
-    /// keyed by the listener's bound address. A request arriving on one of these
-    /// listeners is matched only against its namespace's routes (isolated from
-    /// the global set). Listeners absent from this map use [`Self::route_matcher`].
-    pub(super) listener_matchers: Arc<RwLock<HashMap<String, Arc<RouteMatcher>>>>,
+    /// resolved from the accepted connection's local address. A request arriving
+    /// on one of these listeners is matched only against its namespace's routes
+    /// (isolated from the global set). Listeners absent from this map use
+    /// [`Self::route_matcher`].
+    pub(super) listener_matchers: Arc<RwLock<ListenerMatchers>>,
     /// Scoped route matcher (namespace/service aware)
     pub(super) scoped_route_matcher: Arc<tokio::sync::RwLock<ScopedRouteMatcher>>,
     /// Upstream pools (keyed by upstream ID, global only)
@@ -398,10 +402,8 @@ impl ZentinelProxy {
     /// the global matcher at request time). Unknown namespace references are
     /// skipped with a warning — config validation rejects them before startup,
     /// so this only guards against a reload racing a bad config.
-    fn build_listener_matchers(
-        config: &zentinel_config::Config,
-    ) -> HashMap<String, Arc<RouteMatcher>> {
-        let mut matchers = HashMap::new();
+    fn build_listener_matchers(config: &zentinel_config::Config) -> ListenerMatchers {
+        let mut matchers = ListenerMatchers::default();
         for listener in &config.listeners {
             let Some(ns_id) = listener.namespace.as_ref() else {
                 continue;
@@ -427,7 +429,13 @@ impl ZentinelProxy {
                         routes = ns.routes.len(),
                         "Listener bound to namespace route set"
                     );
-                    matchers.insert(listener.address.clone(), Arc::new(matcher));
+                    if !matchers.insert(&listener.address, Arc::new(matcher)) {
+                        error!(
+                            listener_id = %listener.id,
+                            address = %listener.address,
+                            "Listener address is not a socket address; namespace routes                              will not be served on it"
+                        );
+                    }
                 }
                 Err(e) => {
                     error!(
@@ -446,7 +454,7 @@ impl ZentinelProxy {
     async fn setup_reload_handler(
         config_manager: Arc<ConfigManager>,
         route_matcher: Arc<RwLock<RouteMatcher>>,
-        listener_matchers: Arc<RwLock<HashMap<String, Arc<RouteMatcher>>>>,
+        listener_matchers: Arc<RwLock<ListenerMatchers>>,
         upstream_pools: Registry<UpstreamPool>,
         scoped_route_matcher: Arc<tokio::sync::RwLock<ScopedRouteMatcher>>,
         scoped_upstream_pools: ScopedRegistry<UpstreamPool>,
@@ -998,6 +1006,11 @@ impl ZentinelProxy {
 mod listener_matcher_tests {
     use super::*;
     use crate::routing::RequestInfo;
+    use std::net::SocketAddr;
+
+    fn local(s: &str) -> SocketAddr {
+        s.parse().expect("test address parses")
+    }
 
     const KDL: &str = r#"
         schema-version "1.0"
@@ -1036,9 +1049,9 @@ mod listener_matcher_tests {
 
         // Only the namespace-bound listener gets a dedicated matcher.
         assert_eq!(matchers.len(), 1);
-        assert!(!matchers.contains_key("0.0.0.0:8080"));
+        assert!(!matchers.contains_configured("0.0.0.0:8080"));
         let admin = matchers
-            .get("127.0.0.1:9000")
+            .get(local("127.0.0.1:9000"))
             .expect("admin listener bound to namespace");
 
         // Isolated: the admin listener serves the namespace route...
@@ -1076,5 +1089,107 @@ mod listener_matcher_tests {
         let config = zentinel_config::Config::from_kdl(kdl).expect("config parses");
         let matchers = ZentinelProxy::build_listener_matchers(&config);
         assert!(matchers.is_empty());
+    }
+
+    /// A namespaced listener bound to `0.0.0.0` used to be unreachable: the
+    /// matcher was stored under the configured `0.0.0.0:8080`, but a connection
+    /// accepted on that bind reports the concrete interface from
+    /// `getsockname()`, so the lookup always missed and the request silently
+    /// fell back to the *global* route set.
+    const WILDCARD_KDL: &str = r#"
+        schema-version "1.0"
+        system { worker-threads 0 }
+        listeners {
+            listener "public" {
+                address "0.0.0.0:8080"
+                namespace "iso"
+            }
+        }
+        routes {
+            route "global-secret" {
+                matches { path "/secret" }
+                service-type "builtin"
+                builtin-handler "config"
+            }
+        }
+        namespace "iso" {
+            routes {
+                route "only" {
+                    matches { path "/ok" }
+                    service-type "builtin"
+                    builtin-handler "health"
+                }
+            }
+        }
+    "#;
+
+    #[test]
+    fn wildcard_bound_namespace_listener_resolves_from_concrete_local_addr() {
+        let config = zentinel_config::Config::from_kdl(WILDCARD_KDL).expect("config parses");
+        let matchers = ZentinelProxy::build_listener_matchers(&config);
+
+        // Every interface a `0.0.0.0` bind can accept on must resolve.
+        for arrival in ["127.0.0.1:8080", "203.0.113.5:8080", "10.0.0.7:8080"] {
+            let matcher = matchers
+                .get(local(arrival))
+                .unwrap_or_else(|| panic!("no matcher for connection arriving on {arrival}"));
+
+            // The namespace route is live...
+            assert!(
+                matcher
+                    .match_request(&RequestInfo::new("GET", "/ok", "x"))
+                    .is_some(),
+                "namespace route should match on {arrival}"
+            );
+            // ...and the global route stays out of reach, which is the
+            // isolation guarantee `namespace` is documented to provide.
+            assert!(
+                matcher
+                    .match_request(&RequestInfo::new("GET", "/secret", "x"))
+                    .is_none(),
+                "global route must not leak into namespace on {arrival}"
+            );
+        }
+    }
+
+    #[test]
+    fn wildcard_listener_does_not_capture_other_ports() {
+        let config = zentinel_config::Config::from_kdl(WILDCARD_KDL).expect("config parses");
+        let matchers = ZentinelProxy::build_listener_matchers(&config);
+        assert!(matchers.get(local("203.0.113.5:9090")).is_none());
+    }
+
+    /// Per-listener timeouts resolve through the same path, and used to be
+    /// inert on wildcard binds for the same reason.
+    #[test]
+    fn per_listener_timeouts_resolve_on_wildcard_bind() {
+        let kdl = r#"
+            schema-version "1.0"
+            system { worker-threads 0 }
+            listeners {
+                listener "public" {
+                    address "0.0.0.0:8080"
+                    request-timeout-secs 17
+                    keepalive-timeout-secs 23
+                }
+            }
+            routes {
+                route "api" {
+                    matches { path-prefix "/api" }
+                    upstream "backend"
+                }
+            }
+            upstreams {
+                upstream "backend" { target "127.0.0.1:3000" }
+            }
+        "#;
+        let config = zentinel_config::Config::from_kdl(kdl).expect("config parses");
+        let listener =
+            super::listener_addr::listener_for_addr(&config.listeners, local("203.0.113.5:8080"))
+                .expect("wildcard listener resolves from a concrete local address");
+
+        assert_eq!(listener.id, "public");
+        assert_eq!(listener.request_timeout_secs, 17);
+        assert_eq!(listener.keepalive_timeout_secs, 23);
     }
 }


### PR DESCRIPTION
Fixes #396.

## What was broken

A listener's `namespace` binding — and its per-listener `request-timeout-secs` /
`keepalive-timeout-secs` — were silently ignored on any listener bound to a
wildcard address (`0.0.0.0:<port>` / `[::]:<port>`).

Namespace matchers were stored under the **configured** bind address:

```rust
matchers.insert(listener.address.clone(), Arc::new(matcher)); // key: "0.0.0.0:443"
```

but looked up by the accepted connection's **local** address, which Pingora takes
from `getsockname()`:

```rust
let addr = session.downstream_session.server_addr()?.to_string();
matchers.get(&addr).cloned()                                   // key: "203.0.113.5:443"
```

A connection accepted on a wildcard bind always reports the concrete interface it
landed on, never `0.0.0.0:443`, so the lookup could never hit — `listener_matcher_for`
returned `None` and the request fell through to the **global** route set. The
per-listener timeout loop compared the same two values with `==` and was inert for
exactly the same reason.

The two keys only coincide for concrete binds, which is why a loopback-bound admin
listener behaved correctly and hid this.

`namespace` is an isolation control, so the failure direction is the bad one: a
wildcard-bound listener believed to serve only its namespace served the entire
global route set instead, with no warning, log line, or validation error.

## The fix

Both call sites now resolve through a new `proxy::listener_addr` module that matches
on parsed `SocketAddr`s rather than strings:

- exact binds compare by equality;
- wildcard binds match any local address on the same port, restricted to the families
  that bind can actually accept (`0.0.0.0` is `AF_INET` and only ever sees IPv4;
  `[::]` is dual-stack and sees both);
- `::ffff:a.b.c.d` mapped addresses are canonicalised, so a dual-stack bind resolves
  IPv4 and IPv6 connections identically;
- concrete binds take precedence over wildcard binds on the same port.

`ListenerConfig::address` is validated as a `SocketAddr` at load time, so the parse
is total for any config that passed validation; an unparseable address degrades to
"no match" rather than panicking.

`ListenerMatchers` keeps concrete binds in a `HashMap` for an O(1) hit and only falls
through to a scan of wildcard binds on a miss — that list is the number of
wildcard-bound *namespaced* listeners, typically one.

## Verification

The reporter's repro, run against this build:

```
GET /ok      -> 200   (namespace route live;      was 404)
GET /secret  -> 404   (global route isolated;     was 200 + full config dump)
```

Tests added:

- `wildcard_bound_namespace_listener_resolves_from_concrete_local_addr` — asserts the
  namespace route resolves *and* that the global route stays out of reach, across
  three different arrival interfaces.
- `per_listener_timeouts_resolve_on_wildcard_bind` — covers the second call site.
- `wildcard_listener_does_not_capture_other_ports`.
- Unit tests for the address matcher: family restrictions, dual-stack, v4-mapped,
  port disagreement, concrete-wins-over-wildcard precedence.

`cargo test -p zentinel-proxy` green (698 unit + integration), `clippy -D warnings`
and `fmt --check` clean.

## Note for the reporter

The repro in the issue writes the listener on one line:

```kdl
listener "public" { address "0.0.0.0:8080" namespace "iso" }
```

In KDL that parses as a single `address` node with three arguments, so `namespace` is
dropped before it ever reaches this code — and `test`, `lint` and startup all report
success. Splitting the two onto separate lines is required for the repro to exercise
the bug. That silent-drop behaviour is tracked separately in #365; I've added this as
a concrete instance there.