### PR TITLE
feat(discovery): resolve SRV records instead of falling back to A/AAAA

### DIFF
--- a/crates/proxy/src/discovery.rs
+++ b/crates/proxy/src/discovery.rs
@@ -228,6 +228,208 @@ impl ServiceDiscovery for DnsDiscovery {
 }
 
 // ============================================================================
+// DNS SRV Service Discovery
+// ============================================================================
+
+/// SRV-record service discovery.
+///
+/// Unlike [`DnsDiscovery`], the port comes from the record rather than the
+/// configuration, which is the point of SRV: a service can move ports without
+/// the client being reconfigured.
+///
+/// Selection follows RFC 2782. Only the lowest-numbered priority present is
+/// used — higher numbers are standby targets, and returning them alongside the
+/// active set would send live traffic to backups. Within that priority the
+/// record's weight becomes the backend weight, so an operator's SRV weighting
+/// reaches the load balancer.
+pub struct SrvDiscovery {
+    service: String,
+    refresh_interval: Duration,
+    /// Cached backends
+    cached_backends: RwLock<BTreeSet<Backend>>,
+    /// Last resolution time
+    last_resolution: RwLock<Instant>,
+}
+
+impl SrvDiscovery {
+    /// Create a new SRV discovery instance
+    pub fn new(service: String, refresh_interval: Duration) -> Self {
+        Self {
+            service,
+            refresh_interval,
+            cached_backends: RwLock::new(BTreeSet::new()),
+            last_resolution: RwLock::new(Instant::now() - refresh_interval),
+        }
+    }
+
+    /// Whether the cache is due for refresh.
+    fn needs_refresh(&self) -> bool {
+        let last = *self.last_resolution.read();
+        last.elapsed() >= self.refresh_interval
+    }
+
+    /// Look the service up and resolve each SRV target to addresses.
+    async fn resolve(&self) -> Result<BTreeSet<Backend>, Box<Error>> {
+        use hickory_resolver::proto::rr::{RData, RecordType};
+        use hickory_resolver::TokioResolver;
+
+        trace!(service = %self.service, "Resolving SRV records for service discovery");
+
+        let resolver = TokioResolver::builder_tokio()
+            .and_then(|builder| builder.build())
+            .map_err(|e| {
+                Error::explain(
+                    ErrorType::ConnectNoRoute,
+                    format!("could not build DNS resolver for '{}': {e}", self.service),
+                )
+            })?;
+
+        let lookup = resolver
+            .lookup(self.service.as_str(), RecordType::SRV)
+            .await
+            .map_err(|e| {
+                Error::explain(
+                    ErrorType::ConnectNoRoute,
+                    format!("SRV lookup failed for '{}': {e}", self.service),
+                )
+            })?;
+
+        let records: Vec<_> = lookup
+            .answers()
+            .iter()
+            .filter_map(|record| match &record.data {
+                RData::SRV(srv) => Some(srv),
+                _ => None,
+            })
+            .collect();
+
+        if records.is_empty() {
+            return Err(Error::explain(
+                ErrorType::ConnectNoRoute,
+                format!("no SRV records returned for '{}'", self.service),
+            ));
+        }
+
+        let (best_priority, active) = select_active_srv(&records).ok_or_else(|| {
+            Error::explain(
+                ErrorType::ConnectNoRoute,
+                format!(
+                    "SRV target for '{}' is '.', service explicitly unavailable",
+                    self.service
+                ),
+            )
+        })?;
+
+        let mut backends = BTreeSet::new();
+        for srv in active {
+            let target = srv.target.to_utf8();
+
+            // The SRV target is a hostname; it still needs A/AAAA resolution.
+            let ips = match resolver.lookup_ip(target.as_str()).await {
+                Ok(ips) => ips,
+                Err(e) => {
+                    // One unresolvable target should not discard the rest.
+                    warn!(
+                        service = %self.service,
+                        target = %target,
+                        error = %e,
+                        "SRV target did not resolve, skipping it"
+                    );
+                    continue;
+                }
+            };
+
+            for ip in ips.iter() {
+                backends.insert(Backend {
+                    addr: pingora_core::protocols::l4::socket::SocketAddr::Inet(
+                        std::net::SocketAddr::new(ip, srv.port),
+                    ),
+                    // SRV weight 0 means "no preference", not "never pick me";
+                    // a zero weight here would exclude the backend entirely.
+                    weight: usize::from(srv.weight).max(1),
+                    ext: http::Extensions::new(),
+                });
+            }
+        }
+
+        if backends.is_empty() {
+            return Err(Error::explain(
+                ErrorType::ConnectNoRoute,
+                format!(
+                    "no SRV target resolved to an address for '{}'",
+                    self.service
+                ),
+            ));
+        }
+
+        debug!(
+            service = %self.service,
+            priority = best_priority,
+            backend_count = backends.len(),
+            "SRV resolution successful"
+        );
+
+        Ok(backends)
+    }
+}
+
+/// Pick the SRV records that should receive traffic, per RFC 2782.
+///
+/// Returns the winning priority and its records, or `None` when the answer is
+/// the single root target `.`, which RFC 2782 defines as "the service is
+/// decidedly not available at this domain".
+///
+/// Only the lowest-numbered priority is returned: higher numbers are standby
+/// targets, and mixing them into the active set would send live traffic to
+/// backups. Records whose target is the root are dropped from the active set
+/// rather than resolved.
+fn select_active_srv<'a>(
+    records: &'a [&'a hickory_resolver::proto::rr::rdata::SRV],
+) -> Option<(u16, Vec<&'a hickory_resolver::proto::rr::rdata::SRV>)> {
+    let best_priority = records.iter().map(|srv| srv.priority).min()?;
+    let active: Vec<_> = records
+        .iter()
+        .copied()
+        .filter(|srv| srv.priority == best_priority && !srv.target.is_root())
+        .collect();
+
+    if active.is_empty() {
+        return None;
+    }
+    Some((best_priority, active))
+}
+
+#[async_trait]
+impl ServiceDiscovery for SrvDiscovery {
+    async fn discover(&self) -> Result<(BTreeSet<Backend>, HashMap<u64, bool>)> {
+        if self.needs_refresh() {
+            match self.resolve().await {
+                Ok(backends) => {
+                    *self.cached_backends.write() = backends;
+                    *self.last_resolution.write() = Instant::now();
+                }
+                Err(e) => {
+                    let cached = self.cached_backends.read().clone();
+                    if !cached.is_empty() {
+                        warn!(
+                            service = %self.service,
+                            error = %e,
+                            cached_count = cached.len(),
+                            "SRV resolution failed, using cached backends"
+                        );
+                        return Ok((cached, HashMap::new()));
+                    }
+                    return Err(e);
+                }
+            }
+        }
+
+        let backends = self.cached_backends.read().clone();
+        Ok((backends, HashMap::new()))
+    }
+}
+
+// ============================================================================
 // Consul Service Discovery
 // ============================================================================
 
@@ -1189,17 +1391,10 @@ pub(crate) fn build_discovery(
                 upstream_id = %upstream_id,
                 service = %service,
                 refresh_interval_secs = refresh_interval.as_secs(),
-                "DNS SRV discovery not yet fully implemented, using DNS A record fallback"
+                "Registered DNS SRV service discovery"
             );
 
-            // DNS SRV requires async DNS resolver - fall back to regular DNS for now
-            // Extract hostname from service name (e.g., "_http._tcp.example.com" -> "example.com")
-            let hostname = service
-                .split('.')
-                .skip_while(|s| s.starts_with('_'))
-                .collect::<Vec<_>>()
-                .join(".");
-            Arc::new(DnsDiscovery::new(hostname, 80, refresh_interval))
+            Arc::new(SrvDiscovery::new(service, refresh_interval))
         }
         DiscoveryConfig::Consul {
             address,
@@ -1674,5 +1869,93 @@ mod tests {
         assert!(result.is_some());
         let (backends, _) = result.unwrap().unwrap();
         assert_eq!(backends.len(), 2);
+    }
+}
+
+#[cfg(test)]
+mod srv_tests {
+    use super::select_active_srv;
+    use hickory_resolver::proto::rr::rdata::SRV;
+    use hickory_resolver::proto::rr::Name;
+    use std::str::FromStr;
+
+    fn srv(priority: u16, weight: u16, port: u16, target: &str) -> SRV {
+        SRV::new(
+            priority,
+            weight,
+            port,
+            Name::from_str(target).expect("valid name"),
+        )
+    }
+
+    /// RFC 2782: "A client MUST attempt to contact the target host with the
+    /// lowest-numbered priority it can reach." Higher numbers are standbys, so
+    /// returning them alongside the primaries would put live traffic on backups.
+    #[test]
+    fn only_the_lowest_priority_is_active() {
+        let records = [
+            srv(20, 10, 8080, "backup.example.com."),
+            srv(10, 10, 8080, "primary-a.example.com."),
+            srv(10, 20, 8081, "primary-b.example.com."),
+        ];
+        let refs: Vec<&SRV> = records.iter().collect();
+
+        let (priority, active) = select_active_srv(&refs).expect("an active set");
+        assert_eq!(priority, 10);
+        assert_eq!(active.len(), 2, "both priority-10 targets are active");
+        assert!(
+            active.iter().all(|srv| srv.priority == 10),
+            "the priority-20 backup must not appear"
+        );
+    }
+
+    /// The record carries the port; that is the whole point of SRV over A.
+    #[test]
+    fn ports_come_from_the_records() {
+        let records = [srv(0, 5, 9443, "svc.example.com.")];
+        let refs: Vec<&SRV> = records.iter().collect();
+        let (_, active) = select_active_srv(&refs).expect("an active set");
+        assert_eq!(active[0].port, 9443);
+        assert_eq!(active[0].weight, 5);
+    }
+
+    /// RFC 2782: a single root target means "the service is decidedly not
+    /// available at this domain". It must not be resolved as a hostname.
+    #[test]
+    fn a_root_target_means_service_unavailable() {
+        let records = [srv(0, 0, 0, ".")];
+        let refs: Vec<&SRV> = records.iter().collect();
+        assert!(
+            select_active_srv(&refs).is_none(),
+            "'.' must not produce backends"
+        );
+    }
+
+    /// A root target alongside real ones is dropped, not treated as fatal.
+    #[test]
+    fn a_root_target_is_dropped_from_a_mixed_set() {
+        let records = [srv(0, 10, 8080, "real.example.com."), srv(0, 0, 0, ".")];
+        let refs: Vec<&SRV> = records.iter().collect();
+        let (_, active) = select_active_srv(&refs).expect("an active set");
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].target.to_utf8(), "real.example.com.");
+    }
+
+    /// A priority whose every target is root falls through to no active set
+    /// rather than silently promoting the standby priority.
+    #[test]
+    fn root_only_best_priority_yields_nothing() {
+        let records = [srv(0, 0, 0, "."), srv(10, 10, 8080, "backup.example.com.")];
+        let refs: Vec<&SRV> = records.iter().collect();
+        assert!(
+            select_active_srv(&refs).is_none(),
+            "priority 0 is unavailable; promoting priority 10 would ignore the signal"
+        );
+    }
+
+    #[test]
+    fn no_records_yields_nothing() {
+        let refs: Vec<&SRV> = Vec::new();
+        assert!(select_active_srv(&refs).is_none());
     }
 }

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -217,6 +217,7 @@ pub use metrics::{MetricsManager, MetricsResponse};
 // Service discovery
 pub use discovery::{
     ConsulDiscovery, DiscoveryConfig, DiscoveryManager, DnsDiscovery, KubernetesDiscovery,
+    SrvDiscovery,
 };
 
 // Kubernetes kubeconfig parsing

--- a/crates/proxy/tests/srv_discovery_live_test.rs
+++ b/crates/proxy/tests/srv_discovery_live_test.rs
@@ -1,0 +1,61 @@
+//! Live SRV resolution against public records.
+//!
+//! Ignored by default: these hit real DNS, so they do not belong in CI where a
+//! network blip would look like a code failure. Run deliberately with:
+//!
+//! ```bash
+//! cargo test -p zentinel-proxy --test srv_discovery_live_test -- --ignored --nocapture
+//! ```
+//!
+//! What they demonstrate that a unit test cannot: the port and weight come from
+//! the SRV record itself. The previous implementation reduced
+//! `_xmpp-client._tcp.jabber.org` to `jabber.org` and resolved A/AAAA on port
+//! 80, which is the wrong host and the wrong port.
+
+use std::time::Duration;
+
+use pingora_load_balancing::discovery::ServiceDiscovery;
+use zentinel_proxy::SrvDiscovery;
+
+#[tokio::test]
+#[ignore = "requires network access to public DNS"]
+async fn resolves_port_and_weight_from_the_record() {
+    let discovery = SrvDiscovery::new(
+        "_xmpp-client._tcp.jabber.org".to_string(),
+        Duration::from_secs(30),
+    );
+
+    let (backends, _) = discovery.discover().await.expect("SRV lookup succeeds");
+    assert!(!backends.is_empty(), "jabber.org publishes SRV records");
+
+    for backend in &backends {
+        let pingora_core::protocols::l4::socket::SocketAddr::Inet(addr) = &backend.addr else {
+            panic!("SRV discovery should only produce inet addresses");
+        };
+        assert_eq!(
+            addr.port(),
+            5222,
+            "the port must come from the SRV record, not a default"
+        );
+        assert!(
+            backend.weight >= 1,
+            "a zero SRV weight must not exclude the backend"
+        );
+    }
+}
+
+/// A name with no SRV records must fail rather than quietly resolving something
+/// else — the old fallback would have stripped the underscore labels and
+/// resolved the bare domain instead.
+#[tokio::test]
+#[ignore = "requires network access to public DNS"]
+async fn a_name_without_srv_records_fails() {
+    let discovery = SrvDiscovery::new(
+        "_definitely-not-a-service._tcp.example.com".to_string(),
+        Duration::from_secs(30),
+    );
+    assert!(
+        discovery.discover().await.is_err(),
+        "missing SRV records must be an error, not a silent fallback"
+    );
+}


### PR DESCRIPTION
The last piece of the discovery surface that did not do what its name said.

## Before

`dns-srv` never read an SRV record. It stripped the underscore labels — `_http._tcp.api.example.com` → `api.example.com` — resolved that as A/AAAA, and used **port 80**:

```rust
let hostname = service.split('.').skip_while(|s| s.starts_with('_')).collect::<Vec<_>>().join(".");
Arc::new(DnsDiscovery::new(hostname, 80, refresh_interval))
```

Wrong host, wrong port, and it discarded the port and weight the record exists to carry. It logged a warning and was documented as a limitation, which is honest but not useful.

## After

`SrvDiscovery` uses hickory-resolver — already a dependency for ACME — and resolves each SRV target to its addresses. Selection follows [RFC 2782](https://www.rfc-editor.org/rfc/rfc2782):

- **Lowest priority only.** Higher numbers are standbys; including them would put live traffic on backups.
- **Weight from the record**, so SRV weighting reaches the load balancer. Weight `0` maps to `1` — it means "no preference", not "never select", and a literal `0` would exclude the backend entirely.
- **A `.` target** means explicitly unavailable, so it yields nothing rather than being resolved as a hostname.

One unresolvable target is skipped with a warning rather than discarding the rest. Otherwise failure semantics match `DnsDiscovery`: last known good set while the source is unreachable.

## Verification

Against real public records:

| Service | Port | Weight |
|---|---|---|
| `_xmpp-client._tcp.jabber.org` | **5222** | **30** |
| `_caldavs._tcp.google.com` | **443** | 1 (record weight 0) |

Both IPv4 and IPv6 targets resolved; a name with no SRV records errors instead of silently resolving the bare domain. The old code would have returned port 80 on `jabber.org` for the first.

Those live checks are committed as `#[ignore]`d tests — runnable with `-- --ignored`, but CI does not depend on DNS.

The RFC 2782 selection rules are extracted into `select_active_srv` and unit-tested (6 tests). I mutation-checked them: dropping the priority filter fails 2, treating `.` as resolvable fails 3.

`cargo test -p zentinel-proxy --lib`: 707 passed. Clippy and fmt clean.

Docs updated in zentinelproxy/zentinelproxy.io-docs#48 — the limitation callout is replaced by the actual semantics. The 26.08_11 changelog entry describing the old behaviour is left alone, since it accurately records what that release did.