### PR TITLE
test: give the integration fixture the routes its suite exercises

### DIFF
--- a/config/docker/proxy.kdl
+++ b/config/docker/proxy.kdl
@@ -30,18 +30,65 @@ routes {
         }
     }
 
-    // Echo agent route. The compose stack runs the echo agent alongside the
-    // proxy on a shared socket volume, and tests/integration_test.sh checks
-    // that a request through here comes back with the agent's headers. Without
-    // this route the agent was running and unreachable, and /echo/* fell
-    // through to the catch-all below and 404'd at the backend.
+    // The routes below exist for tests/integration_test.sh, which checks that
+    // /api, /echo, /limited and /protected each answer.
+    //
+    // The backend is httpbin, which serves /anything/<anything> with a 200 and
+    // 404s everything else -- so each route rewrites its own prefix onto
+    // /anything before forwarding. Without that, every one of these forwarded
+    // its literal path and httpbin refused it, which is what "0/4 routes
+    // working" was reporting.
+
+    // Exercises the agent path end to end: the echo agent adds its headers on
+    // the way through, and the rewrite gives httpbin a path it will answer.
     route "echo" {
         priority "high"
         matches {
             path-prefix "/echo"
         }
         upstream "backend"
-        filters "echo"
+        filters "rewrite-echo" "echo"
+        policies {
+            timeout-secs 10
+            failure-mode "open"
+        }
+    }
+
+    route "api" {
+        priority "high"
+        matches {
+            path-prefix "/api"
+        }
+        upstream "backend"
+        filters "rewrite-api"
+        policies {
+            timeout-secs 10
+            failure-mode "open"
+        }
+    }
+
+    // Rate limited. A single request passes; the suite's burst of 30 is what
+    // draws the 429. Both outcomes count as the route working.
+    route "limited" {
+        priority "high"
+        matches {
+            path-prefix "/limited"
+        }
+        upstream "backend"
+        filters "rewrite-limited" "ratelimit"
+        policies {
+            timeout-secs 10
+            failure-mode "open"
+        }
+    }
+
+    route "protected" {
+        priority "high"
+        matches {
+            path-prefix "/protected"
+        }
+        upstream "backend"
+        filters "rewrite-protected"
         policies {
             timeout-secs 10
             failure-mode "open"
@@ -80,6 +127,36 @@ filters {
         agent "echo"
         timeout-ms 500
         failure-mode "open"
+    }
+
+    // httpbin answers /anything/<anything>; these put each route's traffic
+    // somewhere it will respond rather than 404.
+    filter "rewrite-echo" {
+        type "url-rewrite"
+        replace-prefix-match "/anything"
+    }
+
+    filter "rewrite-api" {
+        type "url-rewrite"
+        replace-prefix-match "/anything"
+    }
+
+    filter "rewrite-limited" {
+        type "url-rewrite"
+        replace-prefix-match "/anything"
+    }
+
+    filter "rewrite-protected" {
+        type "url-rewrite"
+        replace-prefix-match "/anything"
+    }
+
+    filter "ratelimit" {
+        type "rate-limit"
+        max-rps 5
+        burst 5
+        key "client-ip"
+        status-code 429
     }
 }
 


### PR DESCRIPTION
The suite checks that `/api`, `/echo`, `/limited` and `/protected` each answer, and reported **0/4 routes working**. The config declared none of them, so all four fell through the catch-all to httpbin — which serves `/anything/<anything>` and 404s everything else.

## (3) first: is there an existing fixture?

You asked me to check `docker-compose.test.yml` before building anything, on the theory the suite was written against a fuller stack and the two had drifted.

**It wasn't.** Its "auth agent" is:

```yaml
command: >
  sh -c "
    echo 'Mock auth agent - echoes allow for all requests'
    while true; do sleep 3600; done
  "
```

A container that prints a line and sleeps. No socket, no protocol. It is also an *override* file — no build, no config mount — so the proxy config would have stayed the same minimal one either way.

So nothing in the repo satisfied these assertions. They are new, not restored. Worth knowing before anyone else goes looking.

## (2) then: the fixture

Four routes, each rewriting its own prefix onto `/anything` via the `url-rewrite` filter so the backend has a path it will answer.

| route | filters |
|---|---|
| `/echo` | rewrite + **echo agent** |
| `/api` | rewrite |
| `/limited` | rewrite + rate-limit (5 rps) |
| `/protected` | rewrite |

`/echo` carrying the agent filter makes this **the first end-to-end exercise of the agent protocol through a real proxy** — unit tests and the protocol crate's own integration tests were the only coverage it had, despite agents being Zentinel's whole extension model.

`/limited` at 5 rps: a single request passes, and the suite's burst of thirty draws the 429. The route test counts either as working, and `test_ratelimit_agent` wants the 429.

## Verification

```
$ zentinel lint --config config/docker/proxy.kdl
Configuration loaded successfully routes=6 upstreams=1 agents=1 listeners=1
```

Schema validation passes. The eight warnings are the pre-existing best-practice notes, now repeated per added route.

Same caveat as before: I cannot run the stack locally — no Docker daemon here — so dispatching after merge is the test. Last run was **10 passed, 2 failed, 1 skipped**; this targets all three of the remaining results.
