### PR TITLE
chore: bump workspace version to 0.6.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8182,7 +8182,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8223,7 +8223,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8245,7 +8245,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8324,7 +8324,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8505,7 +8505,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8596,7 +8596,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8613,7 +8613,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.28"
+version = "0.6.29"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/config-inspect/Cargo.toml
+++ b/crates/config-inspect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-config-inspect"
-version = "0.6.28"
+version = "0.6.29"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/playground-wasm/Cargo.toml
+++ b/crates/playground-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-playground-wasm"
-version = "0.6.28"
+version = "0.6.29"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/sim/Cargo.toml
+++ b/crates/sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-sim"
-version = "0.6.28"
+version = "0.6.29"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Post-release bump for 26.08_6. Opened by hand: the Release workflow force-pushes this
branch and then its own `gh pr create` step fails, every time, leaving the branch orphaned
with no PR. This is that step, completed manually.

## Contents

- `92ae9e7` — the workflow's own commit, bumping the four `Cargo.toml` files
  (workspace root plus the three excluded crates: `config-inspect`, `playground-wasm`,
  `sim`).
- `7275a2a` — `Cargo.lock`, which the workflow does not touch. Without it main carries a
  lockfile still naming `0.6.28` after the bump.

`cargo update --workspace` moved only the workspace members' own versions —
`zentinel-proxy`, `zentinel-gateway`, `zentinel-stack`, `zentinel-wasm-runtime` — and left
all 154 external dependencies alone. No dependency bump is riding along with this.

## Safe to merge this time

The standing hazard with this branch is that the workflow bases it on the release commit
and force-pushes it; if `main` has moved on since, merging it reverts everything in
between. Checked before touching it:

```
$ git log --oneline chore/bump-0.6.29..origin/main
(empty)
```

It is based directly on `59a6eb7`, the release commit, which is still the tip of `main`.
Nothing is behind it, so nothing gets reverted. **If `main` moves before this merges, the
branch needs rebasing rather than merging as-is.**

## After this

`main` sits at `0.6.29`, matching what is now on crates.io — the correct steady state
between releases, and what the next release's prepare PR assumes when it leaves
`Cargo.toml` untouched.