### PR TITLE
chore: bump workspace version to 0.6.37

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8182,7 +8182,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.36"
+version = "0.6.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8223,7 +8223,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.36"
+version = "0.6.37"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8245,7 +8245,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.36"
+version = "0.6.37"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8324,7 +8324,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.36"
+version = "0.6.37"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8505,7 +8505,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.36"
+version = "0.6.37"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8596,7 +8596,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.36"
+version = "0.6.37"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8613,7 +8613,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.36"
+version = "0.6.37"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.36"
+version = "0.6.37"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/config-inspect/Cargo.toml
+++ b/crates/config-inspect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-config-inspect"
-version = "0.6.36"
+version = "0.6.37"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/playground-wasm/Cargo.toml
+++ b/crates/playground-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-playground-wasm"
-version = "0.6.36"
+version = "0.6.37"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/sim/Cargo.toml
+++ b/crates/sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-sim"
-version = "0.6.36"
+version = "0.6.37"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Post-release bump for 26.08_14, which published `0.6.37` to crates.io.

The release workflow pushes this branch but its own `gh pr create` reliably fails, so the PR is opened by hand — and it only edits the four `Cargo.toml` files, leaving `Cargo.lock` naming the previous version. The lockfile commit is added here.

Verified before pushing: `git log origin/chore/bump-0.6.37..origin/main` was empty, so this branch is not behind main and merging it discards nothing.