### PR TITLE
chore: bump workspace version to 0.6.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8182,7 +8182,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8223,7 +8223,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8245,7 +8245,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8324,7 +8324,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8505,7 +8505,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8596,7 +8596,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8613,7 +8613,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.30"
+version = "0.6.31"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/config-inspect/Cargo.toml
+++ b/crates/config-inspect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-config-inspect"
-version = "0.6.30"
+version = "0.6.31"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/playground-wasm/Cargo.toml
+++ b/crates/playground-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-playground-wasm"
-version = "0.6.30"
+version = "0.6.31"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/sim/Cargo.toml
+++ b/crates/sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-sim"
-version = "0.6.30"
+version = "0.6.31"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Post-release bump for 26.08_8. Opened by hand, as always — the workflow force-pushes this
branch and its own `gh pr create` then fails.

- the workflow's commit, bumping the four `Cargo.toml` files
- `Cargo.lock`, which the workflow does not touch; without it main carries a lockfile still
  naming `0.6.30`

`cargo update --workspace` moved only the workspace members' own versions; external
dependencies are untouched.

**Safe to merge:** `git log chore/bump-0.6.31..origin/main` is empty, so the branch is
based on the current tip and reverts nothing.

Afterwards main sits at `0.6.31`, matching crates.io.