### PR TITLE
fix(tests): stop the integration suite killing itself on its first pass

### DIFF
--- a/tests/integration_test.sh
+++ b/tests/integration_test.sh
@@ -113,24 +113,35 @@ log_debug() {
     fi
 }
 
+# The counters below are incremented as `VAR=$((VAR + 1))` rather than
+# `((VAR++))` on purpose.
+#
+# `((VAR++))` yields the value *before* the increment as its exit status, so the
+# very first increment of a counter -- 0 to 1 -- exits non-zero. Under the
+# `set -e` at the top of this file that terminates the script, and the EXIT trap
+# then prints a summary of a run that never happened. The symptom is a report
+# reading "Total tests run: 0 / Tests passed: 1 / All tests passed!" alongside a
+# non-zero exit, which is what this suite did on the first successful assertion
+# every time it was run.
+
 log_success() {
     echo -e "${GREEN}[PASS]${NC} $1"
-    ((TESTS_PASSED++))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
 }
 
 log_failure() {
     echo -e "${RED}[FAIL]${NC} $1"
-    ((TESTS_FAILED++))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 }
 
 log_skip() {
     echo -e "${YELLOW}[SKIP]${NC} $1"
-    ((TESTS_SKIPPED++))
+    TESTS_SKIPPED=$((TESTS_SKIPPED + 1))
 }
 
 log_test() {
     echo -e "${YELLOW}[TEST]${NC} $1"
-    ((TESTS_RUN++))
+    TESTS_RUN=$((TESTS_RUN + 1))
 }
 
 # Cleanup function
@@ -400,9 +411,9 @@ test_ratelimit_agent() {
         local status=$(curl -s -o /dev/null -w "%{http_code}" "http://${PROXY_HOST}:${PROXY_PORT}/limited/test?req=$i" 2>/dev/null)
 
         if [[ "$status" == "200" ]]; then
-            ((success_count++))
+            success_count=$((success_count + 1))
         elif [[ "$status" == "429" ]]; then
-            ((limited_count++))
+            limited_count=$((limited_count + 1))
         fi
     done
 
@@ -488,10 +499,10 @@ test_multi_agent() {
 
     local agents_detected=0
     if echo "$headers" | grep -qi "X-.*Agent"; then
-        ((agents_detected++))
+        agents_detected=$((agents_detected + 1))
     fi
     if echo "$headers" | grep -qi "X-RateLimit"; then
-        ((agents_detected++))
+        agents_detected=$((agents_detected + 1))
     fi
 
     if [[ $agents_detected -ge 1 ]]; then
@@ -580,9 +591,9 @@ test_performance() {
     for i in {1..100}; do
         local status=$(curl -s -o /dev/null -w "%{http_code}" "http://${PROXY_HOST}:${PROXY_PORT}/get" 2>/dev/null)
         if [[ "$status" == "200" ]]; then
-            ((success++))
+            success=$((success + 1))
         else
-            ((failed++))
+            failed=$((failed + 1))
         fi
     done
 
@@ -635,7 +646,7 @@ test_configuration() {
     for route in "/api/test" "/echo/test" "/limited/test" "/protected/test"; do
         local status=$(curl -s -o /dev/null -w "%{http_code}" "http://${PROXY_HOST}:${PROXY_PORT}${route}" 2>/dev/null)
         if [[ "$status" == "200" || "$status" == "403" || "$status" == "429" ]]; then
-            ((routes_working++))
+            routes_working=$((routes_working + 1))
         fi
     done
 


### PR DESCRIPTION
The integration suite dies at the first assertion that increments a counter, and always has.

## The bug

`((VAR++))` yields the value *before* the increment as its exit status. So the first increment of any counter — 0 to 1 — exits **non-zero**. Under the `set -euo pipefail` at the top of the file that terminates the script, and the `EXIT` trap then prints a summary of a run that never happened:

```
[PASS] Docker images built successfully
Cleaning up Docker containers...
  Total tests run:   0
  Tests passed:      1
  Tests failed:      0
All tests passed!
##[error]Process completed with exit code 1
```

**Reporting "All tests passed!" and exiting 1 simultaneously is why this survived.** Anyone running it by hand saw the green line; nothing was watching the exit code, because nothing was running it automatically.

## Eleven sites, not four

The four logging functions are the obvious ones. The other seven are local counters inside the test bodies — `success_count`, `limited_count`, `agents_detected`, `success`, `failed`, `routes_working` — and each would kill the run at *its* first increment.

Fixing only the loggers would have moved the failure a few lines down and looked like progress. I checked for the pattern across the whole file rather than stopping at the ones named in the traceback.

All eleven become `VAR=$((VAR + 1))`, whose exit status is the assignment's rather than the value's.

## Verified, not remembered

```
# ((N++)) with N=0, under set -e
before
exit=1          <- script died; "after" never printed

# N=$((N + 1))
before
after, N=1
exit=0
```

My first attempt at this proof was wrong — I wrapped the subshell in `|| echo`, which puts it in an error-tolerant context and suppresses `set -e` inside it. Worth mentioning because it is the same class of mistake as the bug.

## Where this sits

Third fix in a chain, each revealing the next:

1. **#448** — the suite was never run by CI.
2. **#449** — once run, the Docker build failed on a stale Rust pin.
3. **this** — with a working build, the harness kills itself at the first pass.

The 29 assertions still have not executed. This should be the last thing in the way, but I have said that twice already, so: dispatch the Integration workflow after merging and we will find out.
