### PR TITLE
fix: make the echo agent reachable, and route /echo through it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -235,8 +235,12 @@ FROM gcr.io/distroless/cc-debian12:nonroot AS echo-agent
 
 COPY --from=builder /app/target/release/zentinel-echo-agent /zentinel-echo-agent
 
+# ECHO_AGENT_SOCKET, not SOCKET_PATH: the agent's argument parser reads the
+# former, so the latter was inert and the agent fell back to its hardcoded
+# default of /tmp/echo-agent.sock -- inside its own container, off the shared
+# socket volume, where no proxy could reach it.
 ENV RUST_LOG=info,zentinel_echo_agent=debug \
-    SOCKET_PATH=/var/run/zentinel/echo.sock
+    ECHO_AGENT_SOCKET=/var/run/zentinel/echo.sock
 
 USER nonroot:nonroot
 
@@ -253,7 +257,7 @@ LABEL org.opencontainers.image.title="Zentinel Echo Agent" \
       org.opencontainers.image.description="Echo agent for Zentinel proxy testing"
 
 ENV RUST_LOG=info,zentinel_echo_agent=debug \
-    SOCKET_PATH=/var/run/zentinel/echo.sock
+    ECHO_AGENT_SOCKET=/var/run/zentinel/echo.sock
 
 USER nonroot:nonroot
 

--- a/config/docker/proxy.kdl
+++ b/config/docker/proxy.kdl
@@ -30,6 +30,24 @@ routes {
         }
     }
 
+    // Echo agent route. The compose stack runs the echo agent alongside the
+    // proxy on a shared socket volume, and tests/integration_test.sh checks
+    // that a request through here comes back with the agent's headers. Without
+    // this route the agent was running and unreachable, and /echo/* fell
+    // through to the catch-all below and 404'd at the backend.
+    route "echo" {
+        priority "high"
+        matches {
+            path-prefix "/echo"
+        }
+        upstream "backend"
+        filters "echo"
+        policies {
+            timeout-secs 10
+            failure-mode "open"
+        }
+    }
+
     // Main route - direct proxy to backend
     route "default" {
         priority "low"
@@ -41,6 +59,27 @@ routes {
             timeout-secs 30
             failure-mode "open"
         }
+    }
+}
+
+agents {
+    agent "echo" {
+        type "custom"
+        unix-socket path="/var/run/zentinel/echo.sock"
+        events "request_headers" "response_headers"
+        timeout-ms 500
+        // Fail open: this is a demonstration agent on a test stack, and a
+        // request should not be refused because it is not running.
+        failure-mode "open"
+    }
+}
+
+filters {
+    filter "echo" {
+        type "agent"
+        agent "echo"
+        timeout-ms 500
+        failure-mode "open"
     }
 }
 


### PR DESCRIPTION
The integration suite's two remaining failures had **two different causes**. Fixing either alone would have left the other, and looked like progress.

```
[FAIL] Route matching issues (0/4 routes working)
[FAIL] Echo route request succeeds - expected HTTP 200, got HTTP 404
[SKIP] Echo agent headers not detected (agent may not be running)
```

## 1. The agent was listening on the wrong socket

The Dockerfile sets `SOCKET_PATH`. The agent's argument parser reads `ECHO_AGENT_SOCKET`. With neither that nor `--socket` given it takes a hardcoded fallback:

```rust
(None, None) => {
    // Default to Unix socket if neither specified
    let socket = PathBuf::from("/tmp/echo-agent.sock");
```

So it bound a path **inside its own container**, off the shared `agent-sockets` volume, where no proxy could reach it. That is what the `[SKIP]` was reporting. Both the `echo-agent` and `echo-agent-prebuilt` stages had it.

**This one is not only test scaffolding.** The published `echo-agent` image is the reference implementation for the agent protocol; anyone deploying it and setting `SOCKET_PATH` — because the Dockerfile does — gets an agent that starts cleanly, logs nothing wrong, and is unreachable.

## 2. Nothing routed to it

`config/docker/proxy.kdl` declared two routes and no agents, so `/echo/anything` fell through the catch-all to the backend and 404'd. The proxy's own startup log said so plainly: `route_count=2`, `configured_agents=0`.

Adds the agent on the shared socket, a filter wrapping it, and an `/echo` route at high priority so it matches ahead of the catch-all. Both fail **open** — a demonstration agent on a test stack should not be able to refuse traffic.

## Verification

```
$ zentinel lint --config config/docker/proxy.kdl
Configuration loaded successfully routes=3 upstreams=1 agents=1 listeners=1
```

Schema validation passes. The five remaining warnings are pre-existing best-practice notes that apply equally to the two routes that were already there.

Linting the real file locally fails on `unix socket path parent directory doesn't exist` — `/var/run/zentinel/` is a container path, so I re-linted against a copy pointing at a local directory to confirm that was the only complaint.

## Where this sits

Sixth fix in the chain, and the first to touch anything outside the test harness:

1. **#448** never run · 2. **#449** unbuildable · 3. **#450** self-terminating · 4. **#451** wrong probe · 5. this — agent unreachable, and unrouted.

The suite last reported **10 passed, 2 failed, 1 skipped**. If this is right, those three become passes and the agent path gets its first end-to-end coverage. I cannot verify that locally — no Docker daemon here — so dispatching after merge is the test.
