### PR TITLE
ci: actually run the integration suite

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,73 @@
+# Runs tests/integration_test.sh, which brings the whole stack up under Docker
+# Compose and drives real requests through it.
+#
+# That suite has existed, unrun, for as long as it has existed: CI runs
+# `cargo test` only, so nothing has ever executed it. Every property it covers
+# -- that agents are reachable, that routes resolve, that the metrics endpoint
+# serves what it claims -- has been unverified between releases.
+#
+# It is scheduled and manual rather than per-PR on purpose. Compose builds the
+# proxy and every agent from source, which is far too slow to sit in front of a
+# pull request, and the point here is that it runs *at all* rather than that it
+# gates. Once it has a track record, promoting the quick subset to a PR gate is
+# the natural next step.
+name: Integration
+
+on:
+  schedule:
+    # 03:00 UTC, an hour after the nightly build slot.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      quick:
+        description: 'Run the quick smoke subset only'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    name: Docker integration suite
+    runs-on: ubuntu-latest
+    # The suite builds a multi-container Rust stack; give it room to fail
+    # slowly rather than be killed at the default limit mid-build.
+    timeout-minutes: 60
+    steps:
+      # Compose builds the proxy and every agent, which does not fit in the
+      # default runner image's free space alongside the preinstalled toolchains.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          df -h /
+
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Run integration suite
+        run: |
+          chmod +x tests/integration_test.sh
+          if [ "${{ inputs.quick }}" = "true" ]; then
+            ./tests/integration_test.sh --quick
+          else
+            ./tests/integration_test.sh
+          fi
+
+      # Container logs are the only way to tell a genuine failure from the
+      # stack never having come up, and they are gone once the job ends.
+      - name: Capture container logs on failure
+        if: failure()
+        run: |
+          docker compose -f docker-compose.yml ps || true
+          docker compose -f docker-compose.yml logs --tail=200 || true
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker-compose.yml down --volumes --remove-orphans || true


### PR DESCRIPTION
Item (2) of the follow-up to #446.

## The finding

`tests/integration_test.sh` is 730 lines and 29 assertions. It brings the whole stack up under Docker Compose — proxy, auth and denylist agents, redis, memcached, backends — and drives real requests through it, checking agent reachability, routing, and the metrics endpoint.

**Nothing has ever run it.** CI runs `cargo test --workspace` and `cargo test --all-targets`; no workflow invokes the script or `tests/Makefile`. So an entire class of "does this work once assembled" has been written down and never executed, and the suite has either rotted or not — there is no way to tell from here.

I found this while checking whether #446's metric is covered end to end. It is a bigger gap than the one I was looking for.

## Why scheduled rather than per-PR

Compose builds the proxy and every agent from source. That is far too slow to sit in front of a pull request, and gating on a suite whose current state is unknown would be the wrong first move.

So: nightly at 03:00 UTC, plus `workflow_dispatch` with a `--quick` option. **The point is that it runs at all, not that it gates.** Once it has a track record, promoting the quick subset to a PR gate is the obvious next step.

## Details worth noting

- **Container logs are captured on failure.** Without them a red run cannot be distinguished from the stack never having come up, and they vanish with the job.
- **60-minute timeout** so a slow multi-container Rust build fails slowly rather than being killed mid-build and looking like a test failure.
- **Disk is freed first** — mirroring what `tests.yml` already does, because the build does not fit alongside the runner image's preinstalled toolchains.
- Teardown runs `always()`.

## What I could not verify

**I could not run this locally** — Docker is installed on this machine but the daemon is not running. So the first dispatch is the real test.

If the suite turns out to be broken, that is worth knowing on its own terms: it has been broken-and-invisible either way, and a red nightly is strictly more informative than silence. I would rather land this and learn than keep guessing.

Suggest merging and then triggering it manually once to see where it stands.
