### PR TITLE
chore: prepare release 26.08_6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ for details.
 
 | CalVer | Crate Version | Date | Highlights |
 |--------|---------------|------|------------|
+| [26.08_6](#26086---2026-08-27) | 0.6.29 | 2026-08-27 | Listener `namespace` isolation and per-listener timeouts now work on wildcard binds — both were silently ignored on `0.0.0.0` listeners; certificate reloads report what changed instead of only counts |
 | [26.08_5](#26085---2026-08-24) | 0.6.28 | 2026-08-24 | MCP and A2A policy is now enforced — it was parsed and ignored in 26.08_4; `cargo install zentinel-proxy` works again; unknown-key checking extended to `route` and `system`; **breaking**: dead buffering fields removed |
 | [26.08_4](#26084---2026-08-23) | 0.6.27 | 2026-08-23 | Native MCP and A2A support; settings that were parsed and discarded now take effect (upstream timeouts, route policies, `failure-mode`); agent and mTLS authentication hardening |
 | [26.08_3](#26083---2026-08-22) | 0.6.26 | 2026-08-22 | Per-SNI certificates, mTLS and TLS hardening settings now reach the listener (#303) |
@@ -69,6 +70,56 @@ for details.
 ## [Unreleased]
 
 _Nothing yet._
+
+---
+
+## [26.08_6] - 2026-08-27
+
+**Crate version:** 0.6.29
+
+> **If you set `namespace` on a listener bound to `0.0.0.0` or `[::]`, it was
+> doing nothing.** The listener served the *global* route set instead of its
+> namespace's, with no warning, log line, or validation error. `namespace` is an
+> isolation control, so this failed in the permissive direction: routes an
+> operator believed were scoped away were reachable. Concrete binds such as
+> `127.0.0.1:9000` were unaffected, which is why this survived — the documented
+> admin-listener example is loopback-bound.
+>
+> **Check any wildcard-bound listener that carries a `namespace` before
+> upgrading:** it begins enforcing isolation for the first time, so routes that
+> have been served from the global set will stop being reachable there. The same
+> listeners' `request-timeout-secs` and `keepalive-timeout-secs` also begin
+> taking effect, having run on defaults until now.
+
+### Fixed
+- **Listener `namespace` is enforced on wildcard binds.** Namespace route
+  matchers were keyed by the *configured* bind address and looked up by the
+  accepted connection's local address, which Pingora takes from `getsockname()`.
+  A connection accepted on `0.0.0.0:443` reports the concrete interface it
+  landed on — `203.0.113.5:443` — and never `0.0.0.0:443`, so the lookup could
+  not hit and the request fell through to the global matcher. Both call sites
+  now resolve on parsed socket addresses: exact binds by equality, wildcard
+  binds by port with the address families that bind can actually accept, and
+  IPv4-mapped addresses canonicalised so a dual-stack listener resolves both
+  families alike. Concrete binds take precedence over wildcard binds on the same
+  port. (#396, #398)
+- **Per-listener `request-timeout-secs` and `keepalive-timeout-secs` apply on
+  wildcard binds.** The same comparison, in `request_filter`, meant a config
+  setting either on a `0.0.0.0` listener validated cleanly and ran on the
+  defaults. (#396, #398)
+
+### Added
+- **Certificate reloads report what changed.** A reload logged counts and a bare
+  success line, which cannot answer whether anything actually changed: a renewal
+  covers the same hostnames as the certificate it replaces, so every count stays
+  identical. Reloads now log `added`, `removed` and `replaced` hostnames at
+  `info`, where `replaced` names a hostname whose certificate changed and
+  carries the SHA-256 fingerprints on both sides — the same digest
+  `openssl x509 -fingerprint -sha256` prints, so it can be matched against a
+  file on disk. A rescan that changed nothing says so explicitly. The default
+  certificate participates as `<default>`, since a silent rotation of it was
+  equally invisible. Completes the diff from the #117 checklist, which shipped
+  without it. (#399, #400)
 
 ---
 


### PR DESCRIPTION
CHANGELOG only. `Cargo.toml` and `Cargo.lock` are deliberately untouched — the Release
workflow reads the current version (`0.6.28`) and publishes it **plus one**, so this
release ships crate `0.6.29`. Bumping here would make it publish `0.6.30` and skip a
version on crates.io.

## Contents

Two fixes, both of the "configured, validated, and silently ignored" shape.

**#396 / #398 — listener `namespace` and per-listener timeouts on wildcard binds.**
Matchers were keyed by the configured bind string and looked up by `getsockname()`, which
never returns `0.0.0.0` for an accepted connection. Reported by @nick-potts with a
complete mechanism trace.

This one carries an upgrade note rather than just a bullet: `namespace` is an isolation
control that was failing **open**, so a wildcard-bound listener that carries one begins
enforcing isolation for the first time on upgrade. Routes that have been reachable there
via the global set will stop being. That is the correct behaviour and the documented
one, but it is a behaviour change on upgrade and operators should look before they leap.

**#399 / #400 — certificate reloads report what changed.** Completes the diff from the
#117 checklist, which shipped with the rescan and the atomic swap but not the diff.
Raised by @DisasteR against the closed issue.

## After merge

Tag the merge commit with the CalVer form:

```bash
git tag -a 26.08_6 origin/main -m "Release 26.08_6 (semver 0.6.28)"
git push origin 26.08_6
```