### PR TITLE
docs: changelog for 26.09_1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ for details.
 
 | CalVer | Crate Version | Date | Highlights |
 |--------|---------------|------|------------|
+| [26.09_1](#26091---2026-09-01) | 0.6.38 | 2026-09-01 | Dependency updates only; the XML parser in the data-masking agent was ported to quick-xml 0.42 |
 | [26.08_14](#260814---2026-08-29) | 0.6.37 | 2026-08-29 | `zentinel` with no configuration starts instead of retrying port 9090 forever; `logging { timestamps }` is read |
 | [26.08_13](#260813---2026-08-29) | 0.6.36 | 2026-08-29 | `dns-srv` discovery reads SRV records: the port and weight come from the record, where it previously resolved the bare domain on port 80 |
 | [26.08_12](#260812---2026-08-29) | 0.6.35 | 2026-08-29 | `Cache-Status` no longer erases what an upstream cache reported, so a Zentinel placed in front of another cache shows the whole path rather than only its own member |
@@ -78,6 +79,26 @@ for details.
 ## [Unreleased]
 
 _Nothing yet._
+
+---
+
+## [26.09_1] - 2026-09-01
+
+**Crate version:** 0.6.38
+
+Dependency updates only. Nothing in this release changes how Zentinel routes,
+inspects or blocks traffic; there is no reason to hurry the upgrade, and no
+configuration change is needed.
+
+### Changed
+- **`quick-xml` 0.41 → 0.42**, which decodes as it reads. The XML parser in the
+  data-masking agent was ported to match: element names and attribute keys now
+  arrive as `&str` rather than `&[u8]`, attribute values as `Cow<'_, str>`, and
+  `BytesText` derefs to `str` instead of offering a fallible `decode()`.
+  Attribute values remain unnormalised, as before, so masking sees exactly the
+  text it saw on 0.41.
+- **`jsonschema` 0.50 → 0.52** in the config and proxy crates.
+- **`uuid` 1.24.1 → 1.26.0** and **`maxminddb` 0.30.0 → 0.30.3**.
 
 ---
 


### PR DESCRIPTION
Changelog entry ahead of tagging `26.09_1`.

## What is in the release

Three dependency bumps and nothing else — four commits since `26.08_14`, one of which was the version bump:

| | |
|---|---|
| `quick-xml` 0.41 → 0.42 | plus the data-masking XML parser port (#440) |
| `jsonschema` 0.50 → 0.52 | config and proxy crates (#439) |
| `uuid` 1.24.1 → 1.26.0, `maxminddb` 0.30.0 → 0.30.3 | rust-minor group (#438) |

The entry says that plainly rather than dressing it up — nothing here changes how Zentinel routes, inspects or blocks traffic, and no configuration change is needed.

## Version

Recorded as crate **0.6.38**, which is what the workflow will publish: it reads `0.6.37` from `Cargo.toml` at the tagged commit and increments.

I checked main against crates.io before writing that — both are at 0.6.37, so the post-release bump from `26.08_14` did land and the two are in step. That check matters because when it fails, the published version silently skips.

## Tag name

`26.09_1`, unpadded, matching all fourteen August tags (`26.08_1` … `26.08_14`). The workflow's regex would also accept `26.09_01`, but that breaks convention and would be ambiguous against a later `26.09_1`.