### PR TITLE
chore: prepare release 26.08_10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ for details.
 
 | CalVer | Crate Version | Date | Highlights |
 |--------|---------------|------|------------|
+| [26.08_10](#260810---2026-08-28) | 0.6.33 | 2026-08-28 | `tracing { enabled #false }` now actually disables tracing, having previously been read by nothing; the access log's `include-trace-id` is honoured |
 | [26.08_9](#26089---2026-08-28) | 0.6.32 | 2026-08-28 | Configuration checking now covers the observability blocks, completing #365; three settings the documentation describes and no parser reads are removed from the shipped configs |
 | [26.08_8](#26088---2026-08-28) | 0.6.31 | 2026-08-28 | Configuration checking reaches the remaining blocks and the browser playground, which was running a different set of checks entirely; agent `type` is read as a child node as well as a property |
 | [26.08_7](#26087---2026-08-27) | 0.6.30 | 2026-08-27 | `zentinel lint` now reports settings that parse but are read by nothing: run-together lines, and keys written into the wrong one of two same-named blocks |
@@ -73,6 +74,37 @@ for details.
 ## [Unreleased]
 
 _Nothing yet._
+
+---
+
+## [26.08_10] - 2026-08-28
+
+**Crate version:** 0.6.33
+
+> **If any configuration of yours sets `tracing { enabled #false }`, tracing has
+> been running regardless, and stops after this upgrade.** That is the setting
+> doing what it says, but it is a change in behaviour: spans stop reaching the
+> collector, and anything downstream that expected them — dashboards, sampling
+> alerts, a trace-based SLO — goes quiet. Check before upgrading if you are not
+> sure which of your configurations set it.
+
+### Fixed
+- **`tracing { enabled }` is read.** Tracing was switched on by the *presence*
+  of the `tracing` block, and `enabled` was read by nothing, so a configuration
+  asking for it to be off got it anyway with no indication. An operator
+  disabling tracing to cut overhead, or to stop shipping spans to a collector
+  they no longer trust, did not get what they asked for. The setting defaults to
+  true, so a `tracing` block without it behaves exactly as before, and the skip
+  is now logged rather than silent. (#415, #420)
+- **`access-log { include-trace-id }` is read.** The access log writer already
+  consults a trace-id field flag, and the field list has no configuration syntax
+  of its own, so this setting was the only way to reach it — and nothing read
+  it, leaving the choice permanently at its default. (#415, #420)
+
+  `logging { timestamps }` remains unread and is still reported by
+  `zentinel lint`. Honouring it means starting the log subscriber after the
+  configuration is read, and it currently starts first so that configuration
+  discovery is logged at all; that trade is #415's remaining question.
 
 ---
 


### PR DESCRIPTION
CHANGELOG only. `Cargo.toml` and `Cargo.lock` untouched — the workflow reads the current
version (`0.6.32`) and publishes it **plus one**, so this ships crate `0.6.33`.

## Contents

One substantive change: **#420**, implementing two of the three settings from #415.

## This one has a genuine upgrade note

Unlike the last several releases, this is **not** configuration-checking only.

`tracing { enabled #false }` was read by nothing, so tracing ran regardless. It now does
what it says — which means **spans stop** for anyone whose configuration sets it. That is
the setting working correctly, and it is still a behaviour change: dashboards, sampling
alerts or a trace-based SLO downstream will go quiet.

The entry leads with that rather than burying it in a bullet, because it is the kind of
change that is discovered at 03:00 otherwise.

`enabled` defaults to true, so a `tracing` block without it is unaffected.

## Also

`access-log { include-trace-id }` is read. `logging { timestamps }` is explicitly called
out as still unread, with the reason — it is #415's remaining question, not an oversight.

## After merge

```bash
git tag -a 26.08_10 origin/main -m "Release 26.08_10 (semver 0.6.32)"
git push origin 26.08_10
```