### PR TITLE
feat(upstream): wire service discovery through to the request path

### DIFF
--- a/crates/common/src/scoped_registry.rs
+++ b/crates/common/src/scoped_registry.rs
@@ -297,6 +297,22 @@ impl<T> ScopedRegistry<T> {
         old_items
     }
 
+    /// Replace the item stored under `canonical`, leaving the scope and export
+    /// indexes untouched.
+    ///
+    /// For items that are rebuilt in place — an upstream pool whose targets
+    /// service discovery has changed — where identity and visibility are
+    /// unchanged and only the value differs. Returns the previous item, or
+    /// `None` if nothing was registered under that id, in which case nothing is
+    /// inserted: this cannot be used to add an item, only to swap one.
+    pub async fn replace_item(&self, canonical: &str, item: Arc<T>) -> Option<Arc<T>> {
+        self.items
+            .write()
+            .await
+            .get_mut(canonical)
+            .map(|slot| std::mem::replace(slot, item))
+    }
+
     /// Get a snapshot of all items.
     pub async fn snapshot(&self) -> HashMap<String, Arc<T>> {
         self.items.read().await.clone()

--- a/crates/config-inspect/Cargo.lock
+++ b/crates/config-inspect/Cargo.lock
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.28"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.28"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config-inspect"
-version = "0.6.28"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "insta",

--- a/crates/config/docs/schema.md
+++ b/crates/config/docs/schema.md
@@ -305,13 +305,32 @@ Backend server pool configuration.
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `id` | `string` | **required** | Unique upstream identifier |
-| `targets` | `[UpstreamTarget]` | **required** | Backend targets |
+| `targets` | `[UpstreamTarget]` | **required** unless `discovery` is set | Backend targets |
+| `discovery` | `UpstreamDiscovery` | - | Service discovery source for targets |
 | `load-balancing` | `string` | `"round-robin"` | Load balancing algorithm |
 | `health-check` | `HealthCheck` | - | Health check configuration |
 | `connection-pool` | `ConnectionPoolConfig` | `{}` | Connection pool settings |
 | `timeouts` | `UpstreamTimeouts` | `{}` | Timeout settings |
 | `tls` | `UpstreamTlsConfig` | - | TLS configuration |
 | `http-version` | `HttpVersionConfig` | `{}` | HTTP version settings |
+
+### UpstreamDiscovery
+
+Written as `discovery "<kind>" { ... }`. Targets resolved from the source are
+added to any statically configured `targets`, and re-resolved on the interval
+below. Settings are checked against the named kind: a setting belonging to a
+different kind is a configuration error, not an ignored key.
+
+| Kind | Settings | Refresh |
+|------|----------|---------|
+| `static` | `backends` (one or more `host:port`) | never |
+| `dns` | `hostname`, `port`, `refresh-interval` (`30`) | `refresh-interval` |
+| `dns-srv` | `service`, `refresh-interval` (`30`) | `refresh-interval` |
+| `consul` | `address`, `service`, `datacenter`, `only-passing` (`#true`), `tag`, `refresh-interval` (`30`) | `refresh-interval` |
+| `kubernetes` | `namespace`, `service`, `port-name`, `kubeconfig`, `refresh-interval` (`30`) | `refresh-interval` |
+| `file` | `path`, `watch-interval` (`5`) | `watch-interval` |
+
+Intervals are in seconds and must be greater than zero.
 
 ### UpstreamTarget
 

--- a/crates/config/docs/validation.md
+++ b/crates/config/docs/validation.md
@@ -65,7 +65,8 @@ Minimum supported: `1.0`
 | Property | Validation |
 |----------|------------|
 | `id` | Non-empty, unique |
-| `targets` | At least one target required |
+| `targets` | At least one target required, unless `discovery` is set |
+| `discovery` | Known kind; settings must belong to that kind; intervals `> 0` |
 | `targets[].address` | Valid host:port format |
 | `targets[].weight` | `> 0` |
 | `health-check.interval-secs` | `> 0` |

--- a/crates/config/src/flatten.rs
+++ b/crates/config/src/flatten.rs
@@ -349,6 +349,7 @@ mod tests {
             timeouts: UpstreamTimeouts::default(),
             tls: None,
             http_version: HttpVersionConfig::default(),
+            discovery: None,
         }
     }
 

--- a/crates/config/src/kdl/upstreams.rs
+++ b/crates/config/src/kdl/upstreams.rs
@@ -9,7 +9,9 @@ use zentinel_common::types::{HealthCheckType, LoadBalancingAlgorithm};
 
 use crate::{kdl::circuitbreaker_helper::parse_circuit_breaker_faildefault, upstreams::*};
 
-use super::helpers::{get_first_arg_string, get_int_entry, parse_upstream_targets};
+use super::helpers::{
+    get_bool_entry, get_first_arg_string, get_int_entry, get_string_entry, parse_upstream_targets,
+};
 
 //Parse a single upstream block
 /// Every child node `parse_upstream` reads.
@@ -34,6 +36,30 @@ pub(crate) const RECOGNIZED_UPSTREAM_KEYS: &[&str] = &[
     "timeouts",
     "tls",
     "circuit-breaker",
+    "discovery",
+];
+
+/// Settings accepted inside `discovery "<kind>" { ... }`.
+///
+/// This is the union across every discovery backend rather than a per-kind
+/// list, because the lint matches on the block name and not on its argument.
+/// A key that belongs to a different backend than the one named is caught by
+/// `parse_discovery`, which rejects it with the kind in the message.
+pub(crate) const RECOGNIZED_DISCOVERY_KEYS: &[&str] = &[
+    "backends",
+    "hostname",
+    "port",
+    "service",
+    "refresh-interval",
+    "address",
+    "datacenter",
+    "only-passing",
+    "tag",
+    "namespace",
+    "port-name",
+    "kubeconfig",
+    "path",
+    "watch-interval",
 ];
 
 /// Every child node `parse_health_check` reads directly.
@@ -149,9 +175,18 @@ pub fn parse_upstream(child: &kdl::KdlNode) -> Result<UpstreamConfig> {
         // `parse_upstream_targets`).
         let targets = parse_upstream_targets(child);
 
-        if targets.is_empty() {
+        // Service discovery, which may supply the targets instead of (or in
+        // addition to) statically configured ones.
+        let discovery = child
+            .children()
+            .and_then(|c| c.nodes().iter().find(|n| n.name().value() == "discovery"))
+            .map(|n| parse_discovery(n, &id))
+            .transpose()?;
+
+        if targets.is_empty() && discovery.is_none() {
             return Err(anyhow::anyhow!(
-                "Upstream '{}' requires at least one target, e.g., target \"127.0.0.1:8081\"",
+                "Upstream '{}' requires at least one target, e.g., target \"127.0.0.1:8081\", \
+                 or a discovery block, e.g., discovery \"dns\" {{ hostname \"api.internal\"; port 8080 }}",
                 id
             ));
         }
@@ -285,6 +320,7 @@ pub fn parse_upstream(child: &kdl::KdlNode) -> Result<UpstreamConfig> {
             timeouts,
             tls,
             http_version,
+            discovery,
         })
     } else {
         Err(anyhow!("Child is not upstream stanza"))
@@ -597,6 +633,190 @@ fn find_bool_entry_from_node(node: &kdl::KdlNode, name: &str) -> Option<bool> {
         .and_then(|c| c.nodes().iter().find(|n| n.name().value() == name))
         .and_then(|n| n.entries().first())
         .and_then(|e| e.value().as_bool())
+}
+
+/// Keys each discovery backend accepts, used to reject settings that belong to
+/// a different backend than the one named.
+const STATIC_DISCOVERY_KEYS: &[&str] = &["backends"];
+const DNS_DISCOVERY_KEYS: &[&str] = &["hostname", "port", "refresh-interval"];
+const DNS_SRV_DISCOVERY_KEYS: &[&str] = &["service", "refresh-interval"];
+const CONSUL_DISCOVERY_KEYS: &[&str] = &[
+    "address",
+    "service",
+    "datacenter",
+    "only-passing",
+    "refresh-interval",
+    "tag",
+];
+const KUBERNETES_DISCOVERY_KEYS: &[&str] = &[
+    "namespace",
+    "service",
+    "port-name",
+    "refresh-interval",
+    "kubeconfig",
+];
+const FILE_DISCOVERY_KEYS: &[&str] = &["path", "watch-interval"];
+
+/// Reject any child of a `discovery` block that the named backend does not use.
+///
+/// The unknown-key lint only knows the union of all backends' keys, so without
+/// this a `hostname` under `discovery "consul"` would parse, validate clean, and
+/// be silently dropped — the failure shape this whole feature exists to avoid.
+fn reject_foreign_discovery_keys(
+    node: &kdl::KdlNode,
+    kind: &str,
+    allowed: &[&str],
+    upstream_id: &str,
+) -> Result<()> {
+    let Some(children) = node.children() else {
+        return Ok(());
+    };
+    for child in children.nodes() {
+        let name = child.name().value();
+        if !allowed.contains(&name) {
+            return Err(anyhow!(
+                "Upstream '{}': '{}' is not a setting of discovery \"{}\" (accepted: {})",
+                upstream_id,
+                name,
+                kind,
+                allowed.join(", ")
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Read a required string child node, naming the block in the error.
+fn required_string(
+    node: &kdl::KdlNode,
+    key: &str,
+    kind: &str,
+    upstream_id: &str,
+) -> Result<String> {
+    get_string_entry(node, key).ok_or_else(|| {
+        anyhow!(
+            "Upstream '{}': discovery \"{}\" requires '{}'",
+            upstream_id,
+            kind,
+            key
+        )
+    })
+}
+
+/// Read a refresh interval in seconds, rejecting zero.
+///
+/// Zero would busy-loop the refresh task, so it is an error rather than a
+/// value that silently becomes the default.
+fn refresh_secs(node: &kdl::KdlNode, key: &str, default: u64, upstream_id: &str) -> Result<u64> {
+    match get_int_entry(node, key) {
+        None => Ok(default),
+        Some(v) if v <= 0 => Err(anyhow!(
+            "Upstream '{}': '{}' must be greater than zero (got {})",
+            upstream_id,
+            key,
+            v
+        )),
+        Some(v) => Ok(v as u64),
+    }
+}
+
+/// Parse a `discovery "<kind>" { ... }` block.
+///
+/// The backend is named by the block's first argument; its settings are child
+/// nodes. Anything that does not belong to that backend is an error rather than
+/// a silently ignored key.
+pub(crate) fn parse_discovery(node: &kdl::KdlNode, upstream_id: &str) -> Result<UpstreamDiscovery> {
+    let kind = get_first_arg_string(node).ok_or_else(|| {
+        anyhow!(
+            "Upstream '{}': discovery requires a type argument, e.g., discovery \"dns\" {{ ... }}",
+            upstream_id
+        )
+    })?;
+
+    match kind.as_str() {
+        "static" => {
+            reject_foreign_discovery_keys(node, &kind, STATIC_DISCOVERY_KEYS, upstream_id)?;
+            let backends = node
+                .children()
+                .and_then(|c| c.nodes().iter().find(|n| n.name().value() == "backends"))
+                .map(|n| {
+                    n.entries()
+                        .iter()
+                        .filter_map(|e| e.value().as_string().map(|s| s.to_string()))
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            if backends.is_empty() {
+                return Err(anyhow!(
+                    "Upstream '{}': discovery \"static\" requires a non-empty 'backends' list",
+                    upstream_id
+                ));
+            }
+            Ok(UpstreamDiscovery::Static { backends })
+        }
+        "dns" => {
+            reject_foreign_discovery_keys(node, &kind, DNS_DISCOVERY_KEYS, upstream_id)?;
+            let hostname = required_string(node, "hostname", &kind, upstream_id)?;
+            let port = get_int_entry(node, "port").ok_or_else(|| {
+                anyhow!(
+                    "Upstream '{}': discovery \"dns\" requires 'port'",
+                    upstream_id
+                )
+            })?;
+            let port = u16::try_from(port).map_err(|_| {
+                anyhow!(
+                    "Upstream '{}': discovery port {} is out of range",
+                    upstream_id,
+                    port
+                )
+            })?;
+            Ok(UpstreamDiscovery::Dns {
+                hostname,
+                port,
+                refresh_interval_secs: refresh_secs(node, "refresh-interval", 30, upstream_id)?,
+            })
+        }
+        "dns-srv" => {
+            reject_foreign_discovery_keys(node, &kind, DNS_SRV_DISCOVERY_KEYS, upstream_id)?;
+            Ok(UpstreamDiscovery::DnsSrv {
+                service: required_string(node, "service", &kind, upstream_id)?,
+                refresh_interval_secs: refresh_secs(node, "refresh-interval", 30, upstream_id)?,
+            })
+        }
+        "consul" => {
+            reject_foreign_discovery_keys(node, &kind, CONSUL_DISCOVERY_KEYS, upstream_id)?;
+            Ok(UpstreamDiscovery::Consul {
+                address: required_string(node, "address", &kind, upstream_id)?,
+                service: required_string(node, "service", &kind, upstream_id)?,
+                datacenter: get_string_entry(node, "datacenter"),
+                only_passing: get_bool_entry(node, "only-passing").unwrap_or(true),
+                refresh_interval_secs: refresh_secs(node, "refresh-interval", 30, upstream_id)?,
+                tag: get_string_entry(node, "tag"),
+            })
+        }
+        "kubernetes" => {
+            reject_foreign_discovery_keys(node, &kind, KUBERNETES_DISCOVERY_KEYS, upstream_id)?;
+            Ok(UpstreamDiscovery::Kubernetes {
+                namespace: required_string(node, "namespace", &kind, upstream_id)?,
+                service: required_string(node, "service", &kind, upstream_id)?,
+                port_name: get_string_entry(node, "port-name"),
+                refresh_interval_secs: refresh_secs(node, "refresh-interval", 30, upstream_id)?,
+                kubeconfig: get_string_entry(node, "kubeconfig"),
+            })
+        }
+        "file" => {
+            reject_foreign_discovery_keys(node, &kind, FILE_DISCOVERY_KEYS, upstream_id)?;
+            Ok(UpstreamDiscovery::File {
+                path: required_string(node, "path", &kind, upstream_id)?,
+                watch_interval_secs: refresh_secs(node, "watch-interval", 5, upstream_id)?,
+            })
+        }
+        other => Err(anyhow!(
+            "Upstream '{}': unknown discovery type '{}' (accepted: static, dns, dns-srv, consul, kubernetes, file)",
+            upstream_id,
+            other
+        )),
+    }
 }
 
 /// Parse health check configuration
@@ -1280,5 +1500,145 @@ mod tests {
         let cbconfig = upstream.circuit_breaker;
 
         assert!(cbconfig.is_none());
+    }
+
+    /// Helper: parse one upstream carrying the given discovery block.
+    fn discovery_of(block: &str) -> Result<Option<UpstreamDiscovery>> {
+        let kdl = format!("upstreams {{\n    upstream \"u\" {{\n{block}\n    }}\n}}");
+        Ok(parse_kdl_upstreams(&kdl)?
+            .get("u")
+            .expect("upstream parsed")
+            .discovery
+            .clone())
+    }
+
+    #[test]
+    fn discovery_defaults_are_applied_when_intervals_are_omitted() {
+        let discovery = discovery_of("        discovery \"dns\" {\n            hostname \"api.internal\"\n            port 8080\n        }")
+            .expect("parses")
+            .expect("discovery present");
+        assert_eq!(
+            discovery,
+            UpstreamDiscovery::Dns {
+                hostname: "api.internal".to_string(),
+                port: 8080,
+                refresh_interval_secs: 30,
+            }
+        );
+        assert_eq!(discovery.refresh_interval_secs(), 30);
+        assert_eq!(discovery.kind(), "dns");
+    }
+
+    #[test]
+    fn file_discovery_defaults_to_a_five_second_watch() {
+        let discovery = discovery_of("        discovery \"file\" {\n            path \"/etc/zentinel/backends.txt\"\n        }")
+            .expect("parses")
+            .expect("discovery present");
+        assert_eq!(discovery.refresh_interval_secs(), 5);
+    }
+
+    #[test]
+    fn static_discovery_reports_no_refresh_interval() {
+        let discovery = discovery_of("        discovery \"static\" {\n            backends \"10.0.0.1:80\" \"10.0.0.2:80\"\n        }")
+            .expect("parses")
+            .expect("discovery present");
+        assert_eq!(
+            discovery,
+            UpstreamDiscovery::Static {
+                backends: vec!["10.0.0.1:80".to_string(), "10.0.0.2:80".to_string()],
+            }
+        );
+        assert_eq!(discovery.refresh_interval_secs(), 0);
+    }
+
+    #[test]
+    fn zero_refresh_interval_is_rejected() {
+        let message = discovery_of("        discovery \"dns\" {\n            hostname \"api.internal\"\n            port 8080\n            refresh-interval 0\n        }")
+            .expect_err("zero would busy-loop the refresh task")
+            .to_string();
+        assert!(
+            message.contains("refresh-interval"),
+            "error should name the key, got: {message}"
+        );
+    }
+
+    #[test]
+    fn missing_required_setting_is_rejected() {
+        let message = discovery_of("        discovery \"dns\" {\n            port 8080\n        }")
+            .expect_err("dns discovery needs a hostname")
+            .to_string();
+        assert!(
+            message.contains("hostname"),
+            "error should name the missing key, got: {message}"
+        );
+    }
+
+    #[test]
+    fn unknown_discovery_type_is_rejected() {
+        let message =
+            discovery_of("        discovery \"etcd\" {\n            address \"x\"\n        }")
+                .expect_err("etcd is not a discovery backend")
+                .to_string();
+        assert!(
+            message.contains("etcd"),
+            "error should name the unknown type, got: {message}"
+        );
+    }
+
+    #[test]
+    fn discovery_without_a_type_argument_is_rejected() {
+        let message = discovery_of("        discovery {\n            hostname \"api\"\n        }")
+            .expect_err("the backend has to be named")
+            .to_string();
+        assert!(
+            message.contains("discovery"),
+            "error should mention discovery, got: {message}"
+        );
+    }
+
+    #[test]
+    fn consul_optional_settings_round_trip() {
+        let discovery = discovery_of(
+            "        discovery \"consul\" {\n            address \"http://consul:8500\"\n            service \"api\"\n            datacenter \"dc2\"\n            only-passing #false\n            refresh-interval 15\n            tag \"canary\"\n        }",
+        )
+        .expect("parses")
+        .expect("discovery present");
+        assert_eq!(
+            discovery,
+            UpstreamDiscovery::Consul {
+                address: "http://consul:8500".to_string(),
+                service: "api".to_string(),
+                datacenter: Some("dc2".to_string()),
+                // Deliberately non-default: a value that silently reverted to
+                // `true` here would be invisible in any test that used the
+                // default.
+                only_passing: false,
+                refresh_interval_secs: 15,
+                tag: Some("canary".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn an_upstream_may_have_discovery_instead_of_targets() {
+        let upstreams = parse_kdl_upstreams(
+            "upstreams {\n    upstream \"u\" {\n        discovery \"file\" {\n            path \"/tmp/b.txt\"\n        }\n    }\n}",
+        )
+        .expect("an upstream backed by discovery needs no static targets");
+        assert!(upstreams["u"].targets.is_empty());
+        assert!(upstreams["u"].discovery.is_some());
+    }
+
+    #[test]
+    fn an_upstream_with_neither_targets_nor_discovery_is_rejected() {
+        let message = parse_kdl_upstreams(
+            "upstreams {\n    upstream \"u\" {\n        load-balancing \"round-robin\"\n    }\n}",
+        )
+        .expect_err("nothing to route to")
+        .to_string();
+        assert!(
+            message.contains("target") && message.contains("discovery"),
+            "error should offer both ways out, got: {message}"
+        );
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -120,8 +120,8 @@ pub use zentinel_common::budget::{
 
 // Upstreams
 pub use upstreams::{
-    ConnectionPoolConfig, HealthCheck, HttpVersionConfig, UpstreamConfig, UpstreamPeer,
-    UpstreamTarget, UpstreamTimeouts, UpstreamTlsConfig,
+    ConnectionPoolConfig, HealthCheck, HttpVersionConfig, UpstreamConfig, UpstreamDiscovery,
+    UpstreamPeer, UpstreamTarget, UpstreamTimeouts, UpstreamTlsConfig,
 };
 
 // Validation
@@ -750,7 +750,9 @@ impl Config {
 
     fn validate_upstreams(&self) -> ZentinelResult<()> {
         for (id, upstream) in &self.upstreams {
-            if upstream.targets.is_empty() {
+            // Discovery-backed upstreams are populated at runtime; see
+            // `validate_upstream` in `validation.rs` for the same exemption.
+            if upstream.targets.is_empty() && upstream.discovery.is_none() {
                 return Err(ZentinelError::Config {
                     message: format!("Upstream '{}' has no targets", id),
                     source: None,
@@ -807,6 +809,7 @@ impl Config {
                 timeouts: UpstreamTimeouts::default(),
                 tls: None,
                 http_version: HttpVersionConfig::default(),
+                discovery: None,
             },
         );
 

--- a/crates/config/src/namespace.rs
+++ b/crates/config/src/namespace.rs
@@ -339,6 +339,7 @@ mod tests {
             timeouts: UpstreamTimeouts::default(),
             tls: None,
             http_version: HttpVersionConfig::default(),
+            discovery: None,
         }
     }
 

--- a/crates/config/src/resolution.rs
+++ b/crates/config/src/resolution.rs
@@ -414,6 +414,7 @@ mod tests {
             timeouts: UpstreamTimeouts::default(),
             tls: None,
             http_version: HttpVersionConfig::default(),
+            discovery: None,
         }
     }
 

--- a/crates/config/src/upstreams.rs
+++ b/crates/config/src/upstreams.rs
@@ -91,8 +91,11 @@ pub struct UpstreamConfig {
     /// Unique upstream identifier
     pub id: String,
 
-    /// Upstream targets
-    #[validate(length(min = 1, message = "At least one target is required"))]
+    /// Upstream targets.
+    ///
+    /// May be empty when `discovery` is set; the emptiness check lives in
+    /// `validate_targets_present` rather than a `length(min = 1)` attribute so
+    /// it can take `discovery` into account.
     pub targets: Vec<UpstreamTarget>,
 
     /// Load balancing algorithm
@@ -122,6 +125,161 @@ pub struct UpstreamConfig {
     /// HTTP version configuration
     #[serde(default)]
     pub http_version: HttpVersionConfig,
+
+    /// Service discovery source for this upstream's targets.
+    ///
+    /// When set, `targets` may be left empty in the configuration: the pool is
+    /// populated from the discovery source at startup and refreshed on the
+    /// source's interval. Statically configured targets are kept and the
+    /// discovered ones are added to them, so a fixed target can be pinned
+    /// alongside a discovered set.
+    #[serde(default)]
+    pub discovery: Option<UpstreamDiscovery>,
+}
+
+// ============================================================================
+// Service Discovery
+// ============================================================================
+
+/// Where an upstream's targets come from, when they are not listed statically.
+///
+/// This mirrors the discovery backends implemented in `zentinel-proxy`'s
+/// `discovery` module. It is a separate type because `zentinel-config` may not
+/// depend on the proxy crate, and because the configuration surface is
+/// deliberately narrower than the runtime one: intervals are plain seconds
+/// here and become `Duration`s on conversion.
+///
+/// Every variant carries its own refresh interval. The pool is populated once
+/// before it starts serving traffic and re-resolved on that interval for as
+/// long as the proxy runs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum UpstreamDiscovery {
+    /// A fixed list of backends. Equivalent to listing `target` nodes, and
+    /// present so that a config can be moved between discovery backends
+    /// without changing shape.
+    Static {
+        /// Backend addresses in `host:port` form.
+        backends: Vec<String>,
+    },
+
+    /// A/AAAA records for a hostname, one target per address returned.
+    Dns {
+        /// Hostname to resolve.
+        hostname: String,
+        /// Port to pair with every resolved address.
+        port: u16,
+        /// Seconds between re-resolutions.
+        #[serde(default = "default_refresh_interval")]
+        refresh_interval_secs: u64,
+    },
+
+    /// SRV records, which carry the port and weight themselves.
+    DnsSrv {
+        /// Full SRV name, e.g. `_http._tcp.example.com`.
+        service: String,
+        /// Seconds between re-resolutions.
+        #[serde(default = "default_refresh_interval")]
+        refresh_interval_secs: u64,
+    },
+
+    /// Healthy instances of a Consul service.
+    Consul {
+        /// Consul HTTP API base URL.
+        address: String,
+        /// Service name to look up.
+        service: String,
+        /// Datacenter, when not the agent's own.
+        datacenter: Option<String>,
+        /// Restrict to instances passing all their health checks.
+        #[serde(default = "default_only_passing")]
+        only_passing: bool,
+        /// Seconds between re-resolutions.
+        #[serde(default = "default_refresh_interval")]
+        refresh_interval_secs: u64,
+        /// Restrict to instances carrying this tag.
+        tag: Option<String>,
+    },
+
+    /// Endpoints backing a Kubernetes service.
+    Kubernetes {
+        /// Namespace holding the service.
+        namespace: String,
+        /// Service name.
+        service: String,
+        /// Named port to select, when the service exposes more than one.
+        port_name: Option<String>,
+        /// Seconds between re-resolutions.
+        #[serde(default = "default_refresh_interval")]
+        refresh_interval_secs: u64,
+        /// Explicit kubeconfig path; in-cluster config is used when absent.
+        kubeconfig: Option<String>,
+    },
+
+    /// A file listing one `host:port` per line, re-read on an interval.
+    File {
+        /// Path to the backend list.
+        path: String,
+        /// Seconds between re-reads.
+        #[serde(default = "default_watch_interval")]
+        watch_interval_secs: u64,
+    },
+}
+
+impl UpstreamDiscovery {
+    /// How often this source is re-resolved.
+    ///
+    /// `Static` never changes, so it reports zero and the proxy skips
+    /// scheduling a refresh task for it.
+    pub fn refresh_interval_secs(&self) -> u64 {
+        match self {
+            Self::Static { .. } => 0,
+            Self::Dns {
+                refresh_interval_secs,
+                ..
+            }
+            | Self::DnsSrv {
+                refresh_interval_secs,
+                ..
+            }
+            | Self::Consul {
+                refresh_interval_secs,
+                ..
+            }
+            | Self::Kubernetes {
+                refresh_interval_secs,
+                ..
+            } => *refresh_interval_secs,
+            Self::File {
+                watch_interval_secs,
+                ..
+            } => *watch_interval_secs,
+        }
+    }
+
+    /// The discovery backend's name as written in KDL, for logs and errors.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Static { .. } => "static",
+            Self::Dns { .. } => "dns",
+            Self::DnsSrv { .. } => "dns-srv",
+            Self::Consul { .. } => "consul",
+            Self::Kubernetes { .. } => "kubernetes",
+            Self::File { .. } => "file",
+        }
+    }
+}
+
+fn default_refresh_interval() -> u64 {
+    30
+}
+
+fn default_watch_interval() -> u64 {
+    5
+}
+
+fn default_only_passing() -> bool {
+    true
 }
 
 /// HTTP version configuration for upstream connections

--- a/crates/config/src/validate/lint.rs
+++ b/crates/config/src/validate/lint.rs
@@ -336,6 +336,7 @@ mod tests {
             timeouts: UpstreamTimeouts::default(),
             tls: None,
             http_version: HttpVersionConfig::default(),
+            discovery: None,
         }
     }
 

--- a/crates/config/src/validate/network.rs
+++ b/crates/config/src/validate/network.rs
@@ -70,6 +70,7 @@ mod tests {
                 timeouts: UpstreamTimeouts::default(),
                 tls: None,
                 http_version: HttpVersionConfig::default(),
+                discovery: None,
             },
         );
 

--- a/crates/config/src/validate/unknown_keys.rs
+++ b/crates/config/src/validate/unknown_keys.rs
@@ -303,6 +303,14 @@ const CLOSED_BLOCKS: &[ClosedBlock] = &[
         keys: crate::kdl::upstreams::RECOGNIZED_UPSTREAM_TLS_KEYS,
     },
     ClosedBlock {
+        // The union of every discovery backend's settings. Keys belonging to a
+        // backend other than the one named are rejected by `parse_discovery`
+        // with a hard error, so this list only has to catch outright typos.
+        name: "discovery",
+        nesting: Nesting::In("upstream"),
+        keys: crate::kdl::upstreams::RECOGNIZED_DISCOVERY_KEYS,
+    },
+    ClosedBlock {
         name: "target",
         nesting: Nesting::Anywhere,
         keys: crate::kdl::upstreams::RECOGNIZED_TARGET_KEYS,

--- a/crates/config/src/validation.rs
+++ b/crates/config/src/validation.rs
@@ -738,11 +738,14 @@ fn validate_upstreams(config: &Config, errors: &mut Vec<String>) {
             "Validating upstream"
         );
 
-        if upstream.targets.is_empty() {
+        // An upstream backed by service discovery gets its targets at runtime,
+        // so an empty list here is expected rather than a misconfiguration.
+        if upstream.targets.is_empty() && upstream.discovery.is_none() {
             warn!(upstream_id = %upstream_id, "Upstream has no targets");
             errors.push(format!(
                 "Upstream '{}' has no targets defined.\n\
-                 Each upstream must have at least one target.",
+                 Each upstream must have at least one target, or a discovery \
+                 block that supplies them.",
                 upstream_id
             ));
         }
@@ -1435,6 +1438,7 @@ mod tests {
             timeouts: UpstreamTimeouts::default(),
             tls: None,
             http_version: HttpVersionConfig::default(),
+            discovery: None,
         }
     }
 
@@ -2186,6 +2190,7 @@ mod tests {
             timeouts: UpstreamTimeouts::default(),
             tls: None,
             http_version: HttpVersionConfig::default(),
+            discovery: None,
         };
 
         // --- Filter types ---

--- a/crates/gateway/src/config_writer.rs
+++ b/crates/gateway/src/config_writer.rs
@@ -555,6 +555,7 @@ mod tests {
                 timeouts: UpstreamTimeouts::default(),
                 tls: None,
                 http_version: HttpVersionConfig::default(),
+                discovery: None,
             },
         );
 

--- a/crates/gateway/src/reconcilers/ingress.rs
+++ b/crates/gateway/src/reconcilers/ingress.rs
@@ -179,6 +179,7 @@ pub fn translate_ingresses(
                         timeouts: UpstreamTimeouts::default(),
                         tls: None,
                         http_version: HttpVersionConfig::default(),
+                        discovery: None,
                     };
 
                     upstreams.insert(upstream_id.clone(), upstream);
@@ -240,6 +241,7 @@ pub fn translate_ingresses(
                         timeouts: UpstreamTimeouts::default(),
                         tls: None,
                         http_version: HttpVersionConfig::default(),
+                        discovery: None,
                     },
                 );
 

--- a/crates/gateway/src/translator.rs
+++ b/crates/gateway/src/translator.rs
@@ -877,6 +877,7 @@ impl ConfigTranslator {
             timeouts: UpstreamTimeouts::default(),
             tls: None,
             http_version: HttpVersionConfig::default(),
+            discovery: None,
         };
 
         Ok((upstream_id, Some(upstream)))
@@ -1297,6 +1298,7 @@ impl ConfigTranslator {
                 h2_ping_interval_secs: 30,
                 max_h2_streams: 100,
             },
+            discovery: None,
         };
 
         Ok((upstream_id, Some(upstream)))
@@ -1447,6 +1449,7 @@ impl ConfigTranslator {
             timeouts: UpstreamTimeouts::default(),
             tls: None, // Passthrough — no TLS termination at proxy
             http_version: HttpVersionConfig::default(),
+            discovery: None,
         };
 
         Ok((upstream_id, Some(upstream)))

--- a/crates/playground-wasm/Cargo.lock
+++ b/crates/playground-wasm/Cargo.lock
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.31"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.31"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config-inspect"
-version = "0.6.31"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "serde",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-playground-wasm"
-version = "0.6.31"
+version = "0.6.33"
 dependencies = [
  "console_error_panic_hook",
  "serde",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-sim"
-version = "0.6.31"
+version = "0.6.33"
 dependencies = [
  "regex",
  "serde",

--- a/crates/proxy/docs/modules.md
+++ b/crates/proxy/docs/modules.md
@@ -449,10 +449,45 @@ Service discovery backends.
 
 ```rust
 impl DiscoveryManager {
-    pub async fn get_backends(&self, upstream: &str) -> Vec<Backend>;
-    pub async fn refresh(&self, upstream: &str);
+    pub fn register(&self, upstream_id: &str, config: DiscoveryConfig) -> Result<(), Box<Error>>;
+    pub fn get(&self, upstream_id: &str) -> Option<Arc<dyn ServiceDiscovery + Send + Sync>>;
+    pub async fn discover(&self, upstream_id: &str)
+        -> Option<Result<(BTreeSet<Backend>, HashMap<u64, bool>)>>;
+    pub fn remove(&self, upstream_id: &str);
+    pub fn count(&self) -> usize;
 }
 ```
+
+**How it reaches the request path**
+
+An `UpstreamPool` holds its own discovery source rather than going through the
+manager: `build_discovery` (the body `DiscoveryManager::register` also uses)
+constructs it, and `UpstreamPool::new` resolves it before the pool serves any
+traffic. Discovered targets are appended to the pool's statically configured
+ones.
+
+`upstream::discovery_refresh` then keeps them current. It is a single supervisor
+task, started in `ZentinelProxy::new`, that reads the upstream registries on each
+tick and refreshes any pool whose interval has elapsed:
+
+```rust
+// crates/proxy/src/upstream/mod.rs
+impl UpstreamPool {
+    pub fn discovery_refresh_interval(&self) -> Option<Duration>;
+    pub async fn refreshed(&self) -> Option<UpstreamPool>;
+}
+```
+
+`refreshed()` returns a replacement pool only when the target set actually
+changed. The replacement shares the original's circuit breakers and statistics,
+so breaker state survives the swap; breakers for targets that disappeared are
+dropped so the map stays bounded as backends churn. The supervisor installs the
+replacement with `Registry::insert` / `ScopedRegistry::replace_item`, which is
+the same swap the `SIGHUP` reload path performs.
+
+Reading the registries on each tick — rather than holding an `Arc<UpstreamPool>`
+per task — is what keeps this correct across a config reload, which replaces
+every pool wholesale.
 
 **Configuration:**
 

--- a/crates/proxy/src/discovery.rs
+++ b/crates/proxy/src/discovery.rs
@@ -1130,6 +1130,146 @@ impl ServiceDiscovery for FileDiscovery {
     }
 }
 
+/// Build the discovery implementation described by `config`.
+///
+/// Split out of [`DiscoveryManager::register`] so an upstream pool can hold its
+/// own discovery source directly. A pool re-resolves on its own interval and has
+/// no use for the manager's registry, and building a fresh Consul or Kubernetes
+/// client on every refresh would mean a new connection every interval.
+///
+/// `upstream_id` is used only for logging.
+pub(crate) fn build_discovery(
+    upstream_id: &str,
+    config: DiscoveryConfig,
+) -> Arc<dyn ServiceDiscovery + Send + Sync> {
+    let discovery: Arc<dyn ServiceDiscovery + Send + Sync> = match config {
+        DiscoveryConfig::Static { backends } => {
+            let backend_set = backends
+                .iter()
+                .filter_map(|addr| {
+                    addr.to_socket_addrs()
+                        .ok()
+                        .and_then(|mut addrs| addrs.next())
+                        .map(|addr| Backend {
+                            addr: pingora_core::protocols::l4::socket::SocketAddr::Inet(addr),
+                            weight: 1,
+                            ext: http::Extensions::new(),
+                        })
+                })
+                .collect();
+
+            info!(
+                upstream_id = %upstream_id,
+                backend_count = backends.len(),
+                "Registered static service discovery"
+            );
+
+            Arc::new(StaticWrapper(StaticDiscovery::new(backend_set)))
+        }
+        DiscoveryConfig::Dns {
+            hostname,
+            port,
+            refresh_interval,
+        } => {
+            info!(
+                upstream_id = %upstream_id,
+                hostname = %hostname,
+                port = port,
+                refresh_interval_secs = refresh_interval.as_secs(),
+                "Registered DNS service discovery"
+            );
+
+            Arc::new(DnsDiscovery::new(hostname, port, refresh_interval))
+        }
+        DiscoveryConfig::DnsSrv {
+            service,
+            refresh_interval,
+        } => {
+            info!(
+                upstream_id = %upstream_id,
+                service = %service,
+                refresh_interval_secs = refresh_interval.as_secs(),
+                "DNS SRV discovery not yet fully implemented, using DNS A record fallback"
+            );
+
+            // DNS SRV requires async DNS resolver - fall back to regular DNS for now
+            // Extract hostname from service name (e.g., "_http._tcp.example.com" -> "example.com")
+            let hostname = service
+                .split('.')
+                .skip_while(|s| s.starts_with('_'))
+                .collect::<Vec<_>>()
+                .join(".");
+            Arc::new(DnsDiscovery::new(hostname, 80, refresh_interval))
+        }
+        DiscoveryConfig::Consul {
+            address,
+            service,
+            datacenter,
+            only_passing,
+            refresh_interval,
+            tag,
+        } => {
+            info!(
+                upstream_id = %upstream_id,
+                address = %address,
+                service = %service,
+                datacenter = datacenter.as_deref().unwrap_or("default"),
+                only_passing = only_passing,
+                refresh_interval_secs = refresh_interval.as_secs(),
+                "Registered Consul service discovery"
+            );
+
+            Arc::new(ConsulDiscovery::new(
+                address,
+                service,
+                datacenter,
+                only_passing,
+                refresh_interval,
+                tag,
+            ))
+        }
+        DiscoveryConfig::Kubernetes {
+            namespace,
+            service,
+            port_name,
+            refresh_interval,
+            kubeconfig,
+        } => {
+            info!(
+                upstream_id = %upstream_id,
+                namespace = %namespace,
+                service = %service,
+                port_name = port_name.as_deref().unwrap_or("default"),
+                refresh_interval_secs = refresh_interval.as_secs(),
+                "Registered Kubernetes endpoint discovery"
+            );
+
+            Arc::new(KubernetesDiscovery::new(
+                namespace,
+                service,
+                port_name,
+                refresh_interval,
+                kubeconfig,
+            ))
+        }
+        DiscoveryConfig::File {
+            path,
+            watch_interval,
+        } => {
+            info!(
+                upstream_id = %upstream_id,
+                path = %path,
+                watch_interval_secs = watch_interval.as_secs(),
+                "Registered file-based service discovery"
+            );
+
+            Arc::new(FileDiscovery::new(path, watch_interval))
+        }
+    };
+
+    discovery
+}
+
 // ============================================================================
 // Service Discovery Manager
 // ============================================================================
@@ -1153,130 +1293,7 @@ impl DiscoveryManager {
 
     /// Register a service discovery for an upstream
     pub fn register(&self, upstream_id: &str, config: DiscoveryConfig) -> Result<(), Box<Error>> {
-        let discovery: Arc<dyn ServiceDiscovery + Send + Sync> = match config {
-            DiscoveryConfig::Static { backends } => {
-                let backend_set = backends
-                    .iter()
-                    .filter_map(|addr| {
-                        addr.to_socket_addrs()
-                            .ok()
-                            .and_then(|mut addrs| addrs.next())
-                            .map(|addr| Backend {
-                                addr: pingora_core::protocols::l4::socket::SocketAddr::Inet(addr),
-                                weight: 1,
-                                ext: http::Extensions::new(),
-                            })
-                    })
-                    .collect();
-
-                info!(
-                    upstream_id = %upstream_id,
-                    backend_count = backends.len(),
-                    "Registered static service discovery"
-                );
-
-                Arc::new(StaticWrapper(StaticDiscovery::new(backend_set)))
-            }
-            DiscoveryConfig::Dns {
-                hostname,
-                port,
-                refresh_interval,
-            } => {
-                info!(
-                    upstream_id = %upstream_id,
-                    hostname = %hostname,
-                    port = port,
-                    refresh_interval_secs = refresh_interval.as_secs(),
-                    "Registered DNS service discovery"
-                );
-
-                Arc::new(DnsDiscovery::new(hostname, port, refresh_interval))
-            }
-            DiscoveryConfig::DnsSrv {
-                service,
-                refresh_interval,
-            } => {
-                info!(
-                    upstream_id = %upstream_id,
-                    service = %service,
-                    refresh_interval_secs = refresh_interval.as_secs(),
-                    "DNS SRV discovery not yet fully implemented, using DNS A record fallback"
-                );
-
-                // DNS SRV requires async DNS resolver - fall back to regular DNS for now
-                // Extract hostname from service name (e.g., "_http._tcp.example.com" -> "example.com")
-                let hostname = service
-                    .split('.')
-                    .skip_while(|s| s.starts_with('_'))
-                    .collect::<Vec<_>>()
-                    .join(".");
-                Arc::new(DnsDiscovery::new(hostname, 80, refresh_interval))
-            }
-            DiscoveryConfig::Consul {
-                address,
-                service,
-                datacenter,
-                only_passing,
-                refresh_interval,
-                tag,
-            } => {
-                info!(
-                    upstream_id = %upstream_id,
-                    address = %address,
-                    service = %service,
-                    datacenter = datacenter.as_deref().unwrap_or("default"),
-                    only_passing = only_passing,
-                    refresh_interval_secs = refresh_interval.as_secs(),
-                    "Registered Consul service discovery"
-                );
-
-                Arc::new(ConsulDiscovery::new(
-                    address,
-                    service,
-                    datacenter,
-                    only_passing,
-                    refresh_interval,
-                    tag,
-                ))
-            }
-            DiscoveryConfig::Kubernetes {
-                namespace,
-                service,
-                port_name,
-                refresh_interval,
-                kubeconfig,
-            } => {
-                info!(
-                    upstream_id = %upstream_id,
-                    namespace = %namespace,
-                    service = %service,
-                    port_name = port_name.as_deref().unwrap_or("default"),
-                    refresh_interval_secs = refresh_interval.as_secs(),
-                    "Registered Kubernetes endpoint discovery"
-                );
-
-                Arc::new(KubernetesDiscovery::new(
-                    namespace,
-                    service,
-                    port_name,
-                    refresh_interval,
-                    kubeconfig,
-                ))
-            }
-            DiscoveryConfig::File {
-                path,
-                watch_interval,
-            } => {
-                info!(
-                    upstream_id = %upstream_id,
-                    path = %path,
-                    watch_interval_secs = watch_interval.as_secs(),
-                    "Registered file-based service discovery"
-                );
-
-                Arc::new(FileDiscovery::new(path, watch_interval))
-            }
-        };
+        let discovery = build_discovery(upstream_id, config);
 
         self.discoveries
             .write()

--- a/crates/proxy/src/proxy/mod.rs
+++ b/crates/proxy/src/proxy/mod.rs
@@ -217,6 +217,14 @@ impl ZentinelProxy {
         let scoped_upstream_pools =
             Self::create_scoped_upstream_pools(&flattened, &mut health_check_runner).await?;
 
+        // Keep discovery-backed pools up to date. The supervisor reads both
+        // registries on each tick, so it also covers pools installed by a later
+        // config reload; it is a no-op when no upstream uses discovery.
+        crate::upstream::discovery_refresh::spawn(
+            upstream_pools.clone(),
+            scoped_upstream_pools.clone(),
+        );
+
         let health_check_runner = Arc::new(health_check_runner);
 
         // Create passive health checker

--- a/crates/proxy/src/upstream/discovery_refresh.rs
+++ b/crates/proxy/src/upstream/discovery_refresh.rs
@@ -1,7 +1,7 @@
 //! Periodic re-resolution of upstream service discovery.
 //!
-//! Pools whose targets come from a discovery source ([`UpstreamConfig::discovery`])
-//! are resolved once while the proxy starts and then re-resolved on the
+//! Pools whose targets come from a discovery source (an upstream's `discovery`
+//! block) are resolved once while the proxy starts and then re-resolved on the
 //! interval their source declares. This module owns that schedule.
 //!
 //! # Why one supervisor rather than a task per upstream

--- a/crates/proxy/src/upstream/discovery_refresh.rs
+++ b/crates/proxy/src/upstream/discovery_refresh.rs
@@ -1,0 +1,193 @@
+//! Periodic re-resolution of upstream service discovery.
+//!
+//! Pools whose targets come from a discovery source ([`UpstreamConfig::discovery`])
+//! are resolved once while the proxy starts and then re-resolved on the
+//! interval their source declares. This module owns that schedule.
+//!
+//! # Why one supervisor rather than a task per upstream
+//!
+//! Pools are replaced wholesale on `SIGHUP`: `Registry::replace` swaps the
+//! whole map for one built from the new configuration. A task holding an
+//! `Arc<UpstreamPool>` would keep refreshing the pool it captured and write its
+//! results back over the pool the reload just installed, so every reload would
+//! need to find and abort the old tasks and spawn new ones — with the pools and
+//! the tasks tracked separately and able to drift apart.
+//!
+//! A single supervisor reads the registry on each tick instead. It therefore
+//! sees exactly the pools that are installed right now: reloaded pools are
+//! picked up automatically, removed ones simply stop appearing, and there is no
+//! task lifecycle to keep in step with the pool lifecycle.
+
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock};
+use std::time::{Duration, Instant};
+
+use prometheus::{register_int_counter_vec, register_int_gauge_vec, IntCounterVec, IntGaugeVec};
+use tracing::{debug, info, warn};
+
+use zentinel_common::{Registry, ScopedRegistry};
+
+use super::UpstreamPool;
+
+/// How often the supervisor wakes to check which pools are due.
+///
+/// Refresh intervals are configured in whole seconds, so a one-second tick
+/// resolves every interval exactly. The tick itself does no work beyond
+/// comparing deadlines when nothing is due.
+const TICK: Duration = Duration::from_secs(1);
+
+/// Upper bound on a single refresh.
+///
+/// A registry that accepts a connection and then never answers would otherwise
+/// hold its slot forever. The refresh is abandoned and retried on the next
+/// interval; the pool keeps serving its current targets meanwhile.
+const REFRESH_TIMEOUT: Duration = Duration::from_secs(10);
+
+static DISCOVERY_REFRESHES: LazyLock<Option<IntCounterVec>> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "zentinel_upstream_discovery_refreshes_total",
+        "Service discovery refreshes that changed an upstream's target set",
+        &["upstream"]
+    )
+    .ok()
+});
+
+static DISCOVERY_TARGETS: LazyLock<Option<IntGaugeVec>> = LazyLock::new(|| {
+    register_int_gauge_vec!(
+        "zentinel_upstream_discovery_targets",
+        "Targets currently resolved for an upstream backed by service discovery",
+        &["upstream"]
+    )
+    .ok()
+});
+
+/// Start the refresh supervisor.
+///
+/// Returns immediately; the supervisor runs until the process exits. It is a
+/// no-op for pools without a discovery source, so it is safe to start
+/// unconditionally.
+pub(crate) fn spawn(global: Registry<UpstreamPool>, scoped: ScopedRegistry<UpstreamPool>) {
+    tokio::spawn(async move {
+        run(global, scoped).await;
+    });
+}
+
+/// Which registry a pool came from, so a refreshed pool goes back where it
+/// belongs. Both are keyed by a string id; only the write method differs.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+enum Source {
+    Global,
+    Scoped,
+}
+
+async fn run(global: Registry<UpstreamPool>, scoped: ScopedRegistry<UpstreamPool>) {
+    // When each pool is next due. Keyed by source and id so a namespaced
+    // upstream and a global one of the same name keep separate schedules.
+    let mut due: HashMap<(Source, String), Instant> = HashMap::new();
+    let mut ticker = tokio::time::interval(TICK);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        ticker.tick().await;
+        let now = Instant::now();
+
+        let mut live: Vec<(Source, String, Arc<UpstreamPool>, Duration)> = Vec::new();
+        for (id, pool) in global.snapshot().await {
+            if let Some(interval) = pool.discovery_refresh_interval() {
+                live.push((Source::Global, id, pool, interval));
+            }
+        }
+        for (id, pool) in scoped.snapshot().await {
+            if let Some(interval) = pool.discovery_refresh_interval() {
+                live.push((Source::Scoped, id, pool, interval));
+            }
+        }
+
+        // Drop schedules for pools that are no longer registered, so the map
+        // cannot grow across reloads that rename or remove upstreams.
+        let present: std::collections::HashSet<(Source, String)> =
+            live.iter().map(|(s, id, _, _)| (*s, id.clone())).collect();
+        due.retain(|key, _| present.contains(key));
+
+        for (source, id, pool, interval) in live {
+            let key = (source, id.clone());
+
+            // First sighting: the pool was resolved when it was built, so the
+            // first refresh is one full interval away rather than immediate.
+            let deadline = *due.entry(key.clone()).or_insert(now + interval);
+            if now < deadline {
+                continue;
+            }
+
+            // Re-arm before spawning so a refresh that outlives its interval
+            // cannot have a second one started underneath it.
+            due.insert(key, now + interval);
+
+            let global = global.clone();
+            let scoped = scoped.clone();
+            tokio::spawn(async move {
+                refresh_one(source, id, pool, global, scoped).await;
+            });
+        }
+    }
+}
+
+/// Re-resolve one pool and install the replacement, if the targets changed.
+async fn refresh_one(
+    source: Source,
+    id: String,
+    pool: Arc<UpstreamPool>,
+    global: Registry<UpstreamPool>,
+    scoped: ScopedRegistry<UpstreamPool>,
+) {
+    let refreshed = match tokio::time::timeout(REFRESH_TIMEOUT, pool.refreshed()).await {
+        Ok(result) => result,
+        Err(_) => {
+            warn!(
+                upstream_id = %id,
+                timeout_secs = REFRESH_TIMEOUT.as_secs(),
+                "Service discovery refresh timed out; keeping current targets"
+            );
+            return;
+        }
+    };
+
+    // `None` means nothing changed, or the source could not be reached and the
+    // pool kept its targets. Either way there is nothing to install.
+    let Some(new_pool) = refreshed else {
+        debug!(upstream_id = %id, "Service discovery refresh: no change");
+        return;
+    };
+
+    let target_count = new_pool.target_count();
+    let new_pool = Arc::new(new_pool);
+
+    let installed = match source {
+        Source::Global => global.insert(id.clone(), new_pool).await.is_some(),
+        Source::Scoped => scoped.replace_item(&id, new_pool).await.is_some(),
+    };
+
+    if !installed {
+        // The upstream was removed (or renamed) by a reload while this refresh
+        // was in flight. Dropping the result is correct: the pool it was built
+        // from is gone.
+        debug!(
+            upstream_id = %id,
+            "Upstream disappeared during discovery refresh; discarding result"
+        );
+        return;
+    }
+
+    if let Some(counter) = DISCOVERY_REFRESHES.as_ref() {
+        counter.with_label_values(&[&id]).inc();
+    }
+    if let Some(gauge) = DISCOVERY_TARGETS.as_ref() {
+        gauge.with_label_values(&[&id]).set(target_count as i64);
+    }
+
+    info!(
+        upstream_id = %id,
+        target_count,
+        "Installed refreshed upstream pool"
+    );
+}

--- a/crates/proxy/src/upstream/discovery_refresh.rs
+++ b/crates/proxy/src/upstream/discovery_refresh.rs
@@ -29,12 +29,20 @@ use zentinel_common::{Registry, ScopedRegistry};
 
 use super::UpstreamPool;
 
-/// How often the supervisor wakes to check which pools are due.
+/// How often the supervisor wakes while at least one pool uses discovery.
 ///
 /// Refresh intervals are configured in whole seconds, so a one-second tick
 /// resolves every interval exactly. The tick itself does no work beyond
 /// comparing deadlines when nothing is due.
 const TICK: Duration = Duration::from_secs(1);
+
+/// How often the supervisor wakes while no pool uses discovery.
+///
+/// The overwhelming majority of configurations have no discovery at all, and
+/// the supervisor still has to look because a reload can introduce it. Backing
+/// off to half a minute makes the idle case cost effectively nothing while
+/// still noticing a reload promptly.
+const IDLE_TICK: Duration = Duration::from_secs(30);
 
 /// Upper bound on a single refresh.
 ///
@@ -84,11 +92,8 @@ async fn run(global: Registry<UpstreamPool>, scoped: ScopedRegistry<UpstreamPool
     // When each pool is next due. Keyed by source and id so a namespaced
     // upstream and a global one of the same name keep separate schedules.
     let mut due: HashMap<(Source, String), Instant> = HashMap::new();
-    let mut ticker = tokio::time::interval(TICK);
-    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
     loop {
-        ticker.tick().await;
         let now = Instant::now();
 
         let mut live: Vec<(Source, String, Arc<UpstreamPool>, Duration)> = Vec::new();
@@ -101,6 +106,12 @@ async fn run(global: Registry<UpstreamPool>, scoped: ScopedRegistry<UpstreamPool
             if let Some(interval) = pool.discovery_refresh_interval() {
                 live.push((Source::Scoped, id, pool, interval));
             }
+        }
+
+        if live.is_empty() {
+            due.clear();
+            tokio::time::sleep(IDLE_TICK).await;
+            continue;
         }
 
         // Drop schedules for pools that are no longer registered, so the map
@@ -129,6 +140,8 @@ async fn run(global: Registry<UpstreamPool>, scoped: ScopedRegistry<UpstreamPool
                 refresh_one(source, id, pool, global, scoped).await;
             });
         }
+
+        tokio::time::sleep(TICK).await;
     }
 }
 

--- a/crates/proxy/src/upstream/health.rs
+++ b/crates/proxy/src/upstream/health.rs
@@ -417,6 +417,7 @@ mod tests {
             timeouts: UpstreamTimeouts::default(),
             tls: None,
             http_version: HttpVersionConfig::default(),
+            discovery: None,
         }
     }
 

--- a/crates/proxy/src/upstream/mod.rs
+++ b/crates/proxy/src/upstream/mod.rs
@@ -846,8 +846,7 @@ impl UpstreamPool {
         let (discovery, discovery_interval, discovered) =
             Self::resolve_discovery(&config, &id).await;
 
-        let mut targets = static_targets.clone();
-        targets.extend(discovered);
+        let targets = Self::merge_targets(&static_targets, discovered);
 
         if targets.is_empty() {
             if discovery.is_some() {
@@ -981,6 +980,27 @@ impl UpstreamPool {
         );
 
         Ok(pool)
+    }
+
+    /// Combine configured targets with discovered ones.
+    ///
+    /// A configured target that the discovery source also returns appears once,
+    /// keeping the configured entry: an operator who pinned a backend and gave
+    /// it a weight should not have that weight doubled just because the source
+    /// happens to list it too.
+    fn merge_targets(
+        static_targets: &[UpstreamTarget],
+        discovered: Vec<UpstreamTarget>,
+    ) -> Vec<UpstreamTarget> {
+        let mut targets = static_targets.to_vec();
+        let pinned: std::collections::HashSet<String> =
+            targets.iter().map(|t| t.full_address()).collect();
+        targets.extend(
+            discovered
+                .into_iter()
+                .filter(|t| !pinned.contains(&t.full_address())),
+        );
+        targets
     }
 
     /// Translate the configuration's discovery block into the runtime one.
@@ -1147,8 +1167,8 @@ impl UpstreamPool {
             }
         };
 
-        let mut targets = self.static_targets.clone();
-        targets.extend(Self::targets_from_backends(&backends));
+        let targets =
+            Self::merge_targets(&self.static_targets, Self::targets_from_backends(&backends));
 
         if Self::same_targets(&self.targets, &targets) {
             return None;

--- a/crates/proxy/src/upstream/mod.rs
+++ b/crates/proxy/src/upstream/mod.rs
@@ -19,7 +19,14 @@ use zentinel_common::{
     types::{CircuitBreakerConfig, LoadBalancingAlgorithm},
     CircuitBreaker, UpstreamId,
 };
-use zentinel_config::UpstreamConfig;
+use zentinel_config::{UpstreamConfig, UpstreamDiscovery};
+
+use pingora_core::protocols::l4::socket::SocketAddr as PingoraSocketAddr;
+use pingora_load_balancing::discovery::ServiceDiscovery;
+use pingora_load_balancing::Backend;
+use std::collections::BTreeSet;
+
+use crate::discovery::DiscoveryConfig;
 
 // ============================================================================
 // Internal Upstream Target Type
@@ -86,6 +93,7 @@ impl UpstreamTarget {
 // Load balancing algorithm implementations
 pub mod adaptive;
 pub mod consistent_hash;
+pub mod discovery_refresh;
 pub mod drain;
 pub mod health;
 pub mod inference_health;
@@ -200,6 +208,21 @@ pub struct UpstreamPool {
     circuit_breakers: Arc<RwLock<HashMap<String, CircuitBreaker>>>,
     /// Pool statistics
     stats: Arc<PoolStats>,
+    /// Resolved discovery source, kept so a refresh can re-resolve without
+    /// rebuilding the client (which for Consul and Kubernetes means not
+    /// re-establishing a connection every interval).
+    discovery: Option<Arc<dyn ServiceDiscovery + Send + Sync>>,
+    /// How often `discovery` is re-resolved. `None` when there is no discovery
+    /// source, or when it is one that cannot change (`static`).
+    discovery_interval: Option<Duration>,
+    /// Targets that came from the configuration rather than from discovery.
+    ///
+    /// Kept separately because a refresh replaces the discovered targets and
+    /// must not drop the configured ones alongside them.
+    static_targets: Vec<UpstreamTarget>,
+    /// The configuration this pool was built from, needed to rebuild the load
+    /// balancer when discovery changes the target set.
+    config: UpstreamConfig,
 }
 
 // Note: Active health checking is handled by the PassiveHealthChecker in health.rs
@@ -210,6 +233,7 @@ pub struct UpstreamPool {
 ///
 /// Note: Actual connection pooling is handled by Pingora internally.
 /// This struct holds configuration that is applied to peer options.
+#[derive(Clone)]
 pub struct ConnectionPoolConfig {
     /// Maximum connections per target (informational - Pingora manages actual pooling)
     pub max_connections: usize,
@@ -228,6 +252,7 @@ pub struct ConnectionPoolConfig {
 }
 
 /// HTTP version configuration for upstream connections
+#[derive(Clone)]
 pub struct HttpVersionOptions {
     /// Minimum HTTP version (1 or 2)
     pub min_version: u8,
@@ -808,21 +833,45 @@ impl UpstreamPool {
         );
 
         // Convert config targets to internal targets
-        let targets: Vec<UpstreamTarget> = config
+        let static_targets: Vec<UpstreamTarget> = config
             .targets
             .iter()
             .filter_map(UpstreamTarget::from_config)
             .collect();
 
+        // Resolve the discovery source, if one is configured, before the pool
+        // starts serving traffic. Discovered targets are added to the
+        // configured ones rather than replacing them, so a fixed backend can be
+        // pinned alongside a discovered set.
+        let (discovery, discovery_interval, discovered) =
+            Self::resolve_discovery(&config, &id).await;
+
+        let mut targets = static_targets.clone();
+        targets.extend(discovered);
+
         if targets.is_empty() {
-            error!(
-                upstream_id = %config.id,
-                "No valid upstream targets configured"
-            );
-            return Err(ZentinelError::Config {
-                message: "No valid upstream targets".to_string(),
-                source: None,
-            });
+            if discovery.is_some() {
+                // The source answered, and answered with nothing. That is a
+                // live condition (a scaled-to-zero deployment, a service with
+                // no passing instances) rather than a broken configuration, so
+                // the pool starts empty and recovers on the next refresh.
+                // Requests to it fail with "no healthy targets" until then.
+                warn!(
+                    upstream_id = %config.id,
+                    discovery = config.discovery.as_ref().map(|d| d.kind()).unwrap_or("none"),
+                    "Service discovery returned no backends; upstream starts with no targets \
+                     and will recover on the next refresh"
+                );
+            } else {
+                error!(
+                    upstream_id = %config.id,
+                    "No valid upstream targets configured"
+                );
+                return Err(ZentinelError::Config {
+                    message: "No valid upstream targets".to_string(),
+                    source: None,
+                });
+            }
         }
 
         for target in &targets {
@@ -919,6 +968,10 @@ impl UpstreamPool {
             tls_config,
             circuit_breakers: Arc::new(RwLock::new(circuit_breakers)),
             stats: Arc::new(PoolStats::default()),
+            discovery,
+            discovery_interval,
+            static_targets,
+            config,
         };
 
         info!(
@@ -928,6 +981,251 @@ impl UpstreamPool {
         );
 
         Ok(pool)
+    }
+
+    /// Translate the configuration's discovery block into the runtime one.
+    fn discovery_config(discovery: &UpstreamDiscovery) -> DiscoveryConfig {
+        match discovery {
+            UpstreamDiscovery::Static { backends } => DiscoveryConfig::Static {
+                backends: backends.clone(),
+            },
+            UpstreamDiscovery::Dns {
+                hostname,
+                port,
+                refresh_interval_secs,
+            } => DiscoveryConfig::Dns {
+                hostname: hostname.clone(),
+                port: *port,
+                refresh_interval: Duration::from_secs(*refresh_interval_secs),
+            },
+            UpstreamDiscovery::DnsSrv {
+                service,
+                refresh_interval_secs,
+            } => DiscoveryConfig::DnsSrv {
+                service: service.clone(),
+                refresh_interval: Duration::from_secs(*refresh_interval_secs),
+            },
+            UpstreamDiscovery::Consul {
+                address,
+                service,
+                datacenter,
+                only_passing,
+                refresh_interval_secs,
+                tag,
+            } => DiscoveryConfig::Consul {
+                address: address.clone(),
+                service: service.clone(),
+                datacenter: datacenter.clone(),
+                only_passing: *only_passing,
+                refresh_interval: Duration::from_secs(*refresh_interval_secs),
+                tag: tag.clone(),
+            },
+            UpstreamDiscovery::Kubernetes {
+                namespace,
+                service,
+                port_name,
+                refresh_interval_secs,
+                kubeconfig,
+            } => DiscoveryConfig::Kubernetes {
+                namespace: namespace.clone(),
+                service: service.clone(),
+                port_name: port_name.clone(),
+                refresh_interval: Duration::from_secs(*refresh_interval_secs),
+                kubeconfig: kubeconfig.clone(),
+            },
+            UpstreamDiscovery::File {
+                path,
+                watch_interval_secs,
+            } => DiscoveryConfig::File {
+                path: path.clone(),
+                watch_interval: Duration::from_secs(*watch_interval_secs),
+            },
+        }
+    }
+
+    /// Convert the backends a discovery source returned into pool targets.
+    ///
+    /// Unix-socket backends are skipped: discovery describes networked service
+    /// registries, and a pool target is an address/port pair.
+    fn targets_from_backends(backends: &BTreeSet<Backend>) -> Vec<UpstreamTarget> {
+        backends
+            .iter()
+            .filter_map(|backend| match &backend.addr {
+                PingoraSocketAddr::Inet(addr) => Some(UpstreamTarget {
+                    address: addr.ip().to_string(),
+                    port: addr.port(),
+                    weight: u32::try_from(backend.weight).unwrap_or(1).max(1),
+                }),
+                PingoraSocketAddr::Unix(_) => None,
+            })
+            .collect()
+    }
+
+    /// Build the configured discovery source and resolve it once.
+    ///
+    /// A source that fails to answer is logged and treated as returning
+    /// nothing: the pool falls back to whatever targets the configuration
+    /// lists, and the refresh task retries on the next interval. Failing the
+    /// whole pool here would mean one unreachable registry could stop the proxy
+    /// from starting at all, taking every other upstream down with it.
+    async fn resolve_discovery(
+        config: &UpstreamConfig,
+        id: &UpstreamId,
+    ) -> (
+        Option<Arc<dyn ServiceDiscovery + Send + Sync>>,
+        Option<Duration>,
+        Vec<UpstreamTarget>,
+    ) {
+        let Some(spec) = config.discovery.as_ref() else {
+            return (None, None, Vec::new());
+        };
+
+        let source = crate::discovery::build_discovery(id.as_str(), Self::discovery_config(spec));
+
+        // `static` never changes, so it is resolved once and never scheduled.
+        let interval = match spec.refresh_interval_secs() {
+            0 => None,
+            secs => Some(Duration::from_secs(secs)),
+        };
+
+        let targets = match source.discover().await {
+            Ok((backends, _healthy)) => {
+                let targets = Self::targets_from_backends(&backends);
+                info!(
+                    upstream_id = %config.id,
+                    discovery = spec.kind(),
+                    discovered = targets.len(),
+                    refresh_interval_secs = interval.map(|i| i.as_secs()).unwrap_or(0),
+                    "Resolved service discovery"
+                );
+                targets
+            }
+            Err(e) => {
+                error!(
+                    upstream_id = %config.id,
+                    discovery = spec.kind(),
+                    error = %e,
+                    "Service discovery failed; using configured targets only"
+                );
+                Vec::new()
+            }
+        };
+
+        (Some(source), interval, targets)
+    }
+
+    /// How often this pool's discovery source should be re-resolved, if at all.
+    pub fn discovery_refresh_interval(&self) -> Option<Duration> {
+        self.discovery_interval
+    }
+
+    /// Re-resolve discovery and, when the target set has changed, build the
+    /// pool that should replace this one.
+    ///
+    /// Returns `None` when there is nothing to do — no discovery source, the
+    /// source failed, or it resolved to the same targets the pool already has.
+    /// Callers install the returned pool in place of this one; the two share
+    /// their circuit breakers and statistics, so a backend that was failing
+    /// before the refresh is still failing after it.
+    ///
+    /// # Errors
+    ///
+    /// Never fails: a discovery source that cannot be reached leaves the pool
+    /// serving its current targets rather than emptying it.
+    pub async fn refreshed(&self) -> Option<UpstreamPool> {
+        let source = self.discovery.as_ref()?;
+
+        let (backends, _healthy) = match source.discover().await {
+            Ok(result) => result,
+            Err(e) => {
+                warn!(
+                    upstream_id = %self.id,
+                    error = %e,
+                    "Service discovery refresh failed; keeping current targets"
+                );
+                return None;
+            }
+        };
+
+        let mut targets = self.static_targets.clone();
+        targets.extend(Self::targets_from_backends(&backends));
+
+        if Self::same_targets(&self.targets, &targets) {
+            return None;
+        }
+
+        let previous: Vec<String> = self.targets.iter().map(|t| t.full_address()).collect();
+        let current: Vec<String> = targets.iter().map(|t| t.full_address()).collect();
+        let added: Vec<&String> = current.iter().filter(|a| !previous.contains(a)).collect();
+        let removed: Vec<&String> = previous.iter().filter(|a| !current.contains(a)).collect();
+
+        info!(
+            upstream_id = %self.id,
+            added = ?added,
+            removed = ?removed,
+            target_count = targets.len(),
+            "Service discovery changed upstream targets"
+        );
+
+        // Reconcile circuit breakers in place: surviving targets keep the
+        // breaker they already had (and therefore their open/closed state),
+        // targets that went away lose theirs so the map cannot grow without
+        // bound as backends churn, and new targets start closed.
+        let cb_config = self.config.circuit_breaker.unwrap_or_default();
+        {
+            let mut breakers = self.circuit_breakers.write().await;
+            breakers.retain(|address, _| current.iter().any(|a| a == address));
+            for address in &current {
+                breakers
+                    .entry(address.clone())
+                    .or_insert_with(|| CircuitBreaker::new(cb_config));
+            }
+        }
+
+        let load_balancer =
+            match Self::create_load_balancer(&self.config.load_balancing, &targets, &self.config) {
+                Ok(balancer) => balancer,
+                Err(e) => {
+                    error!(
+                        upstream_id = %self.id,
+                        error = %e,
+                        "Failed to rebuild load balancer after discovery refresh; \
+                         keeping current targets"
+                    );
+                    return None;
+                }
+            };
+
+        Some(UpstreamPool {
+            id: self.id.clone(),
+            targets,
+            load_balancer,
+            pool_config: self.pool_config.clone(),
+            http_version: self.http_version.clone(),
+            tls_enabled: self.tls_enabled,
+            tls_sni: self.tls_sni.clone(),
+            tls_config: self.tls_config.clone(),
+            // Shared, not copied: breaker state and counters must survive the
+            // swap or a flapping backend would look healthy on every refresh.
+            circuit_breakers: Arc::clone(&self.circuit_breakers),
+            stats: Arc::clone(&self.stats),
+            discovery: self.discovery.clone(),
+            discovery_interval: self.discovery_interval,
+            static_targets: self.static_targets.clone(),
+            config: self.config.clone(),
+        })
+    }
+
+    /// Whether two target sets are the same, ignoring order.
+    fn same_targets(a: &[UpstreamTarget], b: &[UpstreamTarget]) -> bool {
+        if a.len() != b.len() {
+            return false;
+        }
+        let mut a: Vec<(String, u32)> = a.iter().map(|t| (t.full_address(), t.weight)).collect();
+        let mut b: Vec<(String, u32)> = b.iter().map(|t| (t.full_address(), t.weight)).collect();
+        a.sort();
+        b.sort();
+        a == b
     }
 
     /// Create load balancer based on algorithm
@@ -1514,6 +1812,25 @@ impl UpstreamPool {
     }
 
     /// Get target count
+    /// Circuit-breaker state for a target, or `None` when the pool has no
+    /// breaker for that address — which for a discovery-backed pool means the
+    /// target is not currently in the resolved set.
+    pub async fn circuit_breaker_state(
+        &self,
+        target: &str,
+    ) -> Option<zentinel_common::types::CircuitBreakerState> {
+        self.circuit_breakers
+            .read()
+            .await
+            .get(target)
+            .map(|breaker| breaker.state())
+    }
+
+    /// Addresses of the pool's current targets, in selection order.
+    pub fn target_addresses(&self) -> Vec<String> {
+        self.targets.iter().map(|t| t.full_address()).collect()
+    }
+
     pub fn target_count(&self) -> usize {
         self.targets.len()
     }

--- a/crates/proxy/src/upstream/mod.rs
+++ b/crates/proxy/src/upstream/mod.rs
@@ -137,6 +137,16 @@ pub trait LoadBalancer: Send + Sync {
     /// Select next upstream target
     async fn select(&self, context: Option<&RequestContext>) -> ZentinelResult<TargetSelection>;
 
+    /// The key this balancer signs session-affinity cookies with, if it signs
+    /// any.
+    ///
+    /// Used to assert that rebuilding a pool — which service discovery does
+    /// whenever the target set changes — does not rotate the key and invalidate
+    /// every cookie already issued.
+    fn session_signing_key(&self) -> Option<[u8; 32]> {
+        None
+    }
+
     /// Report target health status
     async fn report_health(&self, address: &str, healthy: bool);
 
@@ -223,6 +233,14 @@ pub struct UpstreamPool {
     /// The configuration this pool was built from, needed to rebuild the load
     /// balancer when discovery changes the target set.
     config: UpstreamConfig,
+    /// Sticky-session runtime config, carrying the HMAC key that signs affinity
+    /// cookies.
+    ///
+    /// Held on the pool rather than derived per balancer because the key is
+    /// generated randomly: rebuilding it on a discovery refresh would invalidate
+    /// every outstanding affinity cookie, resetting all sessions each time a
+    /// backend appeared or disappeared.
+    sticky_runtime: Option<StickySessionRuntimeConfig>,
 }
 
 // Note: Active health checking is handled by the PassiveHealthChecker in health.rs
@@ -888,7 +906,19 @@ impl UpstreamPool {
             algorithm = ?config.load_balancing,
             "Creating load balancer"
         );
-        let load_balancer = Self::create_load_balancer(&config.load_balancing, &targets, &config)?;
+        // Built once and kept, so a discovery refresh can rebuild the balancer
+        // without rotating the key that signs affinity cookies.
+        let sticky_runtime = config
+            .sticky_session
+            .as_ref()
+            .map(StickySessionRuntimeConfig::from_config);
+
+        let load_balancer = Self::create_load_balancer(
+            &config.load_balancing,
+            &targets,
+            &config,
+            sticky_runtime.as_ref(),
+        )?;
 
         // Create connection pool configuration (Pingora handles actual pooling)
         debug!(
@@ -971,6 +1001,7 @@ impl UpstreamPool {
             discovery_interval,
             static_targets,
             config,
+            sticky_runtime,
         };
 
         info!(
@@ -1202,19 +1233,23 @@ impl UpstreamPool {
             }
         }
 
-        let load_balancer =
-            match Self::create_load_balancer(&self.config.load_balancing, &targets, &self.config) {
-                Ok(balancer) => balancer,
-                Err(e) => {
-                    error!(
-                        upstream_id = %self.id,
-                        error = %e,
-                        "Failed to rebuild load balancer after discovery refresh; \
-                         keeping current targets"
-                    );
-                    return None;
-                }
-            };
+        let load_balancer = match Self::create_load_balancer(
+            &self.config.load_balancing,
+            &targets,
+            &self.config,
+            self.sticky_runtime.as_ref(),
+        ) {
+            Ok(balancer) => balancer,
+            Err(e) => {
+                error!(
+                    upstream_id = %self.id,
+                    error = %e,
+                    "Failed to rebuild load balancer after discovery refresh; \
+                     keeping current targets"
+                );
+                return None;
+            }
+        };
 
         Some(UpstreamPool {
             id: self.id.clone(),
@@ -1233,6 +1268,7 @@ impl UpstreamPool {
             discovery_interval: self.discovery_interval,
             static_targets: self.static_targets.clone(),
             config: self.config.clone(),
+            sticky_runtime: self.sticky_runtime.clone(),
         })
     }
 
@@ -1253,6 +1289,7 @@ impl UpstreamPool {
         algorithm: &LoadBalancingAlgorithm,
         targets: &[UpstreamTarget],
         config: &UpstreamConfig,
+        sticky_runtime: Option<&StickySessionRuntimeConfig>,
     ) -> ZentinelResult<Arc<dyn LoadBalancer>> {
         let balancer: Arc<dyn LoadBalancer> = match algorithm {
             LoadBalancingAlgorithm::RoundRobin => {
@@ -1324,8 +1361,11 @@ impl UpstreamPool {
                     }
                 })?;
 
-                // Create runtime config with HMAC key
-                let runtime_config = StickySessionRuntimeConfig::from_config(sticky_config);
+                // Reuse the pool's existing key when rebuilding, so affinity
+                // cookies issued before the rebuild still verify.
+                let runtime_config = sticky_runtime
+                    .cloned()
+                    .unwrap_or_else(|| StickySessionRuntimeConfig::from_config(sticky_config));
 
                 // Create fallback load balancer
                 let fallback = Self::create_load_balancer_inner(&sticky_config.fallback, targets)?;
@@ -1844,6 +1884,15 @@ impl UpstreamPool {
             .await
             .get(target)
             .map(|breaker| breaker.state())
+    }
+
+    /// The key used to sign sticky-session affinity cookies, when this upstream
+    /// uses sticky load balancing.
+    ///
+    /// Exposed so tests can assert it survives a pool rebuild; rotating it would
+    /// invalidate every cookie already issued.
+    pub fn sticky_signing_key(&self) -> Option<[u8; 32]> {
+        self.load_balancer.session_signing_key()
     }
 
     /// Addresses of the pool's current targets, in selection order.

--- a/crates/proxy/src/upstream/sticky_session.rs
+++ b/crates/proxy/src/upstream/sticky_session.rs
@@ -233,6 +233,10 @@ impl StickySessionBalancer {
 
 #[async_trait]
 impl LoadBalancer for StickySessionBalancer {
+    fn session_signing_key(&self) -> Option<[u8; 32]> {
+        Some(self.config.hmac_key)
+    }
+
     async fn select(&self, context: Option<&RequestContext>) -> ZentinelResult<TargetSelection> {
         trace!(
             has_context = context.is_some(),

--- a/crates/proxy/tests/upstream_discovery_test.rs
+++ b/crates/proxy/tests/upstream_discovery_test.rs
@@ -1,0 +1,351 @@
+//! End-to-end wiring for upstream service discovery (zentinelproxy/zentinel#419).
+//!
+//! These tests exercise the path a configuration actually travels: KDL text →
+//! `UpstreamConfig::discovery` → a resolved `UpstreamPool` whose targets came
+//! from the discovery source → a refresh that replaces those targets.
+//!
+//! `file` discovery is the source under test because it is the only one that
+//! can be driven deterministically without a network service. The code path it
+//! exercises — resolve at construction, re-resolve in `refreshed()`, reconcile
+//! circuit breakers, rebuild the load balancer — is shared by every backend, so
+//! DNS, Consul and Kubernetes differ only in which client produces the backend
+//! set.
+
+use std::io::Write;
+use std::time::Duration;
+
+use zentinel_common::types::CircuitBreakerState;
+use zentinel_config::{Config, UpstreamDiscovery};
+use zentinel_proxy::upstream::UpstreamPool;
+
+/// Write `lines` to a fresh temporary file and return its path.
+fn backends_file(name: &str, lines: &[&str]) -> std::path::PathBuf {
+    let path = std::env::temp_dir().join(format!("zentinel-discovery-{name}.txt"));
+    let mut file = std::fs::File::create(&path).expect("create backends file");
+    for line in lines {
+        writeln!(file, "{line}").expect("write backend line");
+    }
+    file.flush().expect("flush backends file");
+    path
+}
+
+/// Overwrite an existing backends file, ensuring its mtime moves.
+///
+/// `FileDiscovery` re-reads only when the modification time changes, and a
+/// rewrite within the same filesystem timestamp granularity would otherwise be
+/// invisible to it.
+fn rewrite_backends(path: &std::path::Path, lines: &[&str]) {
+    std::thread::sleep(Duration::from_millis(1100));
+    let mut file = std::fs::File::create(path).expect("rewrite backends file");
+    for line in lines {
+        writeln!(file, "{line}").expect("write backend line");
+    }
+    file.flush().expect("flush backends file");
+}
+
+fn config_with_discovery(path: &std::path::Path, extra_target: Option<&str>) -> Config {
+    let pinned = extra_target
+        .map(|t| format!("        target \"{t}\"\n"))
+        .unwrap_or_default();
+    let kdl = format!(
+        r#"
+schema-version "1.0"
+system {{ worker-threads 0 }}
+listeners {{
+    listener "http" {{ address "127.0.0.1:0" }}
+}}
+upstreams {{
+    upstream "discovered" {{
+{pinned}        discovery "file" {{
+            path "{}"
+            watch-interval 1
+        }}
+    }}
+}}
+routes {{
+    route "all" {{
+        matches {{ path-prefix "/" }}
+        upstream "discovered"
+    }}
+}}
+"#,
+        path.display()
+    );
+    Config::from_kdl(&kdl).expect("config with discovery parses")
+}
+
+/// The regression this issue is about: a `discovery` block used to parse into
+/// nothing at all, so an upstream that relied on it had no targets and routed
+/// nowhere.
+#[tokio::test]
+async fn discovery_block_populates_pool_targets() {
+    let path = backends_file("populate", &["127.0.0.1:19501", "127.0.0.1:19502"]);
+    let config = config_with_discovery(&path, None);
+
+    let upstream = config.upstreams.get("discovered").expect("upstream parsed");
+    assert!(
+        matches!(upstream.discovery, Some(UpstreamDiscovery::File { .. })),
+        "discovery block should parse into UpstreamDiscovery::File, got {:?}",
+        upstream.discovery
+    );
+    assert!(
+        upstream.targets.is_empty(),
+        "no targets are configured statically in this fixture"
+    );
+
+    let pool = UpstreamPool::new(upstream.clone())
+        .await
+        .expect("pool builds from discovery alone");
+
+    let mut addresses = pool.target_addresses();
+    addresses.sort();
+    assert_eq!(
+        addresses,
+        vec!["127.0.0.1:19501".to_string(), "127.0.0.1:19502".to_string()],
+        "pool targets should come from the discovery source"
+    );
+}
+
+/// An upstream with no targets and no discovery is still an error: relaxing the
+/// check for discovery must not have relaxed it for everyone.
+#[tokio::test]
+async fn upstream_without_targets_or_discovery_is_still_rejected() {
+    let kdl = r#"
+schema-version "1.0"
+system { worker-threads 0 }
+listeners { listener "http" { address "127.0.0.1:0" } }
+upstreams {
+    upstream "empty" {
+        load-balancing "round-robin"
+    }
+}
+routes {
+    route "all" { matches { path-prefix "/" } ; upstream "empty" }
+}
+"#;
+    let err = Config::from_kdl(kdl).expect_err("an upstream with nothing must not load");
+    let message = err.to_string();
+    assert!(
+        message.contains("target"),
+        "error should name the missing targets, got: {message}"
+    );
+}
+
+/// Discovered targets are added to configured ones rather than replacing them.
+#[tokio::test]
+async fn static_targets_are_kept_alongside_discovered_ones() {
+    let path = backends_file("mixed", &["127.0.0.1:19511"]);
+    let config = config_with_discovery(&path, Some("127.0.0.1:19510"));
+    let upstream = config.upstreams.get("discovered").expect("upstream parsed");
+
+    let pool = UpstreamPool::new(upstream.clone())
+        .await
+        .expect("pool builds");
+
+    let mut addresses = pool.target_addresses();
+    addresses.sort();
+    assert_eq!(
+        addresses,
+        vec!["127.0.0.1:19510".to_string(), "127.0.0.1:19511".to_string()],
+        "the pinned target and the discovered one should both be present"
+    );
+}
+
+/// A refresh that finds the same backends should not produce a replacement
+/// pool: swapping on every tick would churn the registry for no reason.
+#[tokio::test]
+async fn refresh_without_change_returns_none() {
+    let path = backends_file("nochange", &["127.0.0.1:19521"]);
+    let config = config_with_discovery(&path, None);
+    let upstream = config.upstreams.get("discovered").expect("upstream parsed");
+    let pool = UpstreamPool::new(upstream.clone())
+        .await
+        .expect("pool builds");
+
+    tokio::time::sleep(Duration::from_millis(1100)).await;
+
+    assert!(
+        pool.refreshed().await.is_none(),
+        "an unchanged discovery result should not rebuild the pool"
+    );
+}
+
+/// The core of stage three: a changed backend list produces a pool serving the
+/// new targets.
+#[tokio::test]
+async fn refresh_picks_up_changed_backends() {
+    let path = backends_file("changed", &["127.0.0.1:19531"]);
+    let config = config_with_discovery(&path, None);
+    let upstream = config.upstreams.get("discovered").expect("upstream parsed");
+    let pool = UpstreamPool::new(upstream.clone())
+        .await
+        .expect("pool builds");
+    assert_eq!(pool.target_addresses(), vec!["127.0.0.1:19531".to_string()]);
+
+    rewrite_backends(&path, &["127.0.0.1:19532", "127.0.0.1:19533"]);
+
+    let refreshed = pool
+        .refreshed()
+        .await
+        .expect("a changed backend list should rebuild the pool");
+
+    let mut addresses = refreshed.target_addresses();
+    addresses.sort();
+    assert_eq!(
+        addresses,
+        vec!["127.0.0.1:19532".to_string(), "127.0.0.1:19533".to_string()],
+        "the refreshed pool should serve the new backends"
+    );
+    assert_eq!(refreshed.target_count(), 2);
+}
+
+/// Circuit breaker state has to survive the swap. If it did not, a backend that
+/// was failing would look healthy again on every refresh interval — a flapping
+/// backend would never stay ejected.
+#[tokio::test]
+async fn refresh_preserves_circuit_breaker_state_for_surviving_targets() {
+    let path = backends_file("breakers", &["127.0.0.1:19541"]);
+    let config = config_with_discovery(&path, None);
+    let upstream = config.upstreams.get("discovered").expect("upstream parsed");
+    let pool = UpstreamPool::new(upstream.clone())
+        .await
+        .expect("pool builds");
+
+    // Trip the breaker for the target that will survive the refresh. The
+    // default failure threshold is 5.
+    for _ in 0..10 {
+        pool.report_result("127.0.0.1:19541", false).await;
+    }
+    assert_eq!(
+        pool.circuit_breaker_state("127.0.0.1:19541").await,
+        Some(CircuitBreakerState::Open),
+        "the breaker should be open before the refresh"
+    );
+
+    // Add a second backend, keeping the first.
+    rewrite_backends(&path, &["127.0.0.1:19541", "127.0.0.1:19542"]);
+
+    let refreshed = pool.refreshed().await.expect("target set changed");
+
+    assert_eq!(
+        refreshed.circuit_breaker_state("127.0.0.1:19541").await,
+        Some(CircuitBreakerState::Open),
+        "a target that survived the refresh must keep its open breaker"
+    );
+    assert_eq!(
+        refreshed.circuit_breaker_state("127.0.0.1:19542").await,
+        Some(CircuitBreakerState::Closed),
+        "a newly discovered target should start with a closed breaker"
+    );
+}
+
+/// Breakers for targets that went away must be dropped, or the map grows
+/// without bound as backends churn.
+#[tokio::test]
+async fn refresh_drops_breakers_for_removed_targets() {
+    let path = backends_file("removed", &["127.0.0.1:19551", "127.0.0.1:19552"]);
+    let config = config_with_discovery(&path, None);
+    let upstream = config.upstreams.get("discovered").expect("upstream parsed");
+    let pool = UpstreamPool::new(upstream.clone())
+        .await
+        .expect("pool builds");
+
+    assert!(pool
+        .circuit_breaker_state("127.0.0.1:19552")
+        .await
+        .is_some());
+
+    rewrite_backends(&path, &["127.0.0.1:19551"]);
+    let refreshed = pool.refreshed().await.expect("target set changed");
+
+    assert_eq!(
+        refreshed.circuit_breaker_state("127.0.0.1:19552").await,
+        None,
+        "a target that left the discovery set should not keep a breaker"
+    );
+    assert!(
+        refreshed
+            .circuit_breaker_state("127.0.0.1:19551")
+            .await
+            .is_some(),
+        "the surviving target should still have one"
+    );
+}
+
+/// A source that resolves to nothing leaves the pool empty rather than failing
+/// to build: a scaled-to-zero service should not stop the proxy from starting.
+#[tokio::test]
+async fn empty_discovery_result_builds_an_empty_pool() {
+    let path = backends_file("empty", &[]);
+    let config = config_with_discovery(&path, None);
+    let upstream = config.upstreams.get("discovered").expect("upstream parsed");
+
+    let pool = UpstreamPool::new(upstream.clone())
+        .await
+        .expect("an empty discovery result should not fail pool construction");
+
+    assert_eq!(pool.target_count(), 0);
+    assert!(!pool.has_healthy_targets().await);
+}
+
+/// `static` discovery cannot change, so it must not be scheduled for refresh.
+#[tokio::test]
+async fn static_discovery_is_not_scheduled_for_refresh() {
+    let kdl = r#"
+schema-version "1.0"
+system { worker-threads 0 }
+listeners { listener "http" { address "127.0.0.1:0" } }
+upstreams {
+    upstream "fixed" {
+        discovery "static" {
+            backends "127.0.0.1:19561" "127.0.0.1:19562"
+        }
+    }
+}
+routes {
+    route "all" { matches { path-prefix "/" } ; upstream "fixed" }
+}
+"#;
+    let config = Config::from_kdl(kdl).expect("static discovery parses");
+    let upstream = config.upstreams.get("fixed").expect("upstream parsed");
+    let pool = UpstreamPool::new(upstream.clone())
+        .await
+        .expect("pool builds");
+
+    assert_eq!(pool.target_count(), 2, "static backends become targets");
+    assert!(
+        pool.discovery_refresh_interval().is_none(),
+        "a static list has nothing to refresh"
+    );
+}
+
+/// Settings that belong to another discovery backend are rejected outright.
+/// Accepting and ignoring them is the failure shape this feature exists to
+/// remove.
+#[test]
+fn settings_from_the_wrong_backend_are_rejected() {
+    let kdl = r#"
+schema-version "1.0"
+system { worker-threads 0 }
+listeners { listener "http" { address "127.0.0.1:0" } }
+upstreams {
+    upstream "wrong" {
+        discovery "consul" {
+            address "http://consul:8500"
+            service "api"
+            hostname "not-a-consul-setting"
+        }
+    }
+}
+routes {
+    route "all" { matches { path-prefix "/" } ; upstream "wrong" }
+}
+"#;
+    let message = Config::from_kdl(kdl)
+        .expect_err("a consul block must not accept dns settings")
+        .to_string();
+    assert!(
+        message.contains("hostname"),
+        "the error should name the offending key, got: {message}"
+    );
+}

--- a/crates/proxy/tests/upstream_discovery_test.rs
+++ b/crates/proxy/tests/upstream_discovery_test.rs
@@ -151,6 +151,27 @@ async fn static_targets_are_kept_alongside_discovered_ones() {
     );
 }
 
+/// A pinned target that the discovery source also returns must appear once.
+/// Listing it twice would silently double the share of traffic it receives.
+#[tokio::test]
+async fn a_pinned_target_that_is_also_discovered_appears_once() {
+    let path = backends_file("dedupe", &["127.0.0.1:19570", "127.0.0.1:19571"]);
+    let config = config_with_discovery(&path, Some("127.0.0.1:19570"));
+    let upstream = config.upstreams.get("discovered").expect("upstream parsed");
+
+    let pool = UpstreamPool::new(upstream.clone())
+        .await
+        .expect("pool builds");
+
+    let mut addresses = pool.target_addresses();
+    addresses.sort();
+    assert_eq!(
+        addresses,
+        vec!["127.0.0.1:19570".to_string(), "127.0.0.1:19571".to_string()],
+        "the overlapping address should not be listed twice"
+    );
+}
+
 /// A refresh that finds the same backends should not produce a replacement
 /// pool: swapping on every tick would churn the registry for no reason.
 #[tokio::test]

--- a/crates/proxy/tests/upstream_discovery_test.rs
+++ b/crates/proxy/tests/upstream_discovery_test.rs
@@ -293,6 +293,56 @@ async fn refresh_drops_breakers_for_removed_targets() {
     );
 }
 
+/// Sticky session affinity cookies are signed with a randomly generated HMAC
+/// key. Rebuilding the balancer on refresh must not rotate that key, or every
+/// outstanding cookie would stop verifying each time a backend appeared or
+/// disappeared — resetting all sessions on a churning backend set.
+#[tokio::test]
+async fn refresh_preserves_the_sticky_session_signing_key() {
+    let path = backends_file("sticky", &["127.0.0.1:19581"]);
+    let kdl = format!(
+        r#"
+schema-version "1.0"
+system {{ worker-threads 0 }}
+listeners {{ listener "http" {{ address "127.0.0.1:0" }} }}
+upstreams {{
+    upstream "discovered" {{
+        load-balancing "sticky" {{
+            cookie-name "zsession"
+            fallback "round-robin"
+        }}
+        discovery "file" {{
+            path "{}"
+            watch-interval 1
+        }}
+    }}
+}}
+routes {{
+    route "all" {{ matches {{ path-prefix "/" }} ; upstream "discovered" }}
+}}
+"#,
+        path.display()
+    );
+    let config = Config::from_kdl(&kdl).expect("sticky config parses");
+    let upstream = config.upstreams.get("discovered").expect("upstream parsed");
+    let pool = UpstreamPool::new(upstream.clone())
+        .await
+        .expect("pool builds");
+
+    let before = pool
+        .sticky_signing_key()
+        .expect("sticky upstream has a key");
+
+    rewrite_backends(&path, &["127.0.0.1:19581", "127.0.0.1:19582"]);
+    let refreshed = pool.refreshed().await.expect("target set changed");
+
+    assert_eq!(
+        refreshed.sticky_signing_key().expect("still sticky"),
+        before,
+        "the signing key must survive a discovery refresh"
+    );
+}
+
 /// A source that resolves to nothing leaves the pool empty rather than failing
 /// to build: a scaled-to-zero service should not stop the proxy from starting.
 #[tokio::test]

--- a/crates/sim/Cargo.lock
+++ b/crates/sim/Cargo.lock
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.28"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.28"
+version = "0.6.33"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-sim"
-version = "0.6.28"
+version = "0.6.33"
 dependencies = [
  "insta",
  "proptest",

--- a/crates/sim/src/upstream.rs
+++ b/crates/sim/src/upstream.rs
@@ -418,6 +418,7 @@ mod tests {
             tls: None,
             http_version: Default::default(),
             circuit_breaker: None,
+            discovery: None,
         }
     }
 


### PR DESCRIPTION
Closes #419.

## The gap

`discovery` blocks appear 51 times across 10 documentation pages, including a
604-line guide whose opening line sells the feature, and `proxy::discovery`
carries complete implementations for DNS, Consul, Kubernetes and file sources.
Nothing connected them. `UpstreamConfig` had no `discovery` field, so the block
parsed into nothing: the upstream ended up with no targets and routed nowhere.

This is the "parses but does nothing" shape, in its most expensive form —
1661 lines of working implementation unreachable by configuration.

## What this does

Resolution happens in `UpstreamPool::new`, before the pool serves traffic, which
covers all four construction sites (startup, `SIGHUP` reload, and both scoped
pool paths) without touching the request path. Discovered targets are *added* to
statically configured ones, so a fixed backend can be pinned alongside a
discovered set.

Background refresh is a single supervisor task that reads the upstream
registries each tick and refreshes pools whose interval has elapsed. Reading the
registries rather than capturing an `Arc<UpstreamPool>` per upstream is what
keeps it correct across a reload, which replaces every pool wholesale — a
per-pool task would write its result over the pool the reload just installed.

`UpstreamPool::refreshed()` rebuilds only when the target set actually changed.
The replacement **shares circuit breakers and statistics** with the pool it
replaces, so a failing backend stays ejected across the swap; breakers for
targets that disappeared are dropped so the map stays bounded as backends churn.

## Failure behaviour

Deliberately non-fatal in both directions:

- A source that cannot be reached during a refresh leaves the pool serving its
  current targets and retries next interval.
- A source that fails during startup leaves the upstream with only its static
  targets. An unreachable registry must not stop the proxy from starting and
  take every unrelated upstream down with it.
- A source that answers with *no* backends is honoured (a scaled-to-zero service
  is a real state), logged at `WARN`, and recovers on the next refresh.

## Misconfiguration is an error, not an ignored key

Settings are checked against the discovery kind you name — `hostname` inside a
`discovery "consul"` block is rejected, as are unknown kinds, missing required
settings, and zero intervals.

## Verification

Beyond the unit and integration tests, this was run end to end against two live
backends with `file` discovery:

- proxy started, resolved one backend, served it
- rewriting the backends file switched live traffic to the other backend within
  one interval
- growing the file to both backends produced `ABABABABAB` across ten requests
- six idle seconds produced zero spurious pool swaps

The two circuit-breaker tests were mutation-checked: replacing the shared
`Arc` with a fresh map fails both, so they have teeth.

`cargo test --workspace`: 1609 passed, 0 failed. Clippy and fmt clean.

## Not covered

`dns-srv` still falls back to A/AAAA resolution on port 80 rather than reading
SRV records — pre-existing, and now documented as a warning callout instead of
being presented as working.