### PR TITLE
feat(agentic): count MCP calls per tool, with bounded label cardinality

### DIFF
--- a/crates/common/src/observability.rs
+++ b/crates/common/src/observability.rs
@@ -82,6 +82,8 @@ pub struct RequestMetrics {
     agent_timeouts: IntCounterVec,
     /// Blocked requests by reason
     blocked_requests: CounterVec,
+    /// MCP tool and resource calls, by route, method and target
+    mcp_calls: IntCounterVec,
     /// Request body size histogram
     request_body_size: HistogramVec,
     /// Response body size histogram
@@ -226,6 +228,17 @@ impl RequestMetrics {
             &["reason"]
         )
         .context("Failed to register blocked_requests metric")?;
+
+        // `target` is resolved from the request body, so it is client-supplied
+        // and would be unbounded as a label. The caller passes only names the
+        // route's own configuration lists, and `<other>` for anything else, so
+        // series count is bounded by config rather than by traffic.
+        let mcp_calls = register_int_counter_vec!(
+            "zentinel_mcp_calls_total",
+            "MCP calls by route, JSON-RPC method, target and decision",
+            &["route", "method", "target", "decision"]
+        )
+        .context("Failed to register mcp_calls metric")?;
 
         let request_body_size = register_histogram_vec!(
             "zentinel_request_body_size_bytes",
@@ -391,6 +404,7 @@ impl RequestMetrics {
             agent_latency,
             agent_timeouts,
             blocked_requests,
+            mcp_calls,
             request_body_size,
             response_body_size,
             tls_handshake_duration,
@@ -471,6 +485,45 @@ impl RequestMetrics {
     /// Record a blocked request
     pub fn record_blocked_request(&self, reason: &str) {
         self.blocked_requests.with_label_values(&[reason]).inc();
+    }
+
+    /// Placeholder used when a client-supplied MCP name is not one the route
+    /// declares, so it cannot become its own metric series.
+    pub const MCP_TARGET_OTHER: &'static str = "<other>";
+
+    /// Record an MCP call.
+    ///
+    /// `method` and `target` come from the request *body*, which is where the
+    /// policy engine resolves them: the mirrored `Mcp-Method` and `Mcp-Name`
+    /// headers can disagree with it, and this must count what the server will
+    /// actually execute.
+    ///
+    /// Both are client-supplied, so both are bounded before they become labels:
+    /// use [`Self::bounded_mcp_label`] on each. Without that, a client can mint
+    /// an unbounded number of series by calling `tools/call` with random names.
+    ///
+    /// `decision` is `allowed` or `denied`.
+    pub fn record_mcp_call(&self, route: &str, method: &str, target: &str, decision: &str) {
+        self.mcp_calls
+            .with_label_values(&[route, method, target, decision])
+            .inc();
+    }
+
+    /// Reduce a client-supplied MCP name to something safe to use as a label.
+    ///
+    /// Returns the name when the route's configuration mentions it, and
+    /// [`Self::MCP_TARGET_OTHER`] otherwise, so the number of series a route can
+    /// produce is bounded by how many names its own config lists.
+    ///
+    /// An empty `declared` means the route allows everything, which is a policy
+    /// decision and not a licence to emit unbounded labels: everything is
+    /// reported as `<other>` in that case.
+    pub fn bounded_mcp_label<'a>(name: &str, declared: &'a [String]) -> &'a str {
+        declared
+            .iter()
+            .find(|d| d.as_str() == name)
+            .map(String::as_str)
+            .unwrap_or(Self::MCP_TARGET_OTHER)
     }
 
     /// Record PII detection in inference response
@@ -907,5 +960,52 @@ mod tests {
             Some("Connection refused".to_string()),
         );
         assert_eq!(checker.get_status(), HealthStatus::Unhealthy);
+    }
+}
+
+#[cfg(test)]
+mod mcp_label_bounding_tests {
+    use super::*;
+
+    #[test]
+    fn a_declared_name_is_reported_as_itself() {
+        let declared = vec!["get_weather".to_string(), "search_docs".to_string()];
+        assert_eq!(
+            RequestMetrics::bounded_mcp_label("get_weather", &declared),
+            "get_weather"
+        );
+    }
+
+    #[test]
+    fn an_undeclared_name_cannot_mint_a_series() {
+        // The point of the bound: a client calling tools/call with arbitrary
+        // names must not be able to create unbounded Prometheus series.
+        let declared = vec!["get_weather".to_string()];
+        for attacker_supplied in ["../../etc/passwd", "a".repeat(4096).as_str(), "🙂", ""] {
+            assert_eq!(
+                RequestMetrics::bounded_mcp_label(attacker_supplied, &declared),
+                RequestMetrics::MCP_TARGET_OTHER
+            );
+        }
+    }
+
+    #[test]
+    fn allowing_everything_still_bounds_the_label() {
+        // An empty allowlist means the route permits any tool. That is a policy
+        // decision, not permission to emit a label per distinct name.
+        let declared: Vec<String> = Vec::new();
+        assert_eq!(
+            RequestMetrics::bounded_mcp_label("anything_at_all", &declared),
+            RequestMetrics::MCP_TARGET_OTHER
+        );
+    }
+
+    #[test]
+    fn matching_is_exact_rather_than_prefix() {
+        let declared = vec!["get_weather".to_string()];
+        assert_eq!(
+            RequestMetrics::bounded_mcp_label("get_weather_secret", &declared),
+            RequestMetrics::MCP_TARGET_OTHER
+        );
     }
 }

--- a/crates/proxy/src/agentic/mcp.rs
+++ b/crates/proxy/src/agentic/mcp.rs
@@ -143,6 +143,37 @@ pub enum DenyReason {
     },
 }
 
+impl DenyReason {
+    /// The JSON-RPC method this refusal concerned, where the refusal was about
+    /// a specific call rather than the request's shape.
+    ///
+    /// Used to label metrics, so a denial can be attributed to the tool it
+    /// refused rather than only counted.
+    pub fn method(&self) -> Option<&str> {
+        match self {
+            Self::TargetNotAllowed { method, .. } | Self::MethodNotAllowed { method } => {
+                Some(method)
+            }
+            Self::HeaderBodyMismatch { .. }
+            | Self::ParamHeaderMismatch { .. }
+            | Self::UnvalidatedProtocolVersion { .. }
+            | Self::Unparseable { .. } => None,
+        }
+    }
+
+    /// The tool or resource this refusal concerned, if it named one.
+    pub fn target(&self) -> Option<&str> {
+        match self {
+            Self::TargetNotAllowed { target, .. } => Some(target),
+            Self::MethodNotAllowed { .. }
+            | Self::HeaderBodyMismatch { .. }
+            | Self::ParamHeaderMismatch { .. }
+            | Self::UnvalidatedProtocolVersion { .. }
+            | Self::Unparseable { .. } => None,
+        }
+    }
+}
+
 impl std::fmt::Display for DenyReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -1050,5 +1081,42 @@ mod tests {
             assert!(!version_is_validated(""));
             assert!(!version_is_validated("2026-07-28-extra"));
         }
+    }
+}
+
+#[cfg(test)]
+mod deny_attribution_tests {
+    use super::*;
+
+    #[test]
+    fn a_refused_tool_is_attributable() {
+        let reason = DenyReason::TargetNotAllowed {
+            method: "tools/call".into(),
+            target: "delete_everything".into(),
+        };
+        assert_eq!(reason.method(), Some("tools/call"));
+        assert_eq!(reason.target(), Some("delete_everything"));
+    }
+
+    #[test]
+    fn a_refused_method_names_no_target() {
+        let reason = DenyReason::MethodNotAllowed {
+            method: "resources/read".into(),
+        };
+        assert_eq!(reason.method(), Some("resources/read"));
+        assert_eq!(reason.target(), None);
+    }
+
+    #[test]
+    fn a_spoofed_header_attributes_nothing() {
+        // The header and body disagree, so neither is trustworthy enough to
+        // report as the call that was refused.
+        let reason = DenyReason::HeaderBodyMismatch {
+            header: "mcp-name",
+            header_value: "read_file".into(),
+            body_value: "delete_everything".into(),
+        };
+        assert_eq!(reason.method(), None);
+        assert_eq!(reason.target(), None);
     }
 }

--- a/crates/proxy/src/agentic/mod.rs
+++ b/crates/proxy/src/agentic/mod.rs
@@ -51,6 +51,15 @@ pub enum Outcome {
         reason: String,
         /// Metrics label: `mcp_policy` or `a2a_policy`.
         kind: &'static str,
+        /// Method the refusal concerned, where it named one.
+        ///
+        /// Carried so a denial can be attributed to the call it refused rather
+        /// than only counted. Absent for refusals about the request's shape --
+        /// a header disagreeing with the body, an unparseable payload -- where
+        /// there is no trustworthy method to report.
+        method: Option<String>,
+        /// Tool or resource the refusal concerned, where it named one.
+        target: Option<String>,
     },
 }
 
@@ -80,6 +89,8 @@ pub fn decide(route: &RouteConfig, headers: &[(String, String)], body: &[u8]) ->
             }
             mcp::Decision::Deny { reason } => {
                 return Some(Outcome::Deny {
+                    method: reason.method().map(str::to_owned),
+                    target: reason.target().map(str::to_owned),
                     reason: reason.to_string(),
                     kind: "mcp_policy",
                 })
@@ -94,7 +105,11 @@ pub fn decide(route: &RouteConfig, headers: &[(String, String)], body: &[u8]) ->
                 return Some(Outcome::Deny {
                     reason: reason.to_string(),
                     kind: "a2a_policy",
-                })
+                    // A2A carries no mirrored header to reconcile and this
+                    // metric is MCP's; nothing to attribute.
+                    method: None,
+                    target: None,
+                });
             }
         }
     }

--- a/crates/proxy/src/proxy/http_trait.rs
+++ b/crates/proxy/src/proxy/http_trait.rs
@@ -35,6 +35,7 @@ use super::listener_addr::listener_for_addr;
 use super::model_routing;
 use super::model_routing_metrics::get_model_routing_metrics;
 use super::ZentinelProxy;
+use zentinel_common::observability::RequestMetrics;
 
 /// The IP socket address behind a Pingora endpoint, if it has one.
 ///
@@ -3935,11 +3936,17 @@ impl ZentinelProxy {
                     a2a_method = ?a2a_method,
                     "Agentic request permitted"
                 );
+                self.record_mcp_call(&route, ctx, &mcp_method, &mcp_target, "allowed");
                 ctx.mcp_method = mcp_method;
                 ctx.mcp_target = mcp_target;
                 ctx.a2a_method = a2a_method;
             }
-            Some(agentic::Outcome::Deny { reason, kind }) => {
+            Some(agentic::Outcome::Deny {
+                reason,
+                kind,
+                method,
+                target,
+            }) => {
                 warn!(
                     correlation_id = %ctx.trace_id,
                     route_id = ?ctx.route_id,
@@ -3947,12 +3954,47 @@ impl ZentinelProxy {
                     reason = %reason,
                     "Agentic request denied"
                 );
+                self.record_mcp_call(&route, ctx, &method, &target, "denied");
                 self.metrics.record_blocked_request(kind);
                 return Err(Error::explain(ErrorType::HTTPStatus(403), reason));
             }
         }
 
         Ok(())
+    }
+
+    /// Count one MCP call, bounding the client-supplied labels first.
+    ///
+    /// Only routes carrying an `mcp` block are counted: without one the proxy
+    /// never resolves a method from the body, and reporting `<other>` for every
+    /// request through every other route would be noise.
+    ///
+    /// `method` and `target` come from the request body and are therefore
+    /// attacker-controlled. Both are reduced to something the route's own
+    /// configuration names, so the series a route can produce is bounded by its
+    /// config rather than by what clients send.
+    fn record_mcp_call(
+        &self,
+        route: &zentinel_config::RouteConfig,
+        ctx: &RequestContext,
+        method: &Option<String>,
+        target: &Option<String>,
+        decision: &str,
+    ) {
+        let Some(mcp) = route.mcp.as_ref() else {
+            return;
+        };
+        let route_id = ctx.route_id.as_deref().unwrap_or("unknown");
+        let method_label = method
+            .as_deref()
+            .map(|m| RequestMetrics::bounded_mcp_label(m, &mcp.allowed_methods))
+            .unwrap_or(RequestMetrics::MCP_TARGET_OTHER);
+        let target_label = target
+            .as_deref()
+            .map(|t| RequestMetrics::bounded_mcp_label(t, &mcp.allowed_tools))
+            .unwrap_or(RequestMetrics::MCP_TARGET_OTHER);
+        self.metrics
+            .record_mcp_call(route_id, method_label, target_label, decision);
     }
 
     /// Process a single body chunk in streaming mode.

--- a/crates/proxy/tests/agentic_policy_test.rs
+++ b/crates/proxy/tests/agentic_policy_test.rs
@@ -97,7 +97,7 @@ fn a_tool_outside_the_allowlist_is_denied_from_config() {
     );
 
     match outcome {
-        Some(Outcome::Deny { reason, kind }) => {
+        Some(Outcome::Deny { reason, kind, .. }) => {
             assert_eq!(kind, "mcp_policy");
             assert!(
                 reason.contains("delete_everything"),
@@ -143,7 +143,7 @@ fn a_header_that_disagrees_with_the_body_is_denied() {
     );
 
     match outcome {
-        Some(Outcome::Deny { reason, kind }) => {
+        Some(Outcome::Deny { reason, kind, .. }) => {
             assert_eq!(kind, "mcp_policy");
             assert!(
                 reason.contains("get_weather") && reason.contains("execute_sql"),
@@ -268,7 +268,7 @@ fn a_denied_a2a_method_is_refused_from_config() {
     let outcome = decide(route(&config, "mcp"), &[], &a2a_call("SendMessage"));
 
     match outcome {
-        Some(Outcome::Deny { reason, kind }) => {
+        Some(Outcome::Deny { reason, kind, .. }) => {
             assert_eq!(kind, "a2a_policy");
             assert!(reason.contains("SendMessage"), "got: {reason}");
         }
@@ -331,4 +331,53 @@ fn unknown_methods_deny_reaches_the_evaluator() {
         matches!(outcome, Some(Outcome::Deny { .. })),
         "expected Deny once the route opts in, got {outcome:?}"
     );
+}
+
+/// A denial should say *what* was refused, not only that something was.
+///
+/// The evaluator resolves the method and tool from the body in order to decide,
+/// then used to discard both into a formatted string. Metrics need them back:
+/// counting `mcp_policy` denials without naming the tool tells an operator that
+/// something is being refused and nothing about what.
+#[test]
+fn a_denial_names_the_call_it_refused() {
+    let config = config_with(TOOLS_BLOCK);
+    let outcome = decide(
+        route(&config, "mcp"),
+        &mcp_headers("delete_everything"),
+        &call("delete_everything"),
+    );
+
+    match outcome {
+        Some(Outcome::Deny { method, target, .. }) => {
+            assert_eq!(method.as_deref(), Some("tools/call"));
+            assert_eq!(target.as_deref(), Some("delete_everything"));
+        }
+        other => panic!("expected Deny, got {other:?}"),
+    }
+}
+
+/// When a mirrored header disagrees with the body, neither value is trustworthy
+/// enough to attribute the denial to.
+///
+/// Reporting the header would let a client choose which metric series its
+/// traffic lands in; reporting the body would imply a confidence the mismatch
+/// itself disproves. So the refusal is counted without a call attached.
+#[test]
+fn a_spoofed_header_denial_attributes_no_call() {
+    let config = config_with(TOOLS_BLOCK);
+    let outcome = decide(
+        route(&config, "mcp"),
+        // header says an allowed tool, body calls a different one
+        &mcp_headers("get_weather"),
+        &call("delete_everything"),
+    );
+
+    match outcome {
+        Some(Outcome::Deny { method, target, .. }) => {
+            assert_eq!(method, None, "a spoofed header must not name a method");
+            assert_eq!(target, None, "a spoofed header must not name a target");
+        }
+        other => panic!("expected Deny, got {other:?}"),
+    }
 }


### PR DESCRIPTION
First increment of #443, from the gateway half (A).

## The gap

An operator running Zentinel in front of an MCP server cannot answer **which tools are being called, how often, and which are refused** — despite the proxy resolving exactly that from every request body in order to decide.

| | before |
|---|---|
| Denials | `blocked_requests{reason="mcp_policy"}` — you learn *that* something was refused, not *what* |
| Permitted calls | `trace!` only, which is off in production |
| `ctx.mcp_method` / `ctx.mcp_target` | written at the decision site and **never read again** |

The expensive part — parsing the body and resolving the call — was already being done on every request. Only the emitting was missing.

## What this adds

`zentinel_mcp_calls_total{route, method, target, decision}`, covering allowed and denied, emitted only for routes that declare an `mcp` block so ordinary traffic through other routes stays silent.

## Cardinality is the substance

Both labels come from the request **body**, so they are attacker-controlled. A naive label lets any client mint unbounded Prometheus series by calling `tools/call` with random names — a denial-of-service against the metrics pipeline, mounted through an endpoint whose entire purpose is refusing hostile input.

Labels are reduced to names the route's own configuration declares, and `<other>` otherwise, so the series a route can produce is bounded by its config rather than by traffic.

One case worth calling out: **an empty allowlist means the route permits everything.** That is a policy decision, not licence to emit a label per distinct name — those report as `<other>` too. There is a test named for it.

## Attributing denials required a small API change

`Outcome::Deny` carried only a human-readable reason. `DenyReason` already held the method and target and discarded both into a formatted string, so they are now surfaced via accessors and threaded through.

**Where the mirrored header disagrees with the body, the denial deliberately attributes nothing.** Neither value is trustworthy: reporting the header would let a client choose which series its traffic lands in, and reporting the body would imply a confidence the mismatch itself disproves. That is the one judgement call in here, and it has a test named after it.

Extending the enum broke three existing test patterns, updated with `..`.

## Tests

21 covering this change:

- **Label bounding** against attacker-shaped names — 4 KB names, path traversal, emoji, empty string — plus exact-match rather than prefix, and the empty-allowlist case.
- **Deny attribution** per `DenyReason` variant: a refused tool names both, a refused method names only the method, a spoofed header names neither.
- **End to end through `decide`**, so the config → policy → outcome path is covered rather than only the units.

`cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.

## What this does not do

No rate limiting yet — this is the data it would need. Nothing here changes routing, policy decisions, or what is forwarded; it only counts what was already being decided.
