### PR TITLE
chore: track AGENTS.md and the playground-wasm lockfile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,248 @@
+# Zentinel
+
+> **Security-first reverse proxy built to guard the free web.**
+
+Zentinel is an open-source, high-performance reverse proxy built on Cloudflare's Pingora framework. It emphasizes **predictability**, **transparency**, and **operational simplicity**—infrastructure that lets operators sleep.
+
+## Philosophy (North Star)
+
+Every contribution must align with the [Manifesto](../MANIFESTO.md):
+
+1. **Infrastructure should be calm** — No surprises. Clear limits, predictable timeouts, explainable failure modes.
+2. **Security must be explicit** — No magic, no implied policy. Every decision visible and traceable.
+3. **The edge is a boundary, not a battleground** — Step in only when necessary, proportionally.
+4. **Complexity must be isolated** — Core dataplane stays small. Complex logic lives in external agents.
+5. **The web is a commons** — No vendor lock-in, no hidden control planes. Code is readable, forkable, modifiable.
+6. **Production correctness beats feature breadth** — Boring reliability over shiny features.
+
+**Before adding anything, ask:**
+- Does this introduce ambiguity?
+- Can this fail loudly and safely?
+- Will this make someone's on-call worse?
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         Zentinel Proxy                               │
+│  ┌─────────────────────────────────────────────────────────────────┐│
+│  │                    Pingora Foundation                            ││
+│  │  (async I/O, connection pooling, TLS, HTTP/1.1 & HTTP/2)        ││
+│  └─────────────────────────────────────────────────────────────────┘│
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌────────────┐│
+│  │ Routing  │ │  Rate    │ │  Cache   │ │ Filters  │ │   Agent    ││
+│  │  Engine  │ │ Limiting │ │  Layer   │ │  Chain   │ │  Manager   ││
+│  └──────────┘ └──────────┘ └──────────┘ └──────────┘ └─────┬──────┘│
+└────────────────────────────────────────────────────────────┼────────┘
+                                                             │
+                    ┌────────────────────────────────────────┼────────┐
+                    │              External Agents            │        │
+                    │  ┌─────────┐ ┌─────────┐ ┌─────────┐  │        │
+                    │  │   WAF   │ │  Auth   │ │  Rate   │  │◄───────┘
+                    │  │  Agent  │ │  Agent  │ │  Limit  │  │
+                    │  └─────────┘ └─────────┘ └─────────┘  │
+                    └───────────────────────────────────────────────────┘
+```
+
+**Key design choice:** Agents are external processes, not compiled into the proxy. This provides crash isolation, independent deployment, and language flexibility.
+
+---
+
+## Crates
+
+Each crate has its own `docs/` directory with detailed documentation. **When making changes to a crate, update its `docs/` accordingly.**
+
+### Core Crates
+
+#### `zentinel-proxy` (`crates/proxy/`)
+Main binary and Pingora integration. Implements HTTP handling, routing, filtering, and upstream communication.
+- **Key types:** `ZentinelProxy`, `ProxyApp`
+- **Docs:** `crates/proxy/docs/` — architecture, agents, rate-limiting, inference routing, modules
+
+#### `zentinel-config` (`crates/config/`)
+KDL configuration parsing, validation, and schema. Handles all configuration file processing.
+- **Key types:** `Config`, `RouteConfig`, `UpstreamConfig`, `ListenerConfig`
+- **Docs:** `crates/config/docs/` — KDL format, schema reference, validation rules, examples
+
+#### `zentinel-agent-protocol` (`crates/agent-protocol/`)
+Agent communication protocol (v2). Handles UDS, gRPC, and reverse connections.
+- **Key types:** `AgentPool`, `AgentClientV2`, `Decision`, `ReverseConnectionListener`
+- **Docs:** `crates/agent-protocol/docs/` — v2/ protocol specs, API reference, transport options
+
+#### `zentinel-common` (`crates/common/`)
+Shared types, utilities, and error handling used across all crates.
+- **Key types:** `RequestId`, `Limits`, error types, identifiers
+- **Docs:** `crates/common/docs/` — errors, identifiers, limits, observability, patterns
+
+### Supporting Crates
+
+| Crate | Path | Purpose |
+|-------|------|---------|
+| `playground-wasm` | `crates/playground-wasm/` | WASM module for web playground (config validation) |
+| `wasm-runtime` | `crates/wasm-runtime/` | WASM agent runtime using Wasmtime |
+| `sim` | `crates/sim/` | Simulation and testing utilities |
+| `stack` | `crates/stack/` | Integration test harness |
+
+### Crate Dependencies
+
+```
+zentinel-proxy
+├── zentinel-config
+├── zentinel-agent-protocol
+├── zentinel-common
+└── pingora (external)
+
+zentinel-config
+└── zentinel-common
+
+zentinel-agent-protocol
+└── zentinel-common
+```
+
+**Dependency rules:**
+- `proxy` may depend on all internal crates
+- `config` and `agent-protocol` depend only on `common`
+- `common` has no internal dependencies
+
+---
+
+## Key Concepts
+
+### Request Lifecycle
+
+1. **Accept** — TCP connection established, TLS handshake (if HTTPS)
+2. **Parse** — HTTP request parsed, headers extracted
+3. **Route** — Priority-based matching, LRU cached
+4. **Filter** — Pre-upstream filters, agent hooks
+5. **Upstream** — Load-balanced backend selection, request forwarding
+6. **Response** — Response filters, caching, compression
+7. **Log** — Access logging, metrics emission
+
+### Agent Protocol
+
+Uses the **v2** protocol — binary UDS, gRPC, connection pooling, streaming, cancellation.
+
+Agents handle: WAF, authentication, rate limiting, custom policy, request validation.
+
+### Configuration (KDL)
+
+Human-readable configuration language. Key blocks:
+- `system` — Workers, limits, timeouts
+- `listeners` — Network endpoints, TLS
+- `routes` — Request matching, forwarding
+- `upstreams` — Backend pools, health checks
+- `agents` — External agent configuration
+
+---
+
+## Rules
+
+| File | Purpose |
+|------|---------|
+| [rust-standards.md](rules/rust-standards.md) | Rust coding standards (APIs, error handling, async) |
+| [project.md](rules/project.md) | Zentinel-specific context and architecture |
+| [patterns.md](rules/patterns.md) | Code patterns (Pingora, agents, config) |
+| [workflow.md](rules/workflow.md) | Commands, testing, releases |
+
+---
+
+## Quick Reference
+
+### Common Commands
+
+```bash
+# Development
+cargo build --workspace
+cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+
+# Run locally
+cargo run --bin zentinel -- --config config/zentinel.kdl
+
+# Run specific tests
+cargo test -p zentinel-proxy test_name
+cargo test -p zentinel-config --lib
+
+# Benchmarks
+cargo bench -p zentinel-proxy
+```
+
+### Key Files
+
+| Path | Purpose |
+|------|---------|
+| `crates/proxy/src/lib.rs` | Main proxy implementation |
+| `crates/config/src/lib.rs` | Configuration parsing entry |
+| `crates/agent-protocol/src/v2/` | Agent protocol v2 implementation |
+| `config/zentinel.kdl` | Default configuration |
+| `tests/` | Integration tests |
+
+### Documentation
+
+**When making meaningful changes, documentation must be updated in multiple places:**
+
+#### 1. Crate-level docs (this repo)
+Each crate has a `docs/` directory for technical reference:
+```
+crates/proxy/docs/           # Architecture, routing, filtering
+crates/config/docs/          # KDL format, schema, validation
+crates/agent-protocol/docs/  # Protocol v2/, transports
+crates/common/docs/          # Shared types, errors, patterns
+```
+
+**Update when:** Changing APIs, adding features, modifying behavior.
+
+#### 2. Documentation site (separate repo)
+**Repo:** `github.com/zentinelproxy/zentinelproxy.io-docs`
+**Live:** https://zentinelproxy.io/docs
+
+Contains user-facing documentation: getting started, configuration guides, examples, operations, deployment.
+
+**Update when:**
+- New user-visible features
+- Configuration option changes
+- New examples or use cases
+- Breaking changes
+
+**Structure:**
+```
+content/
+├── getting-started/    # Installation, quick start
+├── concepts/           # Architecture, routing, request lifecycle
+├── configuration/      # All config options
+├── agents/             # Agent protocol v2/
+├── examples/           # Production-ready configs
+├── operations/         # Security, monitoring, troubleshooting
+├── deployment/         # Docker, K8s, systemd
+└── reference/          # CLI, env vars, error codes
+```
+
+#### 3. Design documents (this repo)
+- [AGENT_PROTOCOL_2.0.md](AGENT_PROTOCOL_2.0.md) — Agent protocol design and roadmap
+
+#### External Links
+- **Marketing site:** https://zentinelproxy.io
+- **Documentation:** https://zentinelproxy.io/docs
+
+---
+
+## Contributing Checklist
+
+Before submitting code:
+
+**Code Quality:**
+- [ ] Aligns with [Manifesto](../MANIFESTO.md) principles
+- [ ] Has bounded resources (no unbounded growth)
+- [ ] Fails loudly and safely
+- [ ] Is observable (metrics, logs, traces)
+- [ ] Has tests (unit + integration where applicable)
+- [ ] Passes `cargo clippy -- -D warnings`
+- [ ] Passes `cargo fmt --check`
+
+**Documentation:**
+- [ ] Crate `docs/` updated if API or behavior changed
+- [ ] Docs site (`zentinelproxy.io-docs`) updated if user-visible changes
+- [ ] Code comments for non-obvious logic
+- [ ] Public API has doc comments with `# Errors` section

--- a/crates/playground-wasm/Cargo.lock
+++ b/crates/playground-wasm/Cargo.lock
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.28"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.28"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config-inspect"
-version = "0.6.28"
+version = "0.6.31"
 dependencies = [
  "anyhow",
  "serde",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-playground-wasm"
-version = "0.6.28"
+version = "0.6.31"
 dependencies = [
  "console_error_panic_hook",
  "serde",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-sim"
-version = "0.6.28"
+version = "0.6.31"
 dependencies = [
  "regex",
  "serde",


### PR DESCRIPTION
Two files that were sitting untracked.

**`AGENTS.md`** — untracked since July, and byte-identical to `.claude/CLAUDE.md`. That
identity is the point: `AGENTS.md` is the vendor-neutral filename other coding agents look
for, so tracking it makes the same guidance available to them rather than leaving it
Claude-specific.

**`crates/playground-wasm/Cargo.lock`** — moved when the payload was rebuilt at 0.6.31 for
the playground refresh. That crate is outside the workspace and carries its own lockfile,
so it does not follow the workspace one and the drift would otherwise persist.

No source changes.