### PR TITLE
feat(config): honour tracing `enabled` and the access log's `include-trace-id`

### DIFF
--- a/crates/config/src/kdl/mod.rs
+++ b/crates/config/src/kdl/mod.rs
@@ -1296,8 +1296,13 @@ pub(crate) const RECOGNIZED_LOGGING_KEYS: &[&str] =
     &["level", "format", "access-log", "error-log", "audit-log"];
 
 /// Settings `parse_access_log_config` reads.
-pub(crate) const RECOGNIZED_ACCESS_LOG_KEYS: &[&str] =
-    &["enabled", "file", "format", "buffer-size"];
+pub(crate) const RECOGNIZED_ACCESS_LOG_KEYS: &[&str] = &[
+    "enabled",
+    "file",
+    "format",
+    "buffer-size",
+    "include-trace-id",
+];
 
 /// Settings `parse_error_log_config` reads.
 ///
@@ -1320,7 +1325,8 @@ pub(crate) const RECOGNIZED_METRICS_KEYS: &[&str] =
     &["enabled", "address", "path", "high-cardinality"];
 
 /// Settings and blocks `parse_tracing_config` reads.
-pub(crate) const RECOGNIZED_TRACING_KEYS: &[&str] = &["backend", "sampling-rate", "service-name"];
+pub(crate) const RECOGNIZED_TRACING_KEYS: &[&str] =
+    &["enabled", "backend", "sampling-rate", "service-name"];
 
 /// Settings a tracing `backend` block reads.
 ///
@@ -1408,6 +1414,13 @@ fn parse_access_log_config(node: &kdl::KdlNode) -> Result<crate::observability::
     }
     if let Some(format) = get_string_entry(node, "format") {
         config.format = format;
+    }
+    // `include-trace-id` selects the trace id field in the access log line.
+    // The field list itself has no KDL syntax, so this is the only way to reach
+    // it -- and it was previously read by nothing at all.
+    if let Some(include_trace_id) = get_bool_entry(node, "include-trace-id") {
+        config.include_trace_id = include_trace_id;
+        config.fields.trace_id = include_trace_id;
     }
     if let Some(buffer_size) = get_int_entry(node, "buffer-size") {
         config.buffer_size = buffer_size as usize;
@@ -1508,11 +1521,13 @@ fn parse_tracing_config(node: &kdl::KdlNode) -> Result<crate::observability::Tra
 
     let backend = parse_tracing_backend(node)?;
 
+    let enabled = get_bool_entry(node, "enabled").unwrap_or(true);
     let sampling_rate = get_float_entry(node, "sampling-rate").unwrap_or(0.01);
     let service_name =
         get_string_entry(node, "service-name").unwrap_or_else(|| "zentinel".to_string());
 
     Ok(TracingConfig {
+        enabled,
         backend,
         sampling_rate,
         service_name,
@@ -1562,6 +1577,109 @@ fn parse_tracing_backend(node: &kdl::KdlNode) -> Result<crate::observability::Tr
 
 #[cfg(test)]
 mod tests {
+    /// Tracing used to be switched on by the presence of the block alone, so
+    /// `enabled #false` was read by nothing and tracing started regardless.
+    #[test]
+    fn tracing_enabled_is_read() {
+        fn tracing_of(body: &str) -> crate::observability::TracingConfig {
+            let kdl = format!(
+                r#"
+                schema-version "1.0"
+                system {{
+                    worker-threads 1
+                }}
+                listeners {{
+                    listener "l" {{
+                        address "127.0.0.1:8080"
+                    }}
+                }}
+                routes {{
+                    route "r" {{
+                        matches {{
+                            path "/"
+                        }}
+                        service-type "builtin"
+                        builtin-handler "health"
+                    }}
+                }}
+                observability {{
+                    tracing {{
+                        {body}
+                        backend "otlp" {{
+                            endpoint "http://localhost:4317"
+                        }}
+                    }}
+                }}
+                "#
+            );
+            crate::Config::from_kdl(&kdl)
+                .expect("config parses")
+                .observability
+                .tracing
+                .expect("tracing block present")
+        }
+
+        assert!(tracing_of("").enabled, "absent means enabled, as before");
+        assert!(tracing_of("enabled #true").enabled);
+        assert!(
+            !tracing_of("enabled #false").enabled,
+            "enabled #false must actually disable tracing"
+        );
+    }
+
+    /// `include-trace-id` selects the trace id field in the access log line.
+    /// The field list has no KDL syntax of its own, so this is the only way to
+    /// reach it.
+    #[test]
+    fn access_log_include_trace_id_is_read() {
+        fn access_log_of(body: &str) -> crate::observability::AccessLogConfig {
+            let kdl = format!(
+                r#"
+                schema-version "1.0"
+                system {{
+                    worker-threads 1
+                }}
+                listeners {{
+                    listener "l" {{
+                        address "127.0.0.1:8080"
+                    }}
+                }}
+                routes {{
+                    route "r" {{
+                        matches {{
+                            path "/"
+                        }}
+                        service-type "builtin"
+                        builtin-handler "health"
+                    }}
+                }}
+                observability {{
+                    logging {{
+                        access-log {{
+                            enabled #true
+                            {body}
+                        }}
+                    }}
+                }}
+                "#
+            );
+            crate::Config::from_kdl(&kdl)
+                .expect("config parses")
+                .observability
+                .logging
+                .access_log
+                .expect("access-log block present")
+        }
+
+        let on = access_log_of(r#"include-trace-id #true"#);
+        assert!(on.include_trace_id);
+        assert!(on.fields.trace_id, "the field the writer actually consults");
+
+        let off = access_log_of(r#"include-trace-id #false"#);
+        assert!(!off.include_trace_id);
+        assert!(!off.fields.trace_id);
+    }
+
     /// `type` is documented as a property but four shipped configs wrote it as
     /// a child node, where it silently produced `Custom(<id>)` instead of the
     /// declared type. Both forms are accepted.

--- a/crates/config/src/observability.rs
+++ b/crates/config/src/observability.rs
@@ -297,6 +297,15 @@ impl Default for AuditLogConfig {
 /// Tracing configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TracingConfig {
+    /// Whether to start the tracer.
+    ///
+    /// Tracing used to be switched on by the presence of the `tracing` block
+    /// alone, so a configuration saying `enabled #false` still got tracing. It
+    /// is honoured now, and defaults to true so that a block without it behaves
+    /// as it always has.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
     /// Tracing backend
     pub backend: TracingBackend,
 

--- a/crates/config/src/validate/unknown_keys.rs
+++ b/crates/config/src/validate/unknown_keys.rs
@@ -1797,11 +1797,15 @@ mod tests {
         );
     }
 
-    /// Three settings that the documentation describes and no parser reads.
-    /// They shipped in seven configs; removing them from those configs is not
-    /// enough on its own, so the check has to keep reporting them.
+    /// `timestamps` is documented for the application log and read by nothing.
+    ///
+    /// It is the last of the three from #415 still unimplemented: the tracing
+    /// `enabled` switch and the access log's `include-trace-id` are now parsed,
+    /// so only this one should still be reported. Honouring it would mean
+    /// starting the log subscriber after the configuration is read, which would
+    /// lose the diagnostics emitted while finding that configuration.
     #[test]
-    fn documented_but_unimplemented_observability_settings_are_reported() {
+    fn the_unread_timestamps_setting_is_still_reported() {
         let kdl = r#"
             observability {
                 logging {
@@ -1819,10 +1823,14 @@ mod tests {
             }
         "#;
         let warnings = warnings_for(kdl);
-        for key in ["timestamps", "include-trace-id", "enabled"] {
+        assert!(
+            warnings.iter().any(|w| w.contains("'timestamps'")),
+            "timestamps is documented but read by nothing: {warnings:?}"
+        );
+        for key in ["include-trace-id", "enabled"] {
             assert!(
-                warnings.iter().any(|w| w.contains(&format!("'{key}'"))),
-                "{key} is documented but read by nothing: {warnings:?}"
+                !warnings.iter().any(|w| w.contains(&format!("'{key}'"))),
+                "{key} is parsed now and must not be reported: {warnings:?}"
             );
         }
     }

--- a/crates/proxy/src/main.rs
+++ b/crates/proxy/src/main.rs
@@ -723,20 +723,29 @@ fn run_server(
             .collect();
     }
 
-    // Initialize OpenTelemetry tracer if configured
+    // Initialize OpenTelemetry tracer if configured and enabled.
+    //
+    // The block's presence used to be the only switch, so `enabled #false` was
+    // read by nothing and tracing started anyway. It is honoured here, and the
+    // skip is logged: an operator who turned tracing off should be able to see
+    // that it took effect.
     if let Some(ref tracing_config) = config.observability.tracing {
-        match zentinel_proxy::otel::init_tracer(tracing_config) {
-            Ok(()) => {
-                info!(
-                    backend = ?tracing_config.backend,
-                    sampling_rate = tracing_config.sampling_rate,
-                    service_name = %tracing_config.service_name,
-                    "OpenTelemetry tracing enabled"
-                );
-            }
-            Err(e) => {
-                warn!("Failed to initialize OpenTelemetry tracer: {}", e);
-                warn!("Distributed tracing will be disabled");
+        if !tracing_config.enabled {
+            info!("Distributed tracing disabled by configuration (tracing.enabled)");
+        } else {
+            match zentinel_proxy::otel::init_tracer(tracing_config) {
+                Ok(()) => {
+                    info!(
+                        backend = ?tracing_config.backend,
+                        sampling_rate = tracing_config.sampling_rate,
+                        service_name = %tracing_config.service_name,
+                        "OpenTelemetry tracing enabled"
+                    );
+                }
+                Err(e) => {
+                    warn!("Failed to initialize OpenTelemetry tracer: {}", e);
+                    warn!("Distributed tracing will be disabled");
+                }
             }
         }
     }


### PR DESCRIPTION
Two of the three settings from #415 are now read. Refs #415 rather than closing it — the
third is a real question, below.

## `tracing { enabled }` — the one with teeth

Tracing was switched on by the **presence** of the block. `enabled` was read by nothing, so:

```kdl
tracing {
    enabled #false
    backend "otlp" { endpoint "…" }
}
```

started tracing anyway. An operator turning it off to cut overhead, or to stop shipping
spans to a collector they no longer trust, did not get what they asked for and nothing said
so.

Defaults to `true`, so a block without it behaves exactly as before. The skip is logged
rather than silent — verified against a running proxy:

```
enabled #false → INFO Distributed tracing disabled by configuration (tracing.enabled)
enabled #true  → proceeds to init_tracer
```

## `access-log { include-trace-id }`

The access log writer already consults `fields.trace_id`. **`fields` has no KDL syntax**, so
this setting was the only way to reach it — and it was read by nothing, leaving the field
selection permanently at its default. It now sets both `include_trace_id` and
`fields.trace_id`.

## `timestamps` is deliberately still unimplemented

Honouring it means starting the log subscriber **after** the configuration is read. The
subscriber currently starts first, which is what makes config discovery loggable at all:

```
Loading configuration from: …
Configuration file not found: …
Failed to create default config file: …
```

Trading those diagnostics for an optional timestamp is not obviously the right call, and it
is the least consequential of the three. I would rather leave it as #415's remaining
question than quietly half-do it — parsing it into a field nothing honours would be worse
than leaving it reported.

`zentinel lint` still reports it, so it stays visible.

## Tests

`tracing_enabled_is_read` covers absent / `#true` / `#false`;
`access_log_include_trace_id_is_read` checks both the setting and the field the writer
actually consults.

The lint test that asserted all three were unread is inverted for the two that now work, so
this cannot regress unnoticed — it failed exactly as it should when the parsing landed, and
caught a `RECOGNIZED_ACCESS_LOG_KEYS` edit that had silently not applied.

`cargo test -p zentinel-config --features validation` green at 374; proxy lib tests 698;
clippy `-D warnings` and `fmt --check` clean.