### PR TITLE
feat(logging): honour logging { timestamps }

### DIFF
--- a/crates/config/docs/kdl-format.md
+++ b/crates/config/docs/kdl-format.md
@@ -573,7 +573,7 @@ observability {
     logging {
         level "info"
         format "json"
-        timestamps true
+        timestamps #true
 
         access-log {
             enabled true

--- a/crates/config/src/kdl/mod.rs
+++ b/crates/config/src/kdl/mod.rs
@@ -1292,8 +1292,14 @@ fn parse_rate_limit_key(key: &str) -> Result<RateLimitKey> {
 pub(crate) const RECOGNIZED_OBSERVABILITY_KEYS: &[&str] = &["logging", "metrics", "tracing"];
 
 /// Settings and blocks `parse_logging_config` reads.
-pub(crate) const RECOGNIZED_LOGGING_KEYS: &[&str] =
-    &["level", "format", "access-log", "error-log", "audit-log"];
+pub(crate) const RECOGNIZED_LOGGING_KEYS: &[&str] = &[
+    "level",
+    "format",
+    "timestamps",
+    "access-log",
+    "error-log",
+    "audit-log",
+];
 
 /// Settings `parse_access_log_config` reads.
 pub(crate) const RECOGNIZED_ACCESS_LOG_KEYS: &[&str] = &[
@@ -1373,6 +1379,9 @@ fn parse_logging_config(node: &kdl::KdlNode) -> Result<crate::observability::Log
     }
     if let Some(format) = get_string_entry(node, "format") {
         config.format = format;
+    }
+    if let Some(timestamps) = get_bool_entry(node, "timestamps") {
+        config.timestamps = timestamps;
     }
 
     // Parse child blocks
@@ -3422,6 +3431,80 @@ mod tests {
         assert_eq!(
             cbconfig.half_open_max_requests,
             cb_default.half_open_max_requests
+        );
+    }
+}
+
+#[cfg(test)]
+mod logging_timestamps_tests {
+    use crate::Config;
+
+    fn logging_config(timestamps: &str) -> crate::observability::LoggingConfig {
+        let kdl = format!(
+            r#"
+schema-version "1.0"
+system {{ worker-threads 1 }}
+observability {{
+    logging {{
+        level "info"
+        timestamps {timestamps}
+    }}
+}}
+listeners {{ listener "l" {{ address "127.0.0.1:8080" }} }}
+routes {{
+    route "r" {{
+        matches {{ path "/" }}
+        service-type "builtin"
+        builtin-handler "health"
+    }}
+}}
+"#
+        );
+        Config::from_kdl(&kdl)
+            .expect("config parses")
+            .observability
+            .logging
+    }
+
+    /// The regression: `timestamps` had a struct field and a documented KDL key,
+    /// but `parse_logging_config` never read it, so `#false` parsed to `true`
+    /// and the setting could not be turned off however it was written.
+    #[test]
+    fn timestamps_false_is_read_from_kdl() {
+        assert!(
+            !logging_config("#false").timestamps,
+            "timestamps #false must reach the struct"
+        );
+    }
+
+    #[test]
+    fn timestamps_true_is_read_from_kdl() {
+        assert!(logging_config("#true").timestamps);
+    }
+
+    /// Omitting it keeps the previous behaviour rather than silently disabling
+    /// timestamps for every existing configuration.
+    #[test]
+    fn timestamps_defaults_to_enabled() {
+        let kdl = r#"
+schema-version "1.0"
+system { worker-threads 1 }
+observability { logging { level "info" } }
+listeners { listener "l" { address "127.0.0.1:8080" } }
+routes {
+    route "r" {
+        matches { path "/" }
+        service-type "builtin"
+        builtin-handler "health"
+    }
+}
+"#;
+        assert!(
+            Config::from_kdl(kdl)
+                .expect("parses")
+                .observability
+                .logging
+                .timestamps
         );
     }
 }

--- a/crates/config/src/validate/unknown_keys.rs
+++ b/crates/config/src/validate/unknown_keys.rs
@@ -1805,15 +1805,14 @@ mod tests {
         );
     }
 
-    /// `timestamps` is documented for the application log and read by nothing.
+    /// All three settings from #415 are now read, so none should be reported.
     ///
-    /// It is the last of the three from #415 still unimplemented: the tracing
-    /// `enabled` switch and the access log's `include-trace-id` are now parsed,
-    /// so only this one should still be reported. Honouring it would mean
-    /// starting the log subscriber after the configuration is read, which would
-    /// lose the diagnostics emitted while finding that configuration.
+    /// `timestamps` was the last one: it needed the log subscriber to be built
+    /// after the configuration is read. The diagnostics emitted while finding
+    /// that configuration are buffered and replayed once logging is up, so
+    /// nothing is lost by the reordering.
     #[test]
-    fn the_unread_timestamps_setting_is_still_reported() {
+    fn the_observability_settings_from_415_are_all_read() {
         let kdl = r#"
             observability {
                 logging {
@@ -1831,11 +1830,7 @@ mod tests {
             }
         "#;
         let warnings = warnings_for(kdl);
-        assert!(
-            warnings.iter().any(|w| w.contains("'timestamps'")),
-            "timestamps is documented but read by nothing: {warnings:?}"
-        );
-        for key in ["include-trace-id", "enabled"] {
+        for key in ["timestamps", "include-trace-id", "enabled"] {
             assert!(
                 !warnings.iter().any(|w| w.contains(&format!("'{key}'"))),
                 "{key} is parsed now and must not be reported: {warnings:?}"

--- a/crates/proxy/src/main.rs
+++ b/crates/proxy/src/main.rs
@@ -614,6 +614,94 @@ async fn initialize_acme(
     }))
 }
 
+/// Messages produced before the log subscriber exists.
+///
+/// Config discovery runs before logging is configured, because
+/// `logging { timestamps }` must be known to build the subscriber and a
+/// subscriber can only be installed once. Those messages are the ones that
+/// explain which configuration file the proxy actually chose, so they are held
+/// here and emitted the moment logging is up rather than dropped.
+///
+/// Bounded by construction: config discovery emits at most a handful of lines
+/// and runs exactly once.
+#[derive(Default)]
+struct StartupLog(Vec<(tracing::Level, String)>);
+
+impl StartupLog {
+    fn info(&mut self, message: String) {
+        self.0.push((tracing::Level::INFO, message));
+    }
+
+    fn warn(&mut self, message: String) {
+        self.0.push((tracing::Level::WARN, message));
+    }
+
+    /// Emit everything buffered, in the order it happened.
+    fn emit(self) {
+        for (level, message) in self.0 {
+            match level {
+                tracing::Level::WARN => warn!("{message}"),
+                _ => info!("{message}"),
+            }
+        }
+    }
+}
+
+/// Read the logging configuration the subscriber needs.
+///
+/// This parses the configuration a second time — `ZentinelProxy::new` parses it
+/// again for real — because the subscriber has to exist before the proxy is
+/// built. It happens once at startup and buys the ability to honour
+/// `logging { timestamps }` at all.
+///
+/// A configuration that fails to parse here is not reported as an error: the
+/// proxy is about to load the same file and will fail with a far better message
+/// than this function could. Defaults are used so that failure is still logged.
+fn resolve_logging_config(
+    config_path: Option<&str>,
+    startup_log: &mut StartupLog,
+) -> zentinel_config::LoggingConfig {
+    let parsed = match config_path {
+        Some(path) => zentinel_config::Config::from_file(path).ok(),
+        None => zentinel_config::Config::default_embedded().ok(),
+    };
+
+    match parsed {
+        Some(config) => config.observability.logging,
+        None => {
+            startup_log.warn(
+                "Could not read logging configuration; using defaults until the \
+                 configuration is loaded"
+                    .to_string(),
+            );
+            zentinel_config::LoggingConfig::default()
+        }
+    }
+}
+
+/// Install the log subscriber.
+///
+/// `timestamps` comes from `logging { timestamps }`. Turning it off is for
+/// environments whose log transport stamps arrival time itself — systemd
+/// journal, Docker, most log shippers — where a second timestamp on every line
+/// is noise.
+fn init_logging(verbose: bool, timestamps: bool) {
+    let log_level = if verbose { "debug" } else { "info" };
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(log_level));
+
+    // The two branches differ in the formatter's type, so they cannot be
+    // collapsed into one builder expression.
+    if timestamps {
+        tracing_subscriber::fmt().with_env_filter(filter).init();
+    } else {
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .without_time()
+            .init();
+    }
+}
+
 /// Run the proxy server
 fn run_server(
     config_path: Option<String>,
@@ -621,14 +709,15 @@ fn run_server(
     daemon: bool,
     upgrade: bool,
 ) -> Result<()> {
-    // Initialize logging based on verbose flag
-    let log_level = if verbose { "debug" } else { "info" };
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(log_level)),
-        )
-        .init();
+    // Logging is started further down, once the configuration has been read:
+    // `logging { timestamps }` has to be known before the subscriber is built,
+    // and a subscriber can only be installed once.
+    //
+    // Config discovery happens before that point and is exactly the diagnostic
+    // you want when the proxy loads a file you did not expect, so those messages
+    // are buffered here and emitted as soon as the subscriber exists rather than
+    // being lost.
+    let mut startup_log = StartupLog::default();
 
     // Build Pingora options
     let mut pingora_opt = Opt::default();
@@ -644,26 +733,33 @@ fn run_server(
         Some(path) => {
             let config_path = std::path::Path::new(&path);
             if config_path.exists() {
-                info!("Loading configuration from: {}", path);
+                startup_log.info(format!("Loading configuration from: {path}"));
                 Some(path)
             } else {
                 // Config file doesn't exist - create it with default content
-                info!("Configuration file not found: {}", path);
+                startup_log.info(format!("Configuration file not found: {path}"));
                 if let Err(e) = create_default_config_file(config_path) {
-                    warn!("Failed to create default config file: {}", e);
-                    info!("Using embedded default configuration instead");
+                    startup_log.warn(format!("Failed to create default config file: {e}"));
+                    startup_log.info("Using embedded default configuration instead".to_string());
                     None
                 } else {
-                    info!("Created default configuration at: {}", path);
+                    startup_log.info(format!("Created default configuration at: {path}"));
                     Some(path)
                 }
             }
         }
         None => {
-            info!("No configuration specified, using embedded default configuration");
+            startup_log.info(
+                "No configuration specified, using embedded default configuration".to_string(),
+            );
             None
         }
     };
+
+    // The subscriber can be built now that the configuration is known.
+    let logging = resolve_logging_config(effective_config_path.as_deref(), &mut startup_log);
+    init_logging(verbose, logging.timestamps);
+    startup_log.emit();
 
     // Create signal manager for cross-thread communication
     let signal_manager = Arc::new(SignalManager::new());


### PR DESCRIPTION
Closes #415 — the last of the three observability settings that were documented and read by nothing.

## It was two bugs, not one

I expected to find a struct field nobody consumed. There was also a parser that never populated it:

```
timestamps #false  ->  struct field = true
```

`parse_logging_config` read `level` and `format` and skipped `timestamps`, so the setting could not be turned off however you wrote it — and it wouldn't have mattered, because nothing read the field either. Both fixed, with a regression test for each. The parser test fails if the read is removed; I checked.

## The ordering, and why it costs nothing

The subscriber now starts **after** the configuration is read, as you decided: `timestamps` has to be known to build it, and a subscriber can only be installed once.

The objection was losing the diagnostics emitted while *finding* the configuration — which are exactly what you want when the proxy loads a file you didn't expect. That turned out to be avoidable. Those six messages are buffered in `StartupLog` and emitted the moment logging is up:

```
=== timestamps on ===
2026-08-29T17:28:11.974057Z  INFO zentinel: Loading configuration from: on.kdl
=== timestamps off ===
 INFO zentinel: Loading configuration from: off.kdl
```

`Loading configuration from` survives in both. The tradeoff you accepted didn't need paying.

I considered a toggleable `FormatTime` backed by an `AtomicBool`, which would avoid reordering entirely, but it leaves the timer's separator behind (`  INFO` instead of `INFO`), so the output wouldn't match `without_time()`. Buffering gives exact formatting and loses nothing.

## Cost

Reading the config for the subscriber parses it a second time — `ZentinelProxy::new` parses it again for real. Once, at startup. A file that fails to parse here is deliberately not reported: the proxy is about to fail on the same file with a far better message than this path could produce.

## Also

`timestamps true` → `timestamps #true` in the KDL format guide. Bare booleans are a **parse error** in KDL, not a silently ignored value — I verified rather than assuming.

That is not isolated: **103 bare booleans across 9 crate doc files** show config that cannot parse. Nothing validates `crates/*/docs/`, unlike the docs site which is checked against the playground WASM. Out of scope here; worth its own change.

`cargo test --workspace`: 1623 passed, 0 failed across 37 binaries. Clippy and fmt clean.