### PR TITLE
feat(tls): log what a certificate reload actually changed

### DIFF
--- a/crates/proxy/src/tls.rs
+++ b/crates/proxy/src/tls.rs
@@ -60,7 +60,7 @@
 //! }
 //! ```
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::File;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
@@ -127,7 +127,99 @@ pub struct SniResolver {
     wildcard_certs: HashMap<String, Arc<CertifiedKey>>,
 }
 
+/// The name used for the default certificate in reload diffs.
+///
+/// It has no SNI hostname of its own but is what an unmatched name is served,
+/// so a silent rotation of it would be exactly as invisible as any other.
+const DEFAULT_CERT_LABEL: &str = "<default>";
+
+/// SHA-256 of a leaf certificate's DER encoding, as lowercase hex.
+///
+/// This is the same digest `openssl x509 -fingerprint -sha256 -noout` prints, so
+/// a fingerprint in the log can be matched against a file on disk without
+/// guesswork. Truncated to 16 hex characters: enough to distinguish the
+/// certificates on one listener, short enough to stay readable in a log line.
+fn cert_fingerprint(cert: &CertifiedKey) -> String {
+    use sha2::{Digest, Sha256};
+
+    let Some(leaf) = cert.cert.first() else {
+        return "unknown".to_string();
+    };
+    let digest = Sha256::digest(leaf.as_ref());
+    digest.iter().take(8).map(|b| format!("{b:02x}")).collect()
+}
+
+/// What a reload actually changed, in terms an operator can act on.
+///
+/// Counts alone cannot answer "did anything change?": the common case is a
+/// renewal, where a certificate is replaced by one covering the same names and
+/// every count stays identical. `replaced` is what makes that visible.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct CertDiff {
+    /// Hostnames served now that were not served before.
+    pub added: Vec<String>,
+    /// Hostnames no longer served.
+    pub removed: Vec<String>,
+    /// Hostnames still served, but by a different certificate — i.e. a renewal.
+    pub replaced: Vec<String>,
+}
+
+impl CertDiff {
+    /// Whether the reload was a no-op as far as served certificates go.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.added.is_empty() && self.removed.is_empty() && self.replaced.is_empty()
+    }
+
+    /// Compute the diff between two snapshots of `hostname -> fingerprint`.
+    fn between(before: &BTreeMap<String, String>, after: &BTreeMap<String, String>) -> Self {
+        let mut diff = Self::default();
+
+        for (hostname, new_fp) in after {
+            match before.get(hostname) {
+                None => diff.added.push(hostname.clone()),
+                Some(old_fp) if old_fp != new_fp => {
+                    diff.replaced
+                        .push(format!("{hostname} ({old_fp}->{new_fp})"));
+                }
+                Some(_) => {}
+            }
+        }
+        for hostname in before.keys() {
+            if !after.contains_key(hostname) {
+                diff.removed.push(hostname.clone());
+            }
+        }
+
+        diff
+    }
+
+    /// Render one field of the diff for logging, or `-` when it is empty.
+    fn render(names: &[String]) -> String {
+        if names.is_empty() {
+            "-".to_string()
+        } else {
+            names.join(", ")
+        }
+    }
+}
+
 impl SniResolver {
+    /// Every hostname this resolver serves, mapped to its certificate
+    /// fingerprint.
+    ///
+    /// Built on demand at reload time only, so the hot path pays nothing for it.
+    pub fn served_certs(&self) -> BTreeMap<String, String> {
+        let mut served = BTreeMap::new();
+        served.insert(
+            DEFAULT_CERT_LABEL.to_string(),
+            cert_fingerprint(&self.default_cert),
+        );
+        for (hostname, cert) in self.sni_certs.iter().chain(self.wildcard_certs.iter()) {
+            served.insert(hostname.clone(), cert_fingerprint(cert));
+        }
+        served
+    }
+
     /// Create a new SNI resolver from TLS configuration
     pub fn from_config(config: &TlsConfig, listener_id: Option<&str>) -> Result<Self, TlsError> {
         let listener_id_str = listener_id.unwrap_or("unknown");
@@ -564,14 +656,33 @@ impl HotReloadableSniResolver {
             }
         };
 
+        // Snapshot both sides before the swap. With `reload-mode "watch"` the
+        // reload is unattended by design, so this log line is the only record an
+        // operator has of what a rescan actually did.
+        let before = self.inner.read().served_certs();
+        let after = new_resolver.served_certs();
+        let diff = CertDiff::between(&before, &after);
+
         // Swap in the new resolver atomically
         *self.inner.write() = Arc::new(new_resolver);
         *self.last_reload.write() = Instant::now();
 
-        info!(
-            listener_id = %self.listener_id,
-            "TLS certificates reloaded successfully"
-        );
+        if diff.is_empty() {
+            info!(
+                listener_id = %self.listener_id,
+                hostnames = after.len(),
+                "TLS certificates reloaded successfully; no change to served certificates"
+            );
+        } else {
+            info!(
+                listener_id = %self.listener_id,
+                hostnames = after.len(),
+                added = %CertDiff::render(&diff.added),
+                removed = %CertDiff::render(&diff.removed),
+                replaced = %CertDiff::render(&diff.replaced),
+                "TLS certificates reloaded successfully"
+            );
+        }
         if let Some(metrics) = crate::tls_metrics::get_tls_metrics() {
             metrics.record_reload(&self.listener_id, true);
         }
@@ -1924,5 +2035,91 @@ mod tests {
         let hostname = "Example.COM";
         let normalized = hostname.to_lowercase();
         assert_eq!(normalized, "example.com");
+    }
+}
+
+#[cfg(test)]
+mod cert_diff_tests {
+    use super::*;
+
+    fn snapshot(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(h, f)| (h.to_string(), f.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn an_unchanged_folder_reports_no_change() {
+        let before = snapshot(&[("<default>", "aa"), ("a.test", "bb")]);
+        let diff = CertDiff::between(&before, &before);
+        assert!(diff.is_empty());
+    }
+
+    #[test]
+    fn a_new_certificate_is_reported_as_added() {
+        let before = snapshot(&[("a.test", "aa")]);
+        let after = snapshot(&[("a.test", "aa"), ("b.test", "bb")]);
+        let diff = CertDiff::between(&before, &after);
+        assert_eq!(diff.added, vec!["b.test".to_string()]);
+        assert!(diff.removed.is_empty());
+        assert!(diff.replaced.is_empty());
+    }
+
+    #[test]
+    fn a_deleted_certificate_is_reported_as_removed() {
+        let before = snapshot(&[("a.test", "aa"), ("b.test", "bb")]);
+        let after = snapshot(&[("a.test", "aa")]);
+        let diff = CertDiff::between(&before, &after);
+        assert_eq!(diff.removed, vec!["b.test".to_string()]);
+        assert!(diff.added.is_empty());
+        assert!(diff.replaced.is_empty());
+    }
+
+    /// The case the counts cannot see, and the reason this diff exists: a
+    /// renewal swaps the certificate while every hostname and every count stays
+    /// exactly the same.
+    #[test]
+    fn a_renewal_for_the_same_hostname_is_reported_as_replaced() {
+        let before = snapshot(&[("a.test", "old00000")]);
+        let after = snapshot(&[("a.test", "new11111")]);
+        let diff = CertDiff::between(&before, &after);
+
+        assert!(diff.added.is_empty(), "hostname set is unchanged");
+        assert!(diff.removed.is_empty(), "hostname set is unchanged");
+        assert_eq!(
+            diff.replaced,
+            vec!["a.test (old00000->new11111)".to_string()]
+        );
+        assert!(!diff.is_empty(), "a renewal is a change and must be logged");
+    }
+
+    /// A 1-for-1 rotation: one name retired, its replacement added, counts equal
+    /// on both sides.
+    #[test]
+    fn a_one_for_one_rotation_shows_both_sides() {
+        let before = snapshot(&[("<default>", "dd"), ("old.test", "aa")]);
+        let after = snapshot(&[("<default>", "dd"), ("new.test", "bb")]);
+        let diff = CertDiff::between(&before, &after);
+
+        assert_eq!(before.len(), after.len(), "counts alone show nothing");
+        assert_eq!(diff.added, vec!["new.test".to_string()]);
+        assert_eq!(diff.removed, vec!["old.test".to_string()]);
+    }
+
+    #[test]
+    fn rotating_the_default_certificate_is_visible() {
+        let before = snapshot(&[(DEFAULT_CERT_LABEL, "old00000")]);
+        let after = snapshot(&[(DEFAULT_CERT_LABEL, "new11111")]);
+        assert!(!CertDiff::between(&before, &after).is_empty());
+    }
+
+    #[test]
+    fn empty_diff_fields_render_as_a_dash() {
+        assert_eq!(CertDiff::render(&[]), "-");
+        assert_eq!(
+            CertDiff::render(&["a.test".to_string(), "b.test".to_string()]),
+            "a.test, b.test"
+        );
     }
 }

--- a/crates/proxy/tests/tls_cert_folder_test.rs
+++ b/crates/proxy/tests/tls_cert_folder_test.rs
@@ -312,3 +312,100 @@ fn a_reload_picks_up_a_newly_added_certificate() {
         "the reload should have discovered the new certificate"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Reload observability
+//
+// #117 asked for "full rescan + diff + atomic swap on reload". The rescan and
+// the swap shipped; the diff did not, so a reload logged counts and nothing
+// else. Counts cannot answer the question an operator actually has after an
+// unattended `reload-mode "watch"` rescan -- "did anything change?" -- because
+// the most common event, a renewal, leaves every count identical.
+// ---------------------------------------------------------------------------
+
+/// Write a self-signed cert/key pair for `cn` into `dir` under `stem`.
+///
+/// Each call produces a fresh key, so two calls with the same `cn` model a
+/// renewal: same hostname, different certificate.
+fn issue(dir: &Path, stem: &str, cn: &str) {
+    let mut params =
+        rcgen::CertificateParams::new(vec![cn.to_string()]).expect("valid subject alt name");
+    let mut dn = rcgen::DistinguishedName::new();
+    dn.push(rcgen::DnType::CommonName, cn);
+    params.distinguished_name = dn;
+
+    let key = rcgen::KeyPair::generate().expect("keypair");
+    let cert = params.self_signed(&key).expect("self-signed cert");
+
+    fs::write(dir.join(format!("{stem}.crt")), cert.pem()).expect("write cert");
+    fs::write(dir.join(format!("{stem}.key")), key.serialize_pem()).expect("write key");
+}
+
+fn served(dir: &Path) -> std::collections::BTreeMap<String, String> {
+    let mut config = config_with_folder(dir);
+    config.allow_sni_overlaps = true;
+    SniResolver::from_config(&config, Some("folder-test"))
+        .expect("should build")
+        .served_certs()
+}
+
+#[test]
+fn a_renewal_changes_the_fingerprint_for_an_unchanged_hostname() {
+    let dir = tempfile::tempdir().unwrap();
+    issue(dir.path(), "renewme", "renew.example.com");
+    let before = served(dir.path());
+
+    // The renewal an ACME client would perform: same name, same filename, new
+    // certificate written over the old one.
+    issue(dir.path(), "renewme", "renew.example.com");
+    let after = served(dir.path());
+
+    assert_eq!(
+        before.keys().collect::<Vec<_>>(),
+        after.keys().collect::<Vec<_>>(),
+        "a renewal must not change the hostname set -- that is what makes it invisible to counts"
+    );
+    assert_ne!(
+        before.get("renew.example.com"),
+        after.get("renew.example.com"),
+        "the fingerprint must change, or the reload diff cannot see a renewal"
+    );
+}
+
+#[test]
+fn an_untouched_folder_produces_an_identical_snapshot() {
+    let dir = tempfile::tempdir().unwrap();
+    issue(dir.path(), "stable", "stable.example.com");
+
+    assert_eq!(
+        served(dir.path()),
+        served(dir.path()),
+        "rescanning an unchanged folder must not report a change"
+    );
+}
+
+#[test]
+fn adding_and_removing_certificates_moves_the_hostname_set() {
+    let dir = tempfile::tempdir().unwrap();
+    issue(dir.path(), "first", "first.example.com");
+    let before = served(dir.path());
+
+    fs::remove_file(dir.path().join("first.crt")).expect("remove cert");
+    fs::remove_file(dir.path().join("first.key")).expect("remove key");
+    issue(dir.path(), "second", "second.example.com");
+    let after = served(dir.path());
+
+    assert!(before.contains_key("first.example.com"));
+    assert!(!after.contains_key("first.example.com"));
+    assert!(after.contains_key("second.example.com"));
+    // The 1-for-1 rotation from the issue: counts are equal on both sides.
+    assert_eq!(before.len(), after.len());
+}
+
+/// The default certificate has no SNI hostname, so a silent rotation of it
+/// would be exactly as invisible as any other.
+#[test]
+fn the_default_certificate_is_part_of_the_snapshot() {
+    let dir = tempfile::tempdir().unwrap();
+    assert!(served(dir.path()).contains_key("<default>"));
+}


### PR DESCRIPTION
Closes #399. Raised by @DisasteR in
https://github.com/zentinelproxy/zentinel/issues/117#issuecomment-5426592979.

## Why

#117's checklist read "Full rescan + **diff** + atomic swap on reload". The rescan and
the swap shipped; the diff did not.

Counts alone cannot answer *did anything change?*. The most common reload event is a
renewal — a certificate replaced by one covering exactly the same names — where every
count is identical and nothing at `info` records that anything happened. With
`reload-mode "watch"` that reload is unattended by design, so the log is the only
record an operator has.

## What this does

`SniResolver::served_certs` snapshots `hostname -> leaf-certificate fingerprint`, and
`reload` diffs it across the swap, logging **added**, **removed** and **replaced**
hostnames at `info`.

`replaced` is the important one: a pure hostname diff — which is what the original
checklist item literally asked for — would still miss a renewal, because the hostname
set does not move. Comparing certificate identity is what makes it visible.

The fingerprint is SHA-256 of the DER truncated to 16 hex chars — the same digest
`openssl x509 -fingerprint -sha256 -noout` prints, so it can be matched against a file
on disk without guesswork. The snapshot is built at reload time only; the hot path is
untouched.

The default certificate is included as `<default>` — it has no SNI hostname of its own
but is what an unmatched name is served, so a silent rotation of it would be exactly as
invisible as any other.

## Verified against a live SIGHUP

```
# renewal: same hostname, new certificate -- counts unchanged
TLS certificates reloaded successfully listener_id=https hostnames=2 \
  added=- removed=- replaced=a.example.com (0700948452ddf7bd->e0286ff98b379b79)

# nothing touched
TLS certificates reloaded successfully; no change to served certificates \
  listener_id=https hostnames=2

# 1-for-1 rotation -- counts identical on both sides
TLS certificates reloaded successfully listener_id=https hostnames=2 \
  added=b.example.com removed=a.example.com replaced=-
```

A no-op reload is now distinguishable from one that did something, which it was not
before.

## Tests

- Unit tests for the diff: added / removed / replaced-on-renewal / unchanged /
  1-for-1 rotation / default-cert rotation.
- Integration tests against real certificates on disk: a renewal changes the
  fingerprint while the hostname set is provably unchanged; an untouched folder
  produces an identical snapshot; add+remove moves the hostname set with equal counts
  on both sides.

`cargo test -p zentinel-proxy` green, `clippy -D warnings` and `fmt --check` clean.