### PR TITLE
test: add the /multi route, and gate the suite on the files that break it

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,6 +17,24 @@ on:
   schedule:
     # 03:00 UTC, an hour after the nightly build slot.
     - cron: '0 3 * * *'
+
+  # Gated on the files that break this suite outright, rather than on every
+  # pull request. `--quick` is not the lever it looks like: it skips only the
+  # performance test, while the Docker build -- fourteen minutes of compiling
+  # the proxy and every agent -- is the whole cost. Running that in front of
+  # every PR would tax changes that cannot affect the outcome.
+  #
+  # The paths below are the ones whose drift has actually broken it: the
+  # Dockerfile, the compose stack, the fixture config, the harness itself.
+  # Everything else is caught by the nightly run within a day.
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - 'docker-compose*.yml'
+      - 'config/docker/**'
+      - 'tests/integration_test.sh'
+      - '.github/workflows/integration.yml'
+
   workflow_dispatch:
     inputs:
       quick:

--- a/config/docker/proxy.kdl
+++ b/config/docker/proxy.kdl
@@ -95,6 +95,22 @@ routes {
         }
     }
 
+    // Several filters on one route, which is what test_multi_agent checks: a
+    // request should come back 200 having passed through the whole chain
+    // rather than being dropped by one of them.
+    route "multi" {
+        priority "high"
+        matches {
+            path-prefix "/multi"
+        }
+        upstream "backend"
+        filters "rewrite-multi" "echo" "ratelimit"
+        policies {
+            timeout-secs 10
+            failure-mode "open"
+        }
+    }
+
     // Main route - direct proxy to backend
     route "default" {
         priority "low"
@@ -147,6 +163,11 @@ filters {
     }
 
     filter "rewrite-protected" {
+        type "url-rewrite"
+        replace-prefix-match "/anything"
+    }
+
+    filter "rewrite-multi" {
         type "url-rewrite"
         replace-prefix-match "/anything"
     }


### PR DESCRIPTION
Two things: the last failing assertion, and turning the suite into a gate.

## The `/multi` route

The previous run reached **21 assertions with a single failure** — `test_multi_agent` requests `/multi/test`, and no such route existed. Adds it, carrying the rewrite, the echo agent and the rate limiter, since several filters on one route is exactly what that test checks.

`zentinel lint`: `routes=7 upstreams=1 agents=1`, schema validation passes.

## The gate is not the one I proposed

I suggested promoting the `--quick` subset. On inspection **that is not the lever it looks like** — `--quick` skips the performance test and nothing else:

```bash
if [[ "$QUICK_TEST" == "true" ]]; then
    log_skip "Performance tests skipped in quick mode"
```

The cost is the Docker build: fourteen minutes compiling the proxy and every agent. `--quick` does not touch it. Promoting it would have added twenty minutes to every pull request and saved almost nothing.

So instead it gates on **the files whose drift has actually broken it**:

| path | broke it in |
|---|---|
| `Dockerfile` | #449 — stale Rust pin |
| `docker-compose*.yml` | the stack definition |
| `config/docker/**` | #452, #453 — missing agent and routes |
| `tests/integration_test.sh` | #450, #451 — counters, wrong probe |

Every one of those is a real failure from this week. Changes elsewhere are still covered by the nightly run within a day, without taxing PRs that cannot affect the outcome.

## What is deliberately left undone

Six skips remain, and they are **honest reporting rather than breakage**:

```
[SKIP] Rate limit agent metrics not accessible
[SKIP] WAF agent metrics not accessible
[SKIP] XSS not blocked (status: 200)
[SKIP] Path traversal not blocked (status: 404)
```

There is no WAF agent and no standalone rate-limit agent in the compose stack — the rate limiting here is the proxy's built-in filter. Building those to convert skips into coverage is demo infrastructure, not a bug fix, and I have left it.

One skip I would flag as genuinely unresolved: `Echo agent headers not detected`. The route returns 200 and the agent is configured, but headers are not appearing. The `SOCKET_PATH` → `ECHO_AGENT_SOCKET` fix in #452 was correct in principle; whether the agent now connects needs container logs, which are only captured on hard failure. Worth a look, but it is not blocking a green run.

## Expected result

**16 passed, 0 failed, 6 skipped** — a green gate, locking in the seven fixes it took to get here.
