### PR TITLE
feat(config): check observability blocks, and drop three settings nothing reads

### DIFF
--- a/config/examples/api-gateway.kdl
+++ b/config/examples/api-gateway.kdl
@@ -228,12 +228,10 @@ observability {
         access-log {
             enabled #true
             file "/var/log/zentinel/api-gateway-access.log"
-            include-trace-id #true
         }
     }
 
     tracing {
-        enabled #true
         backend "otlp" {
             endpoint "http://localhost:4317"
         }

--- a/config/examples/api-schema-validation.kdl
+++ b/config/examples/api-schema-validation.kdl
@@ -324,7 +324,6 @@ routes {
 // Observability
 observability {
     tracing {
-        enabled #true
         backend "otlp" {
             endpoint "http://localhost:4317"
         }

--- a/config/examples/inference-routing.kdl
+++ b/config/examples/inference-routing.kdl
@@ -325,7 +325,6 @@ observability {
             enabled #true
             file "/var/log/zentinel/inference-access.log"
             // Include token counts in access logs
-            include-trace-id #true
         }
     }
 }

--- a/config/examples/mixed-services.kdl
+++ b/config/examples/mixed-services.kdl
@@ -365,12 +365,10 @@ observability {
         access-log {
             enabled #true
             file "/var/log/zentinel/gateway-access.log"
-            include-trace-id #true
         }
     }
 
     tracing {
-        enabled #true
         backend "otlp" {
             endpoint "http://tempo.monitoring:4317"
         }

--- a/config/examples/shadow-traffic.kdl
+++ b/config/examples/shadow-traffic.kdl
@@ -340,7 +340,6 @@ observability {
         access-log {
             enabled #true
             file "/var/log/zentinel/access.log"
-            include-trace-id #true
             // Shadow requests are logged with shadow=true field
         }
     }

--- a/config/examples/tracing.kdl
+++ b/config/examples/tracing.kdl
@@ -147,7 +147,6 @@ observability {
         access-log {
             enabled #true
             file "/var/log/zentinel/access.log"
-            include-trace-id #true
         }
     }
 
@@ -162,7 +161,6 @@ observability {
     //   jaegertracing/all-in-one:latest
 
     tracing {
-        enabled #true
 
         // OTLP exporter (works with Jaeger, Tempo, etc.)
         backend "otlp" {

--- a/config/zentinel.kdl
+++ b/config/zentinel.kdl
@@ -417,7 +417,6 @@ observability {
     logging {
         level "info"  // "trace", "debug", "info", "warn", "error"
         format "json"  // "json" or "pretty"
-        timestamps #true
 
         // Access log - all HTTP requests with trace_id for correlation
         access-log {
@@ -425,7 +424,6 @@ observability {
             file "/var/log/zentinel/access.log"
             format "json"  // "json" or "combined"
             buffer-size 8192
-            include-trace-id #true
         }
 
         // Error log - warnings and errors

--- a/crates/config/src/kdl/mod.rs
+++ b/crates/config/src/kdl/mod.rs
@@ -1288,6 +1288,47 @@ fn parse_rate_limit_key(key: &str) -> Result<RateLimitKey> {
 ///     }
 /// }
 /// ```
+/// Blocks `parse_observability_config` reads. It has no settings of its own.
+pub(crate) const RECOGNIZED_OBSERVABILITY_KEYS: &[&str] = &["logging", "metrics", "tracing"];
+
+/// Settings and blocks `parse_logging_config` reads.
+pub(crate) const RECOGNIZED_LOGGING_KEYS: &[&str] =
+    &["level", "format", "access-log", "error-log", "audit-log"];
+
+/// Settings `parse_access_log_config` reads.
+pub(crate) const RECOGNIZED_ACCESS_LOG_KEYS: &[&str] =
+    &["enabled", "file", "format", "buffer-size"];
+
+/// Settings `parse_error_log_config` reads.
+///
+/// Note this takes `level` where the access log takes `format`: the two log
+/// blocks look alike and accept different settings.
+pub(crate) const RECOGNIZED_ERROR_LOG_KEYS: &[&str] = &["enabled", "file", "level", "buffer-size"];
+
+/// Settings `parse_audit_log_config` reads.
+pub(crate) const RECOGNIZED_AUDIT_LOG_KEYS: &[&str] = &[
+    "enabled",
+    "file",
+    "buffer-size",
+    "log-blocked",
+    "log-agent-decisions",
+    "log-waf-events",
+];
+
+/// Settings `parse_metrics_config` reads.
+pub(crate) const RECOGNIZED_METRICS_KEYS: &[&str] =
+    &["enabled", "address", "path", "high-cardinality"];
+
+/// Settings and blocks `parse_tracing_config` reads.
+pub(crate) const RECOGNIZED_TRACING_KEYS: &[&str] = &["backend", "sampling-rate", "service-name"];
+
+/// Settings a tracing `backend` block reads.
+///
+/// The backend kind is the node's own argument (`backend "otlp" { ... }`) and
+/// all three kinds -- otlp, jaeger, zipkin -- take the same single setting, so
+/// one list covers them.
+pub(crate) const RECOGNIZED_TRACING_BACKEND_KEYS: &[&str] = &["endpoint"];
+
 pub fn parse_observability_config(node: &kdl::KdlNode) -> Result<ObservabilityConfig> {
     let mut config = ObservabilityConfig::default();
 

--- a/crates/config/src/validate/unknown_keys.rs
+++ b/crates/config/src/validate/unknown_keys.rs
@@ -429,6 +429,50 @@ const CLOSED_BLOCKS: &[ClosedBlock] = &[
         keys: crate::kdl::filters::RECOGNIZED_RATE_LIMIT_FILTER_KEYS,
     },
     ClosedBlock {
+        name: "observability",
+        nesting: Nesting::Anywhere,
+        keys: crate::kdl::RECOGNIZED_OBSERVABILITY_KEYS,
+    },
+    ClosedBlock {
+        name: "logging",
+        nesting: Nesting::Anywhere,
+        keys: crate::kdl::RECOGNIZED_LOGGING_KEYS,
+    },
+    ClosedBlock {
+        name: "access-log",
+        nesting: Nesting::Anywhere,
+        keys: crate::kdl::RECOGNIZED_ACCESS_LOG_KEYS,
+    },
+    ClosedBlock {
+        // Takes `level` where the access log takes `format`; the two look alike
+        // and accept different settings.
+        name: "error-log",
+        nesting: Nesting::Anywhere,
+        keys: crate::kdl::RECOGNIZED_ERROR_LOG_KEYS,
+    },
+    ClosedBlock {
+        name: "audit-log",
+        nesting: Nesting::Anywhere,
+        keys: crate::kdl::RECOGNIZED_AUDIT_LOG_KEYS,
+    },
+    ClosedBlock {
+        name: "metrics",
+        nesting: Nesting::Anywhere,
+        keys: crate::kdl::RECOGNIZED_METRICS_KEYS,
+    },
+    ClosedBlock {
+        name: "tracing",
+        nesting: Nesting::Anywhere,
+        keys: crate::kdl::RECOGNIZED_TRACING_KEYS,
+    },
+    ClosedBlock {
+        // Qualified: a rate-limit filter also has a `backend`, but that one is
+        // a scalar setting rather than a block.
+        name: "backend",
+        nesting: Nesting::In("tracing"),
+        keys: crate::kdl::RECOGNIZED_TRACING_BACKEND_KEYS,
+    },
+    ClosedBlock {
         name: "policies",
         nesting: Nesting::Anywhere,
         keys: &[
@@ -1684,6 +1728,117 @@ mod tests {
             }
         "#;
         assert!(warnings_for(kdl).is_empty(), "{:?}", warnings_for(kdl));
+    }
+
+    #[test]
+    fn a_valid_observability_block_produces_no_warnings() {
+        let kdl = r#"
+            observability {
+                logging {
+                    level "info"
+                    format "json"
+                    access-log {
+                        enabled #true
+                        file "/var/log/zentinel/access.log"
+                        format "json"
+                        buffer-size 8192
+                    }
+                    error-log {
+                        enabled #true
+                        file "/var/log/zentinel/error.log"
+                        level "warn"
+                        buffer-size 4096
+                    }
+                    audit-log {
+                        enabled #true
+                        file "/var/log/zentinel/audit.log"
+                        buffer-size 4096
+                        log-blocked #true
+                        log-agent-decisions #true
+                        log-waf-events #true
+                    }
+                }
+                metrics {
+                    enabled #true
+                    address "0.0.0.0:9090"
+                    path "/metrics"
+                    high-cardinality #false
+                }
+                tracing {
+                    backend "otlp" {
+                        endpoint "http://localhost:4317"
+                    }
+                    sampling-rate 0.1
+                    service-name "zentinel"
+                }
+            }
+        "#;
+        assert!(warnings_for(kdl).is_empty(), "{:?}", warnings_for(kdl));
+    }
+
+    /// The access log takes `format`, the error log takes `level`. The two
+    /// blocks look alike, so each borrowing the other's setting must be caught.
+    #[test]
+    fn the_two_log_blocks_do_not_share_settings() {
+        let kdl = r#"
+            logging {
+                access-log { level "warn" }
+                error-log { format "json" }
+            }
+        "#;
+        let warnings = warnings_for(kdl);
+        assert!(
+            warnings.iter().any(|w| w.contains("'level'")),
+            "{warnings:?}"
+        );
+        assert!(
+            warnings.iter().any(|w| w.contains("'format'")),
+            "{warnings:?}"
+        );
+    }
+
+    /// Three settings that the documentation describes and no parser reads.
+    /// They shipped in seven configs; removing them from those configs is not
+    /// enough on its own, so the check has to keep reporting them.
+    #[test]
+    fn documented_but_unimplemented_observability_settings_are_reported() {
+        let kdl = r#"
+            observability {
+                logging {
+                    timestamps #true
+                    access-log {
+                        include-trace-id #true
+                    }
+                }
+                tracing {
+                    enabled #true
+                    backend "otlp" {
+                        endpoint "http://localhost:4317"
+                    }
+                }
+            }
+        "#;
+        let warnings = warnings_for(kdl);
+        for key in ["timestamps", "include-trace-id", "enabled"] {
+            assert!(
+                warnings.iter().any(|w| w.contains(&format!("'{key}'"))),
+                "{key} is documented but read by nothing: {warnings:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unknown_observability_block_is_reported() {
+        let kdl = r#"
+            observability {
+                profiling { enabled #true }
+            }
+        "#;
+        assert!(
+            warnings_for(kdl).iter().any(|w| w.contains("'profiling'")),
+            "{:?}",
+            warnings_for(kdl)
+        );
     }
 
     fn warning_texts(result: &ValidationResult) -> Vec<String> {


### PR DESCRIPTION
The last blocks for #365. **Closes #365.**

## Blocks added

`observability`, `logging`, `access-log`, `error-log`, `audit-log`, `metrics`, `tracing`,
and a tracing `backend`.

The access log takes `format` where the error log takes `level` — two blocks that look
alike and accept different settings — so each gets its own list. A test covers both
directions.

## The guard test found three documented settings that do nothing

Seven shipped configs, three settings, **read by no parser**:

| Setting | Block | Configs | Also in docs |
|---|---|---|---|
| `timestamps` | `logging` | 1 | ×6 |
| `include-trace-id` | `access-log` | 6 | ×8 |
| `enabled` | `tracing` | 3 | yes |

Every occurrence was `#true`, so removing them from the configs changes no behaviour —
they were already doing nothing.

**`tracing { enabled }` is the one with teeth.** Tracing is switched on by the *presence*
of the block, so a config saying `enabled #false` gets tracing anyway, silently. No
shipped config does that, but the documentation invites it.

I removed them from the configs here and **filed #415** for the real decision — implement
them or de-document them — rather than taking it in this PR. Implementing changes
behaviour for anyone writing `enabled #false`; de-documenting removes settings people may
want. Both are product calls.

A test pins all three as reportable, so they cannot quietly return to a shipped config.

## Tests

4 new: a fully-populated valid observability block, the two log blocks not sharing
settings, the three documented-but-unimplemented settings, and an unknown sub-block.

`cargo test -p zentinel-config --features validation` green at 372; clippy `-D warnings`
and `fmt --check` clean; all 23 shipped configs still parse.

## #365 is complete

**43 blocks checked**, catching three defect mechanisms — unknown keys, settings swallowed
by a run-together line, and settings written into the wrong one of two same-named blocks.

Across the issue's lifetime the checks found real defects in shipped configs and docs on
almost every pass: `verify` on an upstream `tls`, agent `type` as a child node, `cert-path`
in two docs pages, and now these three. That rate is the argument for the check existing.