### PR TITLE
feat(config): check the readiness block and its four sub-blocks

### DIFF
--- a/crates/config/src/kdl/upstreams.rs
+++ b/crates/config/src/kdl/upstreams.rs
@@ -63,6 +63,61 @@ pub(crate) const RECOGNIZED_INFERENCE_CHECK_KEYS: &[&str] =
 /// unrecognised type as TCP.
 pub(crate) const RECOGNIZED_TCP_CHECK_KEYS: &[&str] = &[];
 
+/// Sub-blocks accepted inside a `readiness` block.
+///
+/// `readiness` holds nothing but these four; it has no settings of its own.
+pub(crate) const RECOGNIZED_READINESS_KEYS: &[&str] = &[
+    "inference-probe",
+    "model-status",
+    "queue-depth",
+    "warmth-detection",
+];
+
+/// Settings accepted inside `readiness > inference-probe`.
+pub(crate) const RECOGNIZED_INFERENCE_PROBE_KEYS: &[&str] = &[
+    "endpoint",
+    "model",
+    "prompt",
+    "max-tokens",
+    "timeout-secs",
+    "max-latency-ms",
+];
+
+/// Settings accepted inside `readiness > model-status`.
+///
+/// Note `expected-status` and `status-field` are *settings*; their defaults are
+/// the strings `"ready"` and `"status"`. Reading those defaults as key names is
+/// the mistake a mechanical scan of this function makes.
+pub(crate) const RECOGNIZED_MODEL_STATUS_KEYS: &[&str] = &[
+    "endpoint-pattern",
+    "models",
+    "expected-status",
+    "status-field",
+    "timeout-secs",
+];
+
+/// Settings accepted inside `readiness > queue-depth`.
+pub(crate) const RECOGNIZED_QUEUE_DEPTH_KEYS: &[&str] = &[
+    "header",
+    "body-field",
+    "endpoint",
+    "degraded-threshold",
+    "unhealthy-threshold",
+    "timeout-secs",
+];
+
+/// Settings accepted inside `readiness > warmth-detection`.
+///
+/// `cold-action` takes one of `log-only`, `mark-degraded` or `mark-unhealthy`
+/// (underscored spellings also accepted). Those are *values*, not settings, and
+/// do not belong in this list.
+pub(crate) const RECOGNIZED_WARMTH_DETECTION_KEYS: &[&str] = &[
+    "cold-action",
+    "sample-size",
+    "cold-threshold-multiplier",
+    "idle-cold-timeout-secs",
+];
+
 /// Every child node `parse_upstream_tls` reads.
 ///
 /// Distinct from a listener's `tls` block, which shares the name and no keys.

--- a/crates/config/src/validate/unknown_keys.rs
+++ b/crates/config/src/validate/unknown_keys.rs
@@ -323,6 +323,31 @@ const CLOSED_BLOCKS: &[ClosedBlock] = &[
         keys: crate::kdl::upstreams::RECOGNIZED_TCP_CHECK_KEYS,
     },
     ClosedBlock {
+        name: "readiness",
+        nesting: Nesting::Anywhere,
+        keys: crate::kdl::upstreams::RECOGNIZED_READINESS_KEYS,
+    },
+    ClosedBlock {
+        name: "inference-probe",
+        nesting: Nesting::In("readiness"),
+        keys: crate::kdl::upstreams::RECOGNIZED_INFERENCE_PROBE_KEYS,
+    },
+    ClosedBlock {
+        name: "model-status",
+        nesting: Nesting::In("readiness"),
+        keys: crate::kdl::upstreams::RECOGNIZED_MODEL_STATUS_KEYS,
+    },
+    ClosedBlock {
+        name: "queue-depth",
+        nesting: Nesting::In("readiness"),
+        keys: crate::kdl::upstreams::RECOGNIZED_QUEUE_DEPTH_KEYS,
+    },
+    ClosedBlock {
+        name: "warmth-detection",
+        nesting: Nesting::In("readiness"),
+        keys: crate::kdl::upstreams::RECOGNIZED_WARMTH_DETECTION_KEYS,
+    },
+    ClosedBlock {
         name: "policies",
         nesting: Nesting::Anywhere,
         keys: &[
@@ -1286,6 +1311,130 @@ mod tests {
                 .any(|w| w.contains("'path'")),
             "{:?}",
             warnings_for(with_settings)
+        );
+    }
+
+    #[test]
+    fn a_fully_populated_readiness_block_produces_no_warnings() {
+        let kdl = r#"
+            health-check {
+                type "inference" {
+                    endpoint "/v1/models"
+                    readiness {
+                        inference-probe {
+                            endpoint "/v1/completions"
+                            model "gpt-4"
+                            prompt "."
+                            max-tokens 1
+                            timeout-secs 30
+                            max-latency-ms 5000
+                        }
+                        model-status {
+                            endpoint-pattern "/v1/models/{model}/status"
+                            models "gpt-4" "claude-3"
+                            expected-status "ready"
+                            status-field "status"
+                            timeout-secs 5
+                        }
+                        queue-depth {
+                            header "X-Queue-Depth"
+                            body-field "queue"
+                            endpoint "/metrics"
+                            degraded-threshold 50
+                            unhealthy-threshold 200
+                            timeout-secs 5
+                        }
+                        warmth-detection {
+                            sample-size 10
+                            cold-threshold-multiplier 3.0
+                            idle-cold-timeout-secs 300
+                            cold-action "mark-degraded"
+                        }
+                    }
+                }
+            }
+        "#;
+        assert!(warnings_for(kdl).is_empty(), "{:?}", warnings_for(kdl));
+    }
+
+    /// The reason this block was left until last: a mechanical scan of
+    /// `parse_inference_readiness` reports its match-arm values and string
+    /// defaults as if they were settings. They are not, and a config using them
+    /// as settings must be reported.
+    #[test]
+    fn values_of_settings_are_not_themselves_settings() {
+        // `log-only`/`mark-degraded`/`mark-unhealthy` are values of `cold-action`.
+        let kdl = r#"
+            readiness {
+                warmth-detection {
+                    log-only #true
+                    mark-degraded #true
+                }
+            }
+        "#;
+        let warnings = warnings_for(kdl);
+        assert!(
+            warnings.iter().any(|w| w.contains("'log-only'")),
+            "{warnings:?}"
+        );
+        assert!(
+            warnings.iter().any(|w| w.contains("'mark-degraded'")),
+            "{warnings:?}"
+        );
+
+        // `ready` and `status` are the *defaults* of `expected-status` and
+        // `status-field`, not settings in their own right.
+        let defaults_as_keys = r#"
+            readiness {
+                model-status {
+                    ready "yes"
+                    status "up"
+                }
+            }
+        "#;
+        let warnings = warnings_for(defaults_as_keys);
+        assert!(
+            warnings.iter().any(|w| w.contains("'ready'")),
+            "{warnings:?}"
+        );
+        assert!(
+            warnings.iter().any(|w| w.contains("'status'")),
+            "{warnings:?}"
+        );
+    }
+
+    /// `readiness` holds sub-blocks and nothing else.
+    #[test]
+    fn a_setting_directly_inside_readiness_is_reported() {
+        let kdl = r#"
+            readiness {
+                timeout-secs 30
+            }
+        "#;
+        let warnings = warnings_for(kdl);
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(warnings[0].contains("'timeout-secs'"), "{}", warnings[0]);
+    }
+
+    /// `endpoint` and `timeout-secs` are valid in several readiness sub-blocks
+    /// and mean different things in each; none of them may borrow another's
+    /// settings.
+    #[test]
+    fn readiness_sub_blocks_do_not_share_settings() {
+        let kdl = r#"
+            readiness {
+                inference-probe { degraded-threshold 50 }
+                queue-depth { prompt "." }
+            }
+        "#;
+        let warnings = warnings_for(kdl);
+        assert!(
+            warnings.iter().any(|w| w.contains("'degraded-threshold'")),
+            "a queue-depth setting on an inference probe: {warnings:?}"
+        );
+        assert!(
+            warnings.iter().any(|w| w.contains("'prompt'")),
+            "an inference-probe setting on queue-depth: {warnings:?}"
         );
     }
 


### PR DESCRIPTION
Part of #365, completing the block held back from #409.

## Why it was held back, and what reading it found

Extracting `parse_inference_readiness` mechanically returns ~27 candidates. **Six of them
are not settings.** Reading the parser line by line instead:

| Candidate | What it actually is |
|---|---|
| `log-only`, `mark-degraded`, `mark-unhealthy` | values of `cold-action` |
| `ready` | the *default* of `expected-status` |
| `status` | the *default* of `status-field` |

Listing those would have accepted `warmth-detection { log-only #true }` — a config that
reads as though it configures something and does nothing whatsoever. Precisely the defect
class this whole issue is about, introduced *by* the check meant to catch it.

A test (`values_of_settings_are_not_themselves_settings`) pins each as reportable, so the
distinction can't quietly erode.

## Structure

`readiness` holds four sub-blocks and **no settings of its own**:

| Block | Settings |
|---|---|
| `inference-probe` | `endpoint`, `model`, `prompt`, `max-tokens`, `timeout-secs`, `max-latency-ms` |
| `model-status` | `endpoint-pattern`, `models`, `expected-status`, `status-field`, `timeout-secs` |
| `queue-depth` | `header`, `body-field`, `endpoint`, `degraded-threshold`, `unhealthy-threshold`, `timeout-secs` |
| `warmth-detection` | `cold-action`, `sample-size`, `cold-threshold-multiplier`, `idle-cold-timeout-secs` |

`endpoint` and `timeout-secs` each appear in three of them meaning different things — the
argument for separate lists rather than a union, same as the two `cache` blocks.

## Verified end-to-end

```
⚠ 'mark-unhealthy' is not a setting in the 'warmth-detection' block and is being ignored.
```

## Tests

4 new: a fully populated readiness block (every setting of all four sub-blocks, no
warnings), the values-are-not-settings cases, a setting placed directly inside
`readiness`, and sub-blocks not borrowing each other's settings in both directions.

`cargo test -p zentinel-config --features validation` green at 361; clippy `-D warnings`
and `fmt --check` clean.

## #365 status

**Checked — 26 blocks:** `system`/`server`, `route`, `listener`, `policies`,
`connection-pool`, `timeouts`, `ruleset`, `cache` ×2, `sni`, `sni-certs`, `acme`, `eab`,
`upstream`, upstream `tls`, `target`, `health-check`, `type` ×4, `readiness`,
`inference-probe`, `model-status`, `queue-depth`, `warmth-detection`.

**Remaining:** `agent`, `rate-limit`, and the observability blocks.

> Reviewers: these tests need `--features validation`.