### PR TITLE
fix(docker): build against Rust 1.95, and stop the version drifting again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,49 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  rust-version:
+    name: Rust version consistency
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # The Rust version is declared in three places. The Dockerfile drifted to
+      # 1.94 while the workspace moved to 1.95, and nothing noticed: release CI
+      # builds the `*-prebuilt` stages, which copy a binary compiled elsewhere
+      # and never touch the base image. Only `docker compose build` and a plain
+      # `docker build .` use the `builder` stage -- so the images humans build
+      # were broken while every workflow stayed green.
+      - name: Check Cargo.toml, rust-toolchain.toml and Dockerfile agree
+        run: |
+          set -euo pipefail
+
+          toolchain=$(grep -oE 'channel = "[0-9.]+"' rust-toolchain.toml | grep -oE '[0-9.]+')
+          msrv=$(grep -m1 -oE 'rust-version = "[0-9.]+"' Cargo.toml | grep -oE '[0-9.]+')
+          docker=$(grep -m1 -oE '^ARG RUST_VERSION=[0-9.]+' Dockerfile | cut -d= -f2)
+
+          echo "rust-toolchain.toml : $toolchain"
+          echo "Cargo.toml rust-version: $msrv"
+          echo "Dockerfile RUST_VERSION: $docker"
+
+          # Compare on major.minor: the Dockerfile tracks the Rust image tag
+          # (`rust:1.95-slim-bookworm`), which has no patch component.
+          minor() { echo "$1" | cut -d. -f1,2; }
+
+          if [ "$(minor "$toolchain")" != "$(minor "$msrv")" ]; then
+            echo "::error::rust-toolchain.toml ($toolchain) and Cargo.toml rust-version ($msrv) disagree"
+            exit 1
+          fi
+
+          if [ "$(minor "$docker")" != "$(minor "$toolchain")" ]; then
+            echo "::error::Dockerfile RUST_VERSION ($docker) does not match the toolchain ($toolchain). \
+          The builder stage will fail to compile the workspace; release CI will not catch it, because \
+          it builds the prebuilt stages instead."
+            exit 1
+          fi
+
+          echo "All three agree on $(minor "$toolchain")"
+
   fmt:
     name: Formatting
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,14 @@
 #   docker build --target proxy-debug -t zentinel:debug .
 
 # Build arguments
-ARG RUST_VERSION=1.94
+#
+# RUST_VERSION must be at least the workspace `rust-version` in Cargo.toml and
+# the channel in rust-toolchain.toml. Only the `builder` stage compiles here --
+# the `*-prebuilt` stages copy a binary built elsewhere -- so release CI, which
+# uses the prebuilt path, stays green even when this is too old. `docker compose
+# build` and a plain `docker build .` use the builder and do not. CI checks the
+# three agree; see the "Rust version" step in ci.yml.
+ARG RUST_VERSION=1.95
 ARG DEBIAN_VARIANT=slim-bookworm
 
 ################################################################################


### PR DESCRIPTION
`docker compose build` and a plain `docker build .` have been failing since the workspace moved to Rust 1.95:

```
error: rustc 1.94.1 is not supported by the following packages:
  kdl@6.7.1 requires rustc 1.95
  zentinel-proxy@0.6.38 requires rustc 1.95.0
```

## Why no workflow caught it

The Dockerfile has two paths, and CI only exercises one:

| stage | compiles in Docker? | used by |
|---|---|---|
| `proxy-prebuilt` | **no** — copies a binary built on the runner | release CI |
| `proxy` (builder) | **yes**, on `rust:${RUST_VERSION}` | `docker compose`, `docker build .` |

Release CI builds the prebuilt stages, so `ARG RUST_VERSION` is never read and the pin can rot indefinitely without a single red check. **The images CI produces work; the images a person produces do not.**

That is also why the release yesterday shipped a working image while this was broken.

## How it surfaced

The integration suite, on its first run after #448. It never reached a single one of its 29 assertions — the stack could not build. Worth noting the suite paid for itself immediately, and that this had been true for some time with nothing to reveal it.

## The fix, and the guard

Bumping the ARG to 1.95 fixes today. The more useful half is the new **Rust version consistency** job: `rust-toolchain.toml`, `Cargo.toml`'s `rust-version`, and the Dockerfile must agree, compared on major.minor since the Dockerfile tracks the Rust image tag (`rust:1.95-slim-bookworm`, no patch component).

Without it, the next MSRV bump re-breaks this silently — which is exactly how it happened the first time.

I verified the guard both ways rather than assuming:

```
--- with the fix in place ---
toolchain=1.95.0 msrv=1.95.0 docker=1.95
PASS: all agree on 1.95
--- with the old value restored (should FAIL) ---
toolchain=1.95.0 msrv=1.95.0 docker=1.94
FAIL: dockerfile drift
```

## What this does not prove

I cannot run the Docker build locally — Docker is installed on this machine but the daemon is not running. The guard is verified; the build is not. **Dispatching the Integration workflow after this merges is the real test**, and it should now get past the build into the 29 assertions nobody has seen the result of yet.
