### PR TITLE
chore: bump version to 0.6.38 for release 26.09_1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8183,7 +8183,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.37"
+version = "0.6.38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8224,7 +8224,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.37"
+version = "0.6.38"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8246,7 +8246,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.37"
+version = "0.6.38"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8325,7 +8325,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.37"
+version = "0.6.38"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8506,7 +8506,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.37"
+version = "0.6.38"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8597,7 +8597,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.37"
+version = "0.6.38"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8614,7 +8614,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.37"
+version = "0.6.38"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.37"
+version = "0.6.38"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/config-inspect/Cargo.toml
+++ b/crates/config-inspect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-config-inspect"
-version = "0.6.37"
+version = "0.6.38"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/playground-wasm/Cargo.toml
+++ b/crates/playground-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-playground-wasm"
-version = "0.6.37"
+version = "0.6.38"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/sim/Cargo.toml
+++ b/crates/sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-sim"
-version = "0.6.37"
+version = "0.6.38"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Post-release version bump for `26.09_1`, which published **0.6.38** to crates.io.

The Release workflow tries to push this straight to `main`, branch protection blocks it, and it falls back to creating this branch. The PR-creation step that should follow is `continue-on-error` and did not run, so the branch was left orphaned — as it has been after previous releases.

**Without this, `main` stays at 0.6.37 while crates.io is at 0.6.38**, and the next release would compute 0.6.38 again and fail to publish.

## Two things checked before opening this

**`main` has not moved** since the release commit — `git log chore/bump-0.6.38..main` is empty — so this branch is a clean bump and not destructive to anything merged in between. That check matters: the branch is built on the tagged commit, so if `main` had advanced, merging it as-is would revert whatever landed.

**The lockfile needed a second commit.** The workflow stages only `Cargo.toml` and `crates/*/Cargo.toml`, leaving `Cargo.lock` describing 0.6.37 while the manifests say 0.6.38. CI fails on that mismatch, which is the reason this branch has never merged on its own. `Cargo.lock` is now regenerated.

## Worth fixing at source

The workflow should stage `Cargo.lock` alongside the manifests, and its PR-creation step should be visible when it fails rather than silently swallowed. Happy to open that separately.