### PR TITLE
fix(tests): probe /health on the proxy port, not the metrics port

### DIFF
--- a/tests/integration_test.sh
+++ b/tests/integration_test.sh
@@ -338,7 +338,7 @@ test_health_endpoints() {
     log_section "Health Endpoint Tests"
 
     log_test "Proxy health endpoint"
-    local response=$(curl -sf "http://${PROXY_HOST}:${METRICS_PORT}/health" 2>/dev/null)
+    local response=$(curl -sf "http://${PROXY_HOST}:${PROXY_PORT}/health" 2>/dev/null)
     if [[ -n "$response" ]]; then
         log_success "Proxy health endpoint responds"
     else
@@ -632,7 +632,7 @@ test_configuration() {
     log_section "Configuration Validation Tests"
 
     log_test "Proxy configuration loaded"
-    local health=$(curl -sf "http://${PROXY_HOST}:${METRICS_PORT}/health" 2>/dev/null)
+    local health=$(curl -sf "http://${PROXY_HOST}:${PROXY_PORT}/health" 2>/dev/null)
     if [[ -n "$health" ]]; then
         log_success "Proxy loaded configuration and is healthy"
     else
@@ -706,7 +706,15 @@ main() {
     wait_for_service "http://${PROXY_HOST}:8081/status/200" "Backend" 60 || exit 1
 
     # Wait for proxy
-    wait_for_service "http://${PROXY_HOST}:${METRICS_PORT}/health" "Proxy" 120 || {
+    # /health is a route on the proxy's own HTTP listener, served by the
+    # `health` builtin-handler in config/docker/proxy.kdl. It is deliberately
+    # not the metrics port: the standalone metrics server serves /metrics and a
+    # landing page at /, and 404s everything else. This probe used to poll
+    # ${METRICS_PORT}/health and waited the full 120s for a 404 to become a 200,
+    # every time -- 26.08_14 resolved the two servers' fight over 9090 in the
+    # metrics server's favour, which moved /health, and nothing noticed because
+    # this suite was not being run.
+    wait_for_service "http://${PROXY_HOST}:${PROXY_PORT}/health" "Proxy" 120 || {
         log_info "Proxy not responding. Checking container logs..."
         docker compose -f docker-compose.yml logs proxy | tail -50
         exit 1


### PR DESCRIPTION
The suite waited the full 120 seconds for the proxy and gave up — while the proxy had been ready in under a second.

```
zentinel_proxy::app: Application marked as ready
zentinel_proxy::metrics_server: Metrics server listening address=0.0.0.0:9090 path=/metrics
zentinel: HTTP listening on: 0.0.0.0:8080
...
[FAIL] Proxy failed to start within 120s
```

It was polling `${METRICS_PORT}/health`. The standalone metrics server serves `/metrics` and a landing page at `/`, and 404s everything else — so the probe sat waiting for a 404 to become a 200.

`/health` is a route on the proxy's **own listener**, served by the `health` builtin-handler in `config/docker/proxy.kdl`, on 8080.

## This is drift, not a typo

**26.08_14** fixed the default configuration "fighting itself for port 9090": the metrics server and an admin listener both tried to bind it, and the fix resolved it in the metrics server's favour. The admin listener was what served `/health`.

So a product change six releases ago silently invalidated this test's assumption, and nobody found out — because the suite was not being run. That is the entire reason this chain of fixes exists, and it is a fair illustration of what an unrun suite accumulates.

## What changed

Three call sites move to `${PROXY_PORT}`: the readiness gate, the health endpoint test, and the configuration-loaded check. The metrics assertions stay on `${METRICS_PORT}/metrics`, which was always correct.

Probing the routed `/health` is also the **better signal** — it proves requests are being matched and handled, where the metrics port only proves a process is listening.

## Where this sits

Fourth fix in a chain, each found by the previous one:

1. **#448** — the suite was never run by CI.
2. **#449** — once run, the Docker build failed on a stale Rust pin.
3. **#450** — with a working build, the harness killed itself at the first `[PASS]`.
4. **this** — with the harness surviving, it waited on an endpoint that moved.

Each run has got measurably further: build failure → first assertion → container startup → readiness. The 29 assertions still have not executed. I have twice predicted the next run would be the last hurdle and been wrong, so I will not predict it a third time — dispatch after merging and we will see.
