### PR TITLE
feat(config): report settings swallowed by a run-together line

### DIFF
--- a/crates/config/src/kdl/server.rs
+++ b/crates/config/src/kdl/server.rs
@@ -38,6 +38,27 @@ pub(crate) const RECOGNIZED_SYSTEM_KEYS: &[&str] = &[
     "route-cache-size",
 ];
 
+/// Every key the listener parsers read.
+///
+/// Both `parse_listeners` here and `parse_namespace_listener` in `namespace.rs`
+/// build a `ListenerConfig` from exactly this set, so a setting added to one
+/// and not the other is a bug this list makes visible.
+///
+/// Kept beside the parser for the same reason as [`RECOGNIZED_SYSTEM_KEYS`]:
+/// the unknown-key lint reads it, and under-listing produces false warnings on
+/// valid configs.
+pub(crate) const RECOGNIZED_LISTENER_KEYS: &[&str] = &[
+    "address",
+    "protocol",
+    "tls",
+    "default-route",
+    "namespace",
+    "request-timeout-secs",
+    "keepalive-timeout-secs",
+    "max-concurrent-streams",
+    "keepalive-max-requests",
+];
+
 pub fn parse_server_config(node: &kdl::KdlNode) -> Result<ServerConfig> {
     trace!("Parsing server configuration block");
 

--- a/crates/config/src/validate/unknown_keys.rs
+++ b/crates/config/src/validate/unknown_keys.rs
@@ -97,6 +97,10 @@ const CLOSED_BLOCKS: &[ClosedBlock] = &[
         keys: crate::kdl::server::RECOGNIZED_SYSTEM_KEYS,
     },
     ClosedBlock {
+        name: "listener",
+        keys: crate::kdl::server::RECOGNIZED_LISTENER_KEYS,
+    },
+    ClosedBlock {
         name: "policies",
         keys: &[
             "request-headers",
@@ -138,6 +142,7 @@ fn walk(node: &kdl::KdlNode, result: &mut ValidationResult) {
                     result
                         .add_warning(ValidationWarning::new(unknown_key_message(block.name, key)));
                 }
+                check_run_together(block, child, result);
             }
         }
     }
@@ -147,6 +152,54 @@ fn walk(node: &kdl::KdlNode, result: &mut ValidationResult) {
             walk(child, result);
         }
     }
+}
+
+/// Warn when a node's surplus arguments name a sibling key.
+///
+/// KDL separates nodes by newline or `;`. Written on one line without either,
+///
+/// ```kdl
+/// listener "public" { address "0.0.0.0:8080" namespace "iso" }
+/// ```
+///
+/// is not two settings — it is a single `address` node carrying three
+/// arguments, and the entry helpers read only the first. `namespace` is
+/// dropped before any parser sees it, so the unknown-key check above cannot
+/// see it either: there is no `namespace` child node to be unknown. The config
+/// loads, validates and starts, and the setting simply does not exist. That is
+/// how a listener's namespace isolation came to be silently absent in #396.
+///
+/// The signature is specific: an argument *after the first* whose value is the
+/// name of a key in this same block. A node legitimately taking a list —
+/// `hostnames "a.com" "b.com"` — never matches, because hostnames are not
+/// listener keys. Only the first argument is exempt, since that is the node's
+/// own value.
+fn check_run_together(block: &ClosedBlock, child: &kdl::KdlNode, result: &mut ValidationResult) {
+    let key = child.name().value();
+
+    for entry in child.entries().iter().skip(1) {
+        // Property syntax (`name=value`) is not a run-together line.
+        if entry.name().is_some() {
+            continue;
+        }
+        let Some(value) = entry.value().as_string() else {
+            continue;
+        };
+        if block.keys.contains(&value) {
+            result.add_warning(ValidationWarning::new(run_together_message(
+                block.name, key, value,
+            )));
+        }
+    }
+}
+
+/// Build the run-together warning.
+fn run_together_message(block: &str, key: &str, swallowed: &str) -> String {
+    format!(
+        "'{swallowed}' is being read as an argument to '{key}' rather than as a setting, \
+         so it is ignored. In the '{block}' block, put each setting on its own line \
+         (or separate them with ';')."
+    )
 }
 
 /// Build the warning, with a suggestion when one key is clearly meant.
@@ -403,6 +456,132 @@ mod tests {
             }
         "#;
         assert!(warnings_for(kdl).is_empty(), "{:?}", warnings_for(kdl));
+    }
+
+    /// The #396 case: `namespace` swallowed as an argument to `address`.
+    #[test]
+    fn a_run_together_listener_line_is_reported() {
+        let kdl = r#"
+            listeners {
+                listener "public" { address "0.0.0.0:8080" namespace "iso" }
+            }
+        "#;
+        let mut result = ValidationResult::default();
+        check_unknown_keys(kdl, &mut result);
+
+        let warnings = warning_texts(&result);
+        assert_eq!(
+            warnings.len(),
+            1,
+            "expected exactly one warning, got: {warnings:?}"
+        );
+        assert!(
+            warnings[0].contains("'namespace'") && warnings[0].contains("'address'"),
+            "warning should name both the swallowed setting and its host: {}",
+            warnings[0]
+        );
+    }
+
+    /// The same config written correctly must be silent.
+    #[test]
+    fn separated_listener_settings_are_not_reported() {
+        for separator in ["\n", ";"] {
+            let kdl = format!(
+                r#"
+                listeners {{
+                    listener "public" {{ address "0.0.0.0:8080"{separator}namespace "iso" }}
+                }}
+                "#
+            );
+            let mut result = ValidationResult::default();
+            check_unknown_keys(&kdl, &mut result);
+            assert!(
+                result.warnings.is_empty(),
+                "separator {separator:?} should parse as two settings, got: {:?}",
+                warning_texts(&result)
+            );
+        }
+    }
+
+    /// A node that legitimately takes a list must not be flagged. This is the
+    /// false positive that would make the check unusable.
+    #[test]
+    fn a_node_taking_a_list_of_values_is_not_reported() {
+        let kdl = r#"
+            route "r" {
+                policies {
+                    cache {
+                        cacheable-methods "GET" "HEAD"
+                    }
+                }
+            }
+        "#;
+        let mut result = ValidationResult::default();
+        check_unknown_keys(kdl, &mut result);
+        assert!(
+            result.warnings.is_empty(),
+            "a value list is not a run-together line: {:?}",
+            warning_texts(&result)
+        );
+    }
+
+    /// Only arguments *after* the first are candidates: the first is the
+    /// node's own value, and may legitimately equal a key name.
+    #[test]
+    fn a_value_equal_to_a_key_name_is_allowed_in_first_position() {
+        let kdl = r#"
+            listeners {
+                listener "public" { address "0.0.0.0:8080" }
+                listener "odd" { default-route "namespace" }
+            }
+        "#;
+        let mut result = ValidationResult::default();
+        check_unknown_keys(kdl, &mut result);
+        assert!(
+            result.warnings.is_empty(),
+            "a first-position value is the node's own: {:?}",
+            warning_texts(&result)
+        );
+    }
+
+    /// Several settings can be swallowed by one line, and each is worth naming.
+    #[test]
+    fn every_swallowed_setting_on_a_line_is_reported() {
+        let kdl = r#"
+            listeners {
+                listener "public" {
+                    address "0.0.0.0:8080" namespace "iso" protocol "https"
+                }
+            }
+        "#;
+        let mut result = ValidationResult::default();
+        check_unknown_keys(kdl, &mut result);
+
+        let warnings = warning_texts(&result);
+        assert_eq!(warnings.len(), 2, "got: {warnings:?}");
+        assert!(warnings.iter().any(|w| w.contains("'namespace'")));
+        assert!(warnings.iter().any(|w| w.contains("'protocol'")));
+    }
+
+    /// Property syntax is a different construct and not this check's business.
+    #[test]
+    fn property_syntax_is_not_a_run_together_line() {
+        let kdl = r#"
+            listeners {
+                listener "public" { address "0.0.0.0:8080" namespace="iso" }
+            }
+        "#;
+        let mut result = ValidationResult::default();
+        check_unknown_keys(kdl, &mut result);
+        assert!(
+            result.warnings.is_empty(),
+            "named entries are properties, not swallowed nodes: {:?}",
+            warning_texts(&result)
+        );
+    }
+
+    fn warning_texts(result: &ValidationResult) -> Vec<String> {
+        result.warnings.iter().map(|w| w.to_string()).collect()
     }
 
     #[test]


### PR DESCRIPTION
Part of #365. Closes the variant found while fixing #396.

## The defect

KDL separates nodes by newline or `;`. A block written on one line with neither is **not**
several settings:

```kdl
listener "public" { address "0.0.0.0:8080" namespace "iso" }
```

That is a single `address` node carrying three arguments. `get_string_entry` reads
`.entries().first()` and discards the rest, and there is no `namespace` *child node* for
anything to find. The setting never reaches a parser.

The config loads. `zentinel test` reports success. `zentinel lint` reports success. The
listener runs without the namespace isolation the file asks for — which is exactly how
#396 happened, and the reporter's own repro was written this way, so it failed for a
second reason on top of the one being reported.

**The existing unknown-key check structurally cannot catch this.** It looks for child
nodes whose names aren't recognised; here there is no child node at all.

## What this reports

An argument **after the first** whose value names a key of the same block. That
combination is the run-together signature and little else:

| Config | Reported? | Why |
|---|---|---|
| `address "0.0.0.0:8080" namespace "iso"` | **yes** | `namespace` is a `listener` key appearing as an argument |
| `hostnames "a.com" "b.com"` | no | a legitimate value list; hostnames aren't listener keys |
| `cacheable-methods "GET" "HEAD"` | no | same |
| `default-route "namespace"` | no | first argument is the node's own value |
| `address "..." namespace="iso"` | no | property syntax, a different construct |

Each swallowed setting on a line is named separately, so
`address "..." namespace "iso" protocol "https"` produces two warnings rather than one
vague complaint.

## `listener` had to become a closed block

The check works per-block, and `listener` wasn't in `CLOSED_BLOCKS` — so the motivating
case wouldn't have been caught. `RECOGNIZED_LISTENER_KEYS` now sits beside the parsers,
following the existing `RECOGNIZED_SYSTEM_KEYS` pattern. Both `parse_listeners` and
`parse_namespace_listener` build a `ListenerConfig` from exactly that set, which the
doc comment records so the two can't drift apart unnoticed.

Listener blocks therefore gain **unknown-key checking** as well, which they did not have.
`shipped_configs_use_only_known_keys` passes, which is what proves the key list is
complete rather than my say-so — under-listing would produce false warnings on real
configs and fail that test.

## Verified end-to-end

```
$ zentinel --config oneline.kdl lint
  ⚠  'namespace' is being read as an argument to 'address' rather than as a setting,
     so it is ignored. In the 'listener' block, put each setting on its own line
     (or separate them with ';').
```

It also immediately caught a **live instance I had written myself** earlier today without
noticing — a scratch config with `system { worker-threads 2 max-connections 1000 }`, where
`max-connections` was being silently dropped. That is the whole argument for the check in
one line: this is a mistake people make while looking straight at it.

Shipped configs are clean — the guard test covers them.

## Scope

Deliberately a **warning**, consistent with the existing unknown-key check, not a hard
error. Escalating would break configs that currently start, and the value here is that the
condition becomes *visible*; whether it should eventually fail config load is a separate
call. The remaining, larger part of #365 — general unknown-key detection for blocks not on
the closed list — is untouched.

Tests: 6 new (the #396 case, both correct separators, value lists, first-position values,
multiple swallowed settings, property syntax). `cargo test -p zentinel-config --features
validation` green at 338; clippy `-D warnings` and `fmt --check` clean.

> Note for reviewers: these tests need `--features validation`; the `validate` module is
> behind that flag, so a plain `cargo test -p zentinel-config` silently skips them.