### PR TITLE
feat(config): check agent and rate-limit blocks; playground gets the same checks

### DIFF
--- a/crates/config/src/kdl/filters.rs
+++ b/crates/config/src/kdl/filters.rs
@@ -67,6 +67,39 @@ pub fn parse_single_filter_definition(node: &kdl::KdlNode) -> Result<Filter> {
     }
 }
 
+/// Every setting a `filter` with `type "rate-limit"` reads.
+///
+/// Includes the backend settings, which `parse_rate_limit_backend` reads from
+/// the same node rather than from a nested block. Both spellings of the two
+/// aliased settings are listed, because both are accepted.
+pub(crate) const RECOGNIZED_RATE_LIMIT_FILTER_KEYS: &[&str] = &[
+    "type",
+    "max-rps",
+    "burst",
+    "key",
+    "on-limit",
+    "status-code",
+    "message",
+    "max-delay-ms",
+    "max-keys",
+    // Backend selection and its settings.
+    "backend",
+    "redis-url",
+    "redis-prefix",
+    "redis-pool-size",
+    "redis-timeout-ms",
+    "redis-fallback",
+    "redis-fallback-local",
+    "memcached-url",
+    "memcached-prefix",
+    "memcached-pool-size",
+    "memcached-timeout-ms",
+    "memcached-ttl",
+    "memcached-ttl-secs",
+    "memcached-fallback",
+    "memcached-fallback-local",
+];
+
 fn parse_rate_limit_filter(node: &kdl::KdlNode) -> Result<Filter> {
     let max_rps = get_int_entry(node, "max-rps")
         .map(|v| v as u32)

--- a/crates/config/src/kdl/mod.rs
+++ b/crates/config/src/kdl/mod.rs
@@ -12,7 +12,7 @@
 //! - `namespace`: Namespace and service parsing
 
 mod circuitbreaker_helper;
-mod filters;
+pub(crate) mod filters;
 mod helpers;
 mod namespace;
 mod retrypolicy_helper;
@@ -315,6 +315,42 @@ use std::path::PathBuf;
 ///     }
 /// }
 /// ```
+/// Every child node `parse_single_agent` reads.
+///
+/// `config` holds arbitrary agent-specific settings forwarded verbatim, so it
+/// is a valid key here but is not itself a closed block.
+pub(crate) const RECOGNIZED_AGENT_KEYS: &[&str] = &[
+    // Accepted as a child node as well as the documented `type=` property.
+    "type",
+    "unix-socket",
+    "grpc",
+    "http",
+    "timeout-ms",
+    "failure-mode",
+    "events",
+    "circuit-breaker",
+    "max-request-body-bytes",
+    "max-response-body-bytes",
+    "request-body-mode",
+    "response-body-mode",
+    "chunk-timeout-ms",
+    "config",
+    "max-concurrent-calls",
+    // Deprecated: parsed, warned about, and otherwise ignored.
+    "protocol-version",
+];
+
+/// Settings accepted inside an agent's `tls` block.
+pub(crate) const RECOGNIZED_AGENT_TLS_KEYS: &[&str] =
+    &["ca-cert", "client-cert", "client-key", "tls-insecure"];
+
+/// Every setting the top-level `rate-limits` block reads.
+pub(crate) const RECOGNIZED_RATE_LIMITS_KEYS: &[&str] =
+    &["default-rps", "default-burst", "key", "global"];
+
+/// Settings accepted inside `rate-limits > global`.
+pub(crate) const RECOGNIZED_GLOBAL_LIMIT_KEYS: &[&str] = &["max-rps", "burst", "key"];
+
 pub fn parse_agents(node: &kdl::KdlNode) -> Result<Vec<AgentConfig>> {
     let mut agents = Vec::new();
 
@@ -423,11 +459,17 @@ fn parse_single_agent(node: &kdl::KdlNode) -> Result<AgentConfig> {
     let id = get_first_arg_string(node)
         .ok_or_else(|| anyhow::anyhow!("Agent requires an ID as first argument"))?;
 
-    // Get agent type from attribute
+    // Get agent type, accepting either the property form
+    // (`agent "waf" type="waf"`) or a `type` child node. The property form is
+    // what the documentation shows; the child form is what four shipped configs
+    // used, where it silently produced `Custom(<id>)` instead of the declared
+    // type. Both are accepted here for the same reason `unix-socket` accepts a
+    // child `path` or a bare argument.
     let agent_type = match node
         .get("type")
         .and_then(|v| v.as_string())
         .map(|s| s.to_string())
+        .or_else(|| get_string_entry(node, "type"))
     {
         Some(t) => match t.as_str() {
             "waf" => AgentType::Waf,
@@ -1479,6 +1521,68 @@ fn parse_tracing_backend(node: &kdl::KdlNode) -> Result<crate::observability::Tr
 
 #[cfg(test)]
 mod tests {
+    /// `type` is documented as a property but four shipped configs wrote it as
+    /// a child node, where it silently produced `Custom(<id>)` instead of the
+    /// declared type. Both forms are accepted.
+    #[test]
+    fn agent_type_is_read_from_a_property_or_a_child_node() {
+        fn agent_type_of(agents_block: &str) -> crate::agents::AgentType {
+            let kdl = format!(
+                r#"
+                schema-version "1.0"
+                system {{
+                    worker-threads 1
+                }}
+                listeners {{
+                    listener "l" {{
+                        address "127.0.0.1:8080"
+                    }}
+                }}
+                routes {{
+                    route "r" {{
+                        matches {{
+                            path "/"
+                        }}
+                        service-type "builtin"
+                        builtin-handler "health"
+                    }}
+                }}
+                {agents_block}
+                "#
+            );
+            crate::Config::from_kdl(&kdl)
+                .expect("config parses")
+                .agents
+                .remove(0)
+                .agent_type
+        }
+
+        let property = agent_type_of(
+            r#"agents {
+                   agent "a1" type="waf" {
+                       unix-socket "/tmp/a.sock"
+                   }
+               }"#,
+        );
+        let child = agent_type_of(
+            r#"agents {
+                   agent "a1" {
+                       type "waf"
+                       unix-socket "/tmp/a.sock"
+                   }
+               }"#,
+        );
+
+        assert!(
+            matches!(property, crate::agents::AgentType::Waf),
+            "property form: got {property:?}"
+        );
+        assert!(
+            matches!(child, crate::agents::AgentType::Waf),
+            "child form was Custom(<id>) before this fix; got {child:?}"
+        );
+    }
+
     use super::*;
     use zentinel_common::CircuitBreakerConfig;
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -52,7 +52,6 @@ pub mod resolution;
 pub mod routes;
 pub mod server;
 pub mod upstreams;
-#[cfg(feature = "validation")]
 pub mod validate;
 pub mod validation;
 pub mod waf;

--- a/crates/config/src/validate/mod.rs
+++ b/crates/config/src/validate/mod.rs
@@ -3,11 +3,18 @@
 //! This module provides comprehensive validation for Zentinel configurations,
 //! including network connectivity, certificate validation, and best practices linting.
 
-pub mod agents;
-pub mod certs;
+// The pure checks -- key names and best practices -- work on a parsed config
+// and a KDL document, so they are available everywhere, including WASM. The
+// rest reach the network, the filesystem and X.509, and need the runtime.
 pub mod lint;
-pub mod network;
 pub mod unknown_keys;
+
+#[cfg(feature = "validation")]
+pub mod agents;
+#[cfg(feature = "validation")]
+pub mod certs;
+#[cfg(feature = "validation")]
+pub mod network;
 
 use std::fmt;
 

--- a/crates/config/src/validate/unknown_keys.rs
+++ b/crates/config/src/validate/unknown_keys.rs
@@ -45,6 +45,17 @@ enum Nesting {
     Root,
     /// Matches only as a direct child of the named block.
     In(&'static str),
+    /// Matches a node inside `parent` carrying a child node `child` whose value
+    /// is `value`.
+    ///
+    /// For blocks discriminated by a setting rather than by their own argument:
+    /// a `filter` block's valid settings depend on its `type` child, while its
+    /// own argument is just the filter's id.
+    InWithChild {
+        parent: &'static str,
+        child: &'static str,
+        value: &'static str,
+    },
     /// Matches a node inside `parent` whose own first argument is `arg`.
     ///
     /// For blocks whose valid keys depend on the value they carry:
@@ -81,6 +92,11 @@ impl ClosedBlock {
                 parent: required,
                 arg,
             } => parent == Some(required) && first_arg(node) == Some(arg),
+            Nesting::InWithChild {
+                parent: required,
+                child,
+                value,
+            } => parent == Some(required) && child_value(node, child) == Some(value),
         }
     }
 
@@ -89,9 +105,18 @@ impl ClosedBlock {
         match self.nesting {
             Nesting::Anywhere => 0,
             Nesting::Root | Nesting::In(_) => 1,
-            Nesting::InWithArg { .. } => 2,
+            Nesting::InWithArg { .. } | Nesting::InWithChild { .. } => 2,
         }
     }
+}
+
+/// The value of a node's named child, if it has one.
+fn child_value<'a>(node: &'a kdl::KdlNode, child: &str) -> Option<&'a str> {
+    node.children()?
+        .nodes()
+        .iter()
+        .find(|n| n.name().value() == child)
+        .and_then(first_arg)
 }
 
 /// A node's first argument as a string, if it has one.
@@ -348,6 +373,62 @@ const CLOSED_BLOCKS: &[ClosedBlock] = &[
         keys: crate::kdl::upstreams::RECOGNIZED_WARMTH_DETECTION_KEYS,
     },
     ClosedBlock {
+        name: "agent",
+        nesting: Nesting::Anywhere,
+        keys: crate::kdl::RECOGNIZED_AGENT_KEYS,
+    },
+    // An agent's transport blocks. Each also accepts its address as a bare
+    // argument (`grpc "http://..."`), which needs no key at all.
+    ClosedBlock {
+        name: "unix-socket",
+        nesting: Nesting::In("agent"),
+        keys: &["path"],
+    },
+    ClosedBlock {
+        name: "grpc",
+        nesting: Nesting::In("agent"),
+        keys: &["address", "tls"],
+    },
+    ClosedBlock {
+        name: "http",
+        nesting: Nesting::In("agent"),
+        keys: &["url", "tls"],
+    },
+    // An agent transport's `tls` block -- a third meaning of the name, after
+    // the listener's and the upstream's.
+    ClosedBlock {
+        name: "tls",
+        nesting: Nesting::In("grpc"),
+        keys: crate::kdl::RECOGNIZED_AGENT_TLS_KEYS,
+    },
+    ClosedBlock {
+        name: "tls",
+        nesting: Nesting::In("http"),
+        keys: crate::kdl::RECOGNIZED_AGENT_TLS_KEYS,
+    },
+    ClosedBlock {
+        name: "rate-limits",
+        nesting: Nesting::Anywhere,
+        keys: crate::kdl::RECOGNIZED_RATE_LIMITS_KEYS,
+    },
+    ClosedBlock {
+        name: "global",
+        nesting: Nesting::In("rate-limits"),
+        keys: crate::kdl::RECOGNIZED_GLOBAL_LIMIT_KEYS,
+    },
+    // A filter's settings depend on its `type` child, not on its own argument,
+    // which is just the filter's id. Only rate-limit filters are described
+    // here; a filter of any other type matches nothing and is left unchecked.
+    ClosedBlock {
+        name: "filter",
+        nesting: Nesting::InWithChild {
+            parent: "filters",
+            child: "type",
+            value: "rate-limit",
+        },
+        keys: crate::kdl::filters::RECOGNIZED_RATE_LIMIT_FILTER_KEYS,
+    },
+    ClosedBlock {
         name: "policies",
         nesting: Nesting::Anywhere,
         keys: &[
@@ -460,6 +541,9 @@ fn describe(block: &ClosedBlock) -> String {
         Nesting::In(parent) => format!("a '{parent}' block's '{}' block", block.name),
         Nesting::InWithArg { parent, arg } => {
             format!("a '{parent}' block's '{} \"{arg}\"' block", block.name)
+        }
+        Nesting::InWithChild { child, value, .. } => {
+            format!("a '{}' block with {child} \"{value}\"", block.name)
         }
         Nesting::Anywhere => format!("the '{}' block", block.name),
     }
@@ -1436,6 +1520,170 @@ mod tests {
             warnings.iter().any(|w| w.contains("'prompt'")),
             "an inference-probe setting on queue-depth: {warnings:?}"
         );
+    }
+
+    #[test]
+    fn a_valid_agent_produces_no_warnings() {
+        let kdl = r#"
+            agents {
+                agent "waf-agent" type="waf" {
+                    unix-socket "/var/run/zentinel/waf.sock"
+                    events "request_headers" "request_body"
+                    timeout-ms 200
+                    failure-mode "closed"
+                    max-concurrent-calls 100
+                    circuit-breaker {
+                        failure-threshold 5
+                    }
+                    config {
+                        anything-goes-here #true
+                    }
+                }
+            }
+        "#;
+        assert!(warnings_for(kdl).is_empty(), "{:?}", warnings_for(kdl));
+    }
+
+    #[test]
+    fn an_unknown_agent_key_is_reported() {
+        let kdl = r#"
+            agents {
+                agent "a" {
+                    timeout-msec 200
+                }
+            }
+        "#;
+        let warnings = warnings_for(kdl);
+        assert!(
+            warnings.iter().any(|w| w.contains("'timeout-msec'")),
+            "{warnings:?}"
+        );
+    }
+
+    /// An agent transport's `tls` is the third distinct meaning of that block
+    /// name, after the listener's and the upstream's.
+    #[test]
+    fn agent_transport_tls_has_its_own_keys() {
+        let valid = r#"
+            agents {
+                agent "a" {
+                    grpc {
+                        address "http://localhost:50051"
+                        tls {
+                            ca-cert "/ca.crt"
+                            client-cert "/c.crt"
+                            client-key "/c.key"
+                            tls-insecure #false
+                        }
+                    }
+                }
+            }
+        "#;
+        assert!(warnings_for(valid).is_empty(), "{:?}", warnings_for(valid));
+
+        // `cert-file` is a listener TLS key; `sni` is an upstream one.
+        let wrong = r#"
+            agents {
+                agent "a" {
+                    grpc {
+                        address "http://localhost:50051"
+                        tls {
+                            cert-file "/c.crt"
+                            sni "x"
+                        }
+                    }
+                }
+            }
+        "#;
+        let warnings = warnings_for(wrong);
+        assert!(
+            warnings.iter().any(|w| w.contains("'cert-file'")),
+            "{warnings:?}"
+        );
+        assert!(warnings.iter().any(|w| w.contains("'sni'")), "{warnings:?}");
+    }
+
+    #[test]
+    fn the_global_rate_limits_block_is_checked() {
+        let valid = r#"
+            rate-limits {
+                default-rps 100
+                default-burst 10
+                key "client-ip"
+                global {
+                    max-rps 50000
+                    burst 1000
+                }
+            }
+        "#;
+        assert!(warnings_for(valid).is_empty(), "{:?}", warnings_for(valid));
+
+        // The shipped configs' spelling for the global limit is
+        // `max-requests-per-second-global`, which this block does not read.
+        let wrong = r#"
+            rate-limits {
+                max-requests-per-second-global 50000
+            }
+        "#;
+        assert!(
+            warnings_for(wrong)
+                .iter()
+                .any(|w| w.contains("'max-requests-per-second-global'")),
+            "{:?}",
+            warnings_for(wrong)
+        );
+    }
+
+    /// A filter's settings depend on its `type` child, not on its own argument
+    /// -- the argument is the filter's id.
+    #[test]
+    fn a_rate_limit_filter_is_checked_by_its_type_child() {
+        let valid = r#"
+            filters {
+                filter "my-limiter" {
+                    type "rate-limit"
+                    max-rps 100
+                    burst 10
+                    key "client-ip"
+                    on-limit "reject"
+                    status-code 429
+                    backend "redis"
+                    redis-url "redis://localhost"
+                    redis-fallback-local #true
+                }
+            }
+        "#;
+        assert!(warnings_for(valid).is_empty(), "{:?}", warnings_for(valid));
+
+        let typo = r#"
+            filters {
+                filter "my-limiter" {
+                    type "rate-limit"
+                    max-rp 100
+                }
+            }
+        "#;
+        let warnings = warnings_for(typo);
+        assert!(
+            warnings.iter().any(|w| w.contains("'max-rp'")),
+            "{warnings:?}"
+        );
+    }
+
+    /// Filters of a type this check does not describe are left alone rather
+    /// than measured against the wrong list.
+    #[test]
+    fn a_filter_of_another_type_is_not_checked() {
+        let kdl = r#"
+            filters {
+                filter "c" {
+                    type "cors"
+                    allow-origins "*"
+                    allow-methods "GET"
+                }
+            }
+        "#;
+        assert!(warnings_for(kdl).is_empty(), "{:?}", warnings_for(kdl));
     }
 
     fn warning_texts(result: &ValidationResult) -> Vec<String> {

--- a/crates/playground-wasm/src/lib.rs
+++ b/crates/playground-wasm/src/lib.rs
@@ -515,7 +515,7 @@ pub fn lint_config(config_kdl: &str) -> JsValue {
         .iter()
         .any(|w| matches!(w.severity, zentinel_config_inspect::Severity::Error));
 
-    let warnings: Vec<LintWarning> = topology
+    let mut warnings: Vec<LintWarning> = topology
         .warnings
         .iter()
         .map(|w| LintWarning {
@@ -525,6 +525,30 @@ pub fn lint_config(config_kdl: &str) -> JsValue {
             context: w.context.clone(),
         })
         .collect();
+
+    // Settings that parse and are then read by nothing: unknown keys, keys
+    // swallowed by a run-together line, and keys written into the wrong one of
+    // two same-named blocks. These work from the KDL source rather than the
+    // parsed config, because by the time a `Config` exists the evidence is gone
+    // -- so the playground has to check the text it was given, exactly as
+    // `zentinel lint` does.
+    let mut key_result = zentinel_config::validate::ValidationResult::default();
+    zentinel_config::validate::unknown_keys::check_unknown_keys(config_kdl, &mut key_result);
+    warnings.extend(key_result.warnings.iter().map(|w| LintWarning {
+        severity: "warning".to_string(),
+        code: "unknown-key".to_string(),
+        message: w.message.clone(),
+        context: Vec::new(),
+    }));
+
+    // Best-practice checks, the same set the CLI reports.
+    let practice = zentinel_config::validate::lint::lint_config(&config);
+    warnings.extend(practice.warnings.iter().map(|w| LintWarning {
+        severity: "warning".to_string(),
+        code: "best-practice".to_string(),
+        message: w.message.clone(),
+        context: Vec::new(),
+    }));
 
     serde_wasm_bindgen::to_value(&LintResponse {
         warnings,


### PR DESCRIPTION
Completes the block list in #365, and closes a gap between the CLI and the browser
playground.

## Blocks added

`agent` and its transport blocks (`unix-socket`, `grpc`, `http`), an agent transport's
`tls`, the global `rate-limits` block and its `global` sub-block, and rate-limit filters.

An agent transport's `tls` is the **third** distinct meaning of that block name, after a
listener's and an upstream's, sharing no keys with either.

## A third kind of qualification

A `filter`'s settings depend on its `type` **child**, while its own argument is just the
filter's id — so neither `In` nor `InWithArg` fits. `Nesting` gains
`InWithChild { parent, child, value }`.

Only rate-limit filters are described; a filter of any other type matches no entry and is
left unchecked rather than measured against the wrong list.

## The guard test found a bug in four shipped configs

`config/zentinel.kdl` among them, seven occurrences:

```kdl
agent "waf-agent" {
    type "waf"      // read by nothing
}
```

The parser read `type` only as a **property** (`agent "waf-agent" type="waf"`), which is
what the docs show. The child form silently produced `Custom("waf-agent")` instead of
`Waf`. Verified directly before changing anything:

```
property form:   agent_type = Some(Waf)
child-node form: agent_type = Some(Custom("a1"))
```

**I fixed the parser rather than the four configs.** Editing ours would leave every user
who copied them still affected, and accepting both forms is the same accommodation
`unix-socket`, `grpc` and `http` already make for a child node or a bare argument.

Safe because the blast radius is small: `agent_type` feeds a tracing field and the
config-dump handler and nothing else — no routing or security behaviour changes. Agents
declared with the child form will start reporting their declared type in logs instead of
their id.

## The playground was checking something else entirely

`lint_config` in the WASM payload reported only `config-inspect`'s topology warnings.
**None of the #365 work reached it** — a config could lint clean in the browser and be
full of settings the proxy ignores.

The cause was packaging, not design: `check_unknown_keys` and `validate::lint` need
nothing but a parsed config and a KDL document, yet sat behind the `validation` feature,
which pulls in tokio, x509-parser and pem and cannot build for WASM.

Gating moves down a level — `validate::{lint, unknown_keys}` are always available;
`validate::{agents, certs, network}` stay behind `validation`. The playground now runs the
same two checks the CLI does.

## Verified against the built payload, not just the source

Every shipped config through the actual WASM binary under node:

```
23 configs | invalid: 0 | with dead keys: 0
```

And a negative control, because `dead-keys=0` would look identical if the checks simply
weren't wired:

```
! 'max-conections' is not a setting in the 'system' block ... Did you mean 'max-connections'?
! 'namespace' is being read as an argument to 'address' rather than as a setting ...
! 'disk-path' is a setting of the top-level 'cache' block, not of a 'route' block's ...
```

All three mechanisms fire in the browser payload.

## Tests

6 new lint tests plus a parser test pinning both agent `type` forms.
`cargo test --workspace` green; `cargo test -p zentinel-config --features validation` at
368; clippy `-D warnings` and `fmt --check` clean; `--no-default-features` builds.

## #365 status

**Checked — 35 blocks.** Remaining: the observability blocks.