### PR TITLE
feat(config): check upstream blocks, and drop a dead key it found

### DIFF
--- a/config/examples/inference-routing.kdl
+++ b/config/examples/inference-routing.kdl
@@ -29,7 +29,8 @@ upstreams {
 
         tls {
             sni "api.openai.com"
-            verify #true
+            // Certificate verification is on by default; `insecure-skip-verify #true`
+            // is the (discouraged) opt-out. There is no `verify` key.
         }
 
         health-check {
@@ -55,7 +56,6 @@ upstreams {
 
         tls {
             sni "api.anthropic.com"
-            verify #true
         }
 
         timeouts {

--- a/crates/config/src/kdl/mod.rs
+++ b/crates/config/src/kdl/mod.rs
@@ -18,7 +18,7 @@ mod namespace;
 mod retrypolicy_helper;
 pub(crate) mod routes;
 pub(crate) mod server;
-mod upstreams;
+pub(crate) mod upstreams;
 
 use tracing::{debug, trace, warn};
 

--- a/crates/config/src/kdl/server.rs
+++ b/crates/config/src/kdl/server.rs
@@ -346,7 +346,7 @@ const KNOWN_TLS_NODES: &[&str] = &[
 ];
 
 /// Child nodes recognized inside an `sni` block.
-const KNOWN_SNI_NODES: &[&str] = &[
+pub(crate) const KNOWN_SNI_NODES: &[&str] = &[
     "hostnames",
     "priority-hostnames",
     "cert-file",

--- a/crates/config/src/kdl/upstreams.rs
+++ b/crates/config/src/kdl/upstreams.rs
@@ -12,6 +12,47 @@ use crate::{kdl::circuitbreaker_helper::parse_circuit_breaker_faildefault, upstr
 use super::helpers::{get_first_arg_string, get_int_entry, parse_upstream_targets};
 
 //Parse a single upstream block
+/// Every child node `parse_upstream` reads.
+///
+/// `address` is the easy one to miss: it is the single-target shorthand
+/// (`upstream "x" { address "127.0.0.1:8081" }`), handled inside
+/// `parse_upstream_targets` rather than here, so it does not appear anywhere in
+/// this function's body.
+///
+/// Kept beside the parser for the same reason as the other recognised-key
+/// lists: the unknown-key lint reads it, and under-listing produces false
+/// warnings on valid configs.
+pub(crate) const RECOGNIZED_UPSTREAM_KEYS: &[&str] = &[
+    "target",
+    "targets",
+    // Single-target shorthand; see `parse_upstream_targets`.
+    "address",
+    "load-balancing",
+    "health-check",
+    "http-version",
+    "connection-pool",
+    "timeouts",
+    "tls",
+    "circuit-breaker",
+];
+
+/// Every child node `parse_upstream_tls` reads.
+///
+/// Distinct from a listener's `tls` block, which shares the name and no keys.
+pub(crate) const RECOGNIZED_UPSTREAM_TLS_KEYS: &[&str] = &[
+    "sni",
+    "insecure-skip-verify",
+    "client-cert",
+    "client-key",
+    "ca-cert",
+];
+
+/// Every child node a `target` block reads.
+///
+/// Both are also accepted as properties (`target address="..." weight=2`),
+/// which the lint ignores; only child nodes are checked.
+pub(crate) const RECOGNIZED_TARGET_KEYS: &[&str] = &["address", "weight"];
+
 pub fn parse_upstream(child: &kdl::KdlNode) -> Result<UpstreamConfig> {
     if child.name().value() == "upstream" {
         let id = get_first_arg_string(child).ok_or_else(|| {

--- a/crates/config/src/validate/unknown_keys.rs
+++ b/crates/config/src/validate/unknown_keys.rs
@@ -195,15 +195,13 @@ const CLOSED_BLOCKS: &[ClosedBlock] = &[
         ],
     },
     ClosedBlock {
+        // The listener TLS parser rejects unknown nodes here outright
+        // (`reject_unknown_nodes`), so this mainly covers the same ground a
+        // second time -- but it shares the parser's list rather than copying
+        // it, so the two cannot drift apart.
         name: "sni",
         nesting: Nesting::Anywhere,
-        keys: &[
-            "hostnames",
-            "priority-hostnames",
-            "cert-file",
-            "key-file",
-            "acme",
-        ],
+        keys: crate::kdl::server::KNOWN_SNI_NODES,
     },
     ClosedBlock {
         name: "sni-certs",
@@ -231,6 +229,29 @@ const CLOSED_BLOCKS: &[ClosedBlock] = &[
         name: "eab",
         nesting: Nesting::Anywhere,
         keys: &["kid", "hmac-key"],
+    },
+    ClosedBlock {
+        name: "upstream",
+        nesting: Nesting::Anywhere,
+        keys: crate::kdl::upstreams::RECOGNIZED_UPSTREAM_KEYS,
+    },
+    ClosedBlock {
+        // An upstream's `tls` block. A listener's `tls` block shares the name
+        // and not one key, hence the qualification.
+        //
+        // The listener side is deliberately absent: `parse_tls_config` already
+        // rejects unknown nodes with a hard error and a targeted hint, so a
+        // lint warning there would arrive after the config had already failed
+        // to load. Upstream TLS has no such check, which is why this one earns
+        // its place.
+        name: "tls",
+        nesting: Nesting::In("upstream"),
+        keys: crate::kdl::upstreams::RECOGNIZED_UPSTREAM_TLS_KEYS,
+    },
+    ClosedBlock {
+        name: "target",
+        nesting: Nesting::Anywhere,
+        keys: crate::kdl::upstreams::RECOGNIZED_TARGET_KEYS,
     },
     ClosedBlock {
         name: "policies",
@@ -959,6 +980,124 @@ mod tests {
             !warnings[0].contains("'disk-path'"),
             "suggestion leaked from the top-level block: {}",
             warnings[0]
+        );
+    }
+
+    /// The single-target shorthand. `address` is read inside
+    /// `parse_upstream_targets`, not in `parse_upstream`, so it appears nowhere
+    /// in the upstream parser's body -- omitting it from the key list would
+    /// warn about a perfectly valid config.
+    #[test]
+    fn the_upstream_address_shorthand_is_not_reported() {
+        let kdl = r#"
+            upstream "backend" {
+                address "127.0.0.1:8081"
+            }
+        "#;
+        assert!(warnings_for(kdl).is_empty(), "{:?}", warnings_for(kdl));
+    }
+
+    #[test]
+    fn a_valid_upstream_produces_no_warnings() {
+        let kdl = r#"
+            upstream "backend" {
+                target "127.0.0.1:8081" weight=2
+                targets {
+                    target { address "127.0.0.1:8082"; weight 3 }
+                }
+                load-balancing "round_robin"
+                health-check { path "/healthz" }
+                http-version { max-version 2 }
+                connection-pool { max-connections 100 }
+                timeouts { connect-secs 5 }
+                tls { sni "backend.internal" }
+                circuit-breaker { failure-threshold 5 }
+            }
+        "#;
+        assert!(warnings_for(kdl).is_empty(), "{:?}", warnings_for(kdl));
+    }
+
+    #[test]
+    fn an_unknown_upstream_key_is_reported() {
+        let kdl = r#"
+            upstream "backend" {
+                target "127.0.0.1:8081"
+                retries 3
+            }
+        "#;
+        let warnings = warnings_for(kdl);
+        assert!(
+            warnings.iter().any(|w| w.contains("'retries'")),
+            "{warnings:?}"
+        );
+    }
+
+    /// The two `tls` blocks share a name and no keys, exactly like the two
+    /// `cache` blocks.
+    #[test]
+    fn upstream_tls_keys_are_distinct_from_listener_tls_keys() {
+        let valid = r#"
+            upstream "backend" {
+                target "127.0.0.1:8081"
+                tls {
+                    sni "backend.internal"
+                    insecure-skip-verify #false
+                    client-cert "/c.crt"
+                    client-key "/c.key"
+                    ca-cert "/ca.crt"
+                }
+            }
+        "#;
+        assert!(warnings_for(valid).is_empty(), "{:?}", warnings_for(valid));
+
+        // `cert-file` is a *listener* TLS key and does nothing on an upstream.
+        let wrong = r#"
+            upstream "backend" {
+                target "127.0.0.1:8081"
+                tls { cert-file "/c.crt" }
+            }
+        "#;
+        assert!(
+            warnings_for(wrong)
+                .iter()
+                .any(|w| w.contains("'cert-file'")),
+            "{:?}",
+            warnings_for(wrong)
+        );
+    }
+
+    /// The dead key this check found in `config/examples/inference-routing.kdl`
+    /// on its first run: certificate verification is controlled by
+    /// `insecure-skip-verify`, and `verify` is read by nothing.
+    #[test]
+    fn the_verify_key_that_shipped_in_an_example_is_reported() {
+        let kdl = r#"
+            upstream "openai" {
+                target "api.openai.com:443"
+                tls {
+                    sni "api.openai.com"
+                    verify #true
+                }
+            }
+        "#;
+        let warnings = warnings_for(kdl);
+        assert!(
+            warnings.iter().any(|w| w.contains("'verify'")),
+            "{warnings:?}"
+        );
+    }
+
+    #[test]
+    fn target_block_keys_are_checked() {
+        let kdl = r#"
+            upstream "backend" {
+                target { address "127.0.0.1:8081"; wieght 2 }
+            }
+        "#;
+        let warnings = warnings_for(kdl);
+        assert!(
+            warnings.iter().any(|w| w.contains("'wieght'")),
+            "{warnings:?}"
         );
     }
 


### PR DESCRIPTION
Part of #365, following #405. Covers the blocks I deliberately deferred there.

## What's added

`upstream`, an upstream's `tls`, and `target`. The `sni` entry now points at the parser's
own `KNOWN_SNI_NODES` instead of a copy, so the two can't drift.

`tls` is the second block name to mean two unrelated things:

| | Keys |
|---|---|
| `upstream` → `tls` | `sni`, `insecure-skip-verify`, `client-cert`, `client-key`, `ca-cert` |
| `listener` → `tls` | `cert-file`, `key-file`, `min-version`, `cipher-suite`, … |

No overlap at all, so the upstream side is qualified with `In("upstream")`.

**The listener side is deliberately not added.** `parse_tls_config` already calls
`reject_unknown_nodes` and fails config load outright with a targeted hint — a lint
warning would arrive after the config had already been rejected. Upstream TLS has no such
protection, which is why that side earns its place. (`reject_unknown_nodes` covers only
listener `tls` and `sni`; I checked.)

## Why I deferred these, and what it caught

#405 derived key lists from the parser function bodies. That method would have been
**wrong here**: `address` is a valid upstream key — the single-target shorthand
`upstream "x" { address "127.0.0.1:8081" }` — but it is read inside
`parse_upstream_targets`, so it appears nowhere in `parse_upstream`'s body. Omitting it
would have warned on every config using the shorthand.

A regression test pins it (`the_upstream_address_shorthand_is_not_reported`).

## It found a dead key in a shipped example on its first run

`shipped_configs_use_only_known_keys` failed immediately on
`config/examples/inference-routing.kdl`:

```kdl
tls {
    sni "api.openai.com"
    verify #true          // <- read by nothing
}
```

Nothing reads `verify`. Certificate verification is controlled by
`insecure-skip-verify`, and it is on by default — so the example got the behaviour it
intended *by accident*, while stating it in a key that does nothing. Two occurrences,
both removed, with a comment naming the real key. The example still loads and validates.

That is the guard test doing exactly its job: it cannot prove a key list is complete, but
it does prove the shipped configs and the lists agree, and it made the disagreement
visible on the first run.

## Tests

6 new: the `address` shorthand, a full valid upstream, an unknown upstream key, the two
`tls` key sets kept apart, the `verify` case specifically, and `target` block keys.

`cargo test -p zentinel-config --features validation` green at 352; clippy `-D warnings`
and `fmt --check` clean; `zentinel test` on the edited example passes.

## Where #365 stands after this

Checked: `system`/`server`, `route`, `listener`, `policies`, `connection-pool`,
`timeouts`, `ruleset`, `cache` ×2, `sni`, `sni-certs`, `acme`, `eab`, `upstream`,
upstream `tls`, `target`.

Still open: `health-check` (its keys depend on `type`, with nested `http`/`grpc`/
`inference`/`readiness` sub-blocks — needs the same careful treatment rather than a
guess), `agent`, `rate-limit`, and the observability blocks.

> Reviewers: these tests need `--features validation`.