### PR TITLE
feat(agentic): hide MCP tools a route forbids from listing responses

### DIFF
--- a/config/docker/proxy.kdl
+++ b/config/docker/proxy.kdl
@@ -111,6 +111,41 @@ routes {
         }
     }
 
+    // MCP. The tool allowlist is what tests/integration_test.sh asserts on:
+    // the upstream offers search_docs, get_weather and execute_sql, and this
+    // route should both refuse a call to execute_sql and stop it appearing in
+    // tools/list at all.
+    route "mcp" {
+        priority "high"
+        matches {
+            path-prefix "/mcp"
+        }
+        upstream "mcp-backend"
+        mcp {
+            tools {
+                allow "search_docs" "get_weather"
+            }
+        }
+        policies {
+            timeout-secs 10
+            failure-mode "open"
+        }
+    }
+
+    // The same upstream with no MCP policy, so a test can show the difference
+    // rather than assert a filtered list in isolation.
+    route "mcp-raw" {
+        priority "high"
+        matches {
+            path-prefix "/mcp-raw"
+        }
+        upstream "mcp-backend"
+        policies {
+            timeout-secs 10
+            failure-mode "open"
+        }
+    }
+
     // Main route - direct proxy to backend
     route "default" {
         priority "low"
@@ -184,6 +219,11 @@ filters {
 upstreams {
     upstream "backend" {
         target "backend:80" weight=1
+        load-balancing "round_robin"
+    }
+
+    upstream "mcp-backend" {
+        target "mcp-backend:8090" weight=1
         load-balancing "round_robin"
     }
 }

--- a/crates/common/src/observability.rs
+++ b/crates/common/src/observability.rs
@@ -84,6 +84,7 @@ pub struct RequestMetrics {
     blocked_requests: CounterVec,
     /// MCP tool and resource calls, by route, method and target
     mcp_calls: IntCounterVec,
+    mcp_listing_filtered: IntCounterVec,
     /// Request body size histogram
     request_body_size: HistogramVec,
     /// Response body size histogram
@@ -239,6 +240,16 @@ impl RequestMetrics {
             &["route", "method", "target", "decision"]
         )
         .context("Failed to register mcp_calls metric")?;
+
+        // Counts entries, not responses: the useful question is how much of an
+        // upstream's surface a route hides, and one response can hide many.
+        // Both labels are bounded by configuration, not by traffic.
+        let mcp_listing_filtered = register_int_counter_vec!(
+            "zentinel_mcp_listing_entries_hidden_total",
+            "MCP listing entries removed from a response because the route forbids calling them",
+            &["route", "method"]
+        )
+        .context("Failed to register mcp_listing_filtered metric")?;
 
         let request_body_size = register_histogram_vec!(
             "zentinel_request_body_size_bytes",
@@ -405,6 +416,7 @@ impl RequestMetrics {
             agent_timeouts,
             blocked_requests,
             mcp_calls,
+            mcp_listing_filtered,
             request_body_size,
             response_body_size,
             tls_handshake_duration,
@@ -507,6 +519,18 @@ impl RequestMetrics {
         self.mcp_calls
             .with_label_values(&[route, method, target, decision])
             .inc();
+    }
+
+    /// Count entries removed from a `tools/list`, `resources/list` or
+    /// `prompts/list` response because the route forbids calling them.
+    ///
+    /// A route where this is persistently non-zero is one whose upstream offers
+    /// more than the route permits -- normal for a gateway, and worth being
+    /// able to see rather than infer.
+    pub fn record_mcp_listing_filtered(&self, route: &str, method: &str, hidden: u64) {
+        self.mcp_listing_filtered
+            .with_label_values(&[route, method])
+            .inc_by(hidden);
     }
 
     /// Reduce a client-supplied MCP name to something safe to use as a label.

--- a/crates/config/src/agentic.rs
+++ b/crates/config/src/agentic.rs
@@ -57,6 +57,22 @@ pub struct McpConfig {
     /// What to do with a body that cannot be inspected.
     #[serde(default)]
     pub on_uninspectable_body: UninspectableBody,
+    /// Remove entries a call would be refused from `tools/list`,
+    /// `resources/list` and `prompts/list` responses.
+    ///
+    /// Defaults to true, and does nothing at all unless a tool allow or deny
+    /// list is set. Without it the advertised surface and the enforced one
+    /// disagree: the proxy refuses a call to a tool the route forbids, having
+    /// let the upstream advertise it. That costs a wasted round trip, spends
+    /// the model's context on tools it may not call, and hands every client an
+    /// inventory of the upstream's capabilities.
+    ///
+    /// A listing that cannot be rewritten -- compressed, oversized, or not
+    /// parseable -- is refused rather than forwarded, on the grounds that
+    /// forwarding it would advertise what the route forbids. Set this to false
+    /// on a route where that trade is the wrong way round.
+    #[serde(default = "default_true")]
+    pub filter_tool_list: bool,
 }
 
 impl Default for McpConfig {
@@ -69,6 +85,7 @@ impl Default for McpConfig {
             require_validated_version: true,
             validate_param_headers: true,
             on_uninspectable_body: UninspectableBody::Deny,
+            filter_tool_list: true,
         }
     }
 }

--- a/crates/config/src/kdl/routes.rs
+++ b/crates/config/src/kdl/routes.rs
@@ -467,6 +467,7 @@ fn parse_optional_block<T>(
 /// ```kdl
 /// mcp {
 ///     require-validated-version #true
+///     filter-tool-list #true
 ///     on-uninspectable-body "deny"
 ///     methods {
 ///         allow "tools/call" "tools/list"
@@ -487,6 +488,10 @@ fn parse_mcp_config(node: &kdl::KdlNode) -> Result<McpConfig> {
 
     if let Some(value) = get_bool_entry(node, "validate-param-headers") {
         config.validate_param_headers = value;
+    }
+
+    if let Some(value) = get_bool_entry(node, "filter-tool-list") {
+        config.filter_tool_list = value;
     }
 
     config.on_uninspectable_body = match get_string_entry(node, "on-uninspectable-body").as_deref()
@@ -519,12 +524,13 @@ fn parse_mcp_config(node: &kdl::KdlNode) -> Result<McpConfig> {
                 // how a policy stops applying without anyone noticing.
                 "require-validated-version"
                 | "validate-param-headers"
+                | "filter-tool-list"
                 | "on-uninspectable-body" => {}
                 other => {
                     return Err(anyhow::anyhow!(
                         "Unknown setting '{other}' in mcp block. Valid settings: \
-                         require-validated-version, validate-param-headers, on-uninspectable-body, \
-                         methods, tools"
+                         require-validated-version, validate-param-headers, filter-tool-list, \
+                         on-uninspectable-body, methods, tools"
                     ))
                 }
             }
@@ -2146,6 +2152,21 @@ mod tests {
             let mcp = route.mcp.expect("mcp block should be parsed");
             assert_eq!(mcp.allowed_tools, ["get_weather", "search_docs"]);
             assert_eq!(mcp.denied_tools, ["execute_sql"]);
+        }
+
+        /// Read the struct back rather than trusting that the key parsed:
+        /// a setting KDL accepts and nothing stores is how a policy stops
+        /// applying without anyone noticing.
+        #[test]
+        fn filter_tool_list_can_be_turned_off() {
+            let route = route_with("    mcp {\n      filter-tool-list #false\n    }");
+            assert!(!route.mcp.expect("parsed").filter_tool_list);
+        }
+
+        #[test]
+        fn filter_tool_list_defaults_on() {
+            let route = route_with("    mcp {\n      tools {\n        deny \"x\"\n      }\n    }");
+            assert!(route.mcp.expect("parsed").filter_tool_list);
         }
 
         #[test]

--- a/crates/proxy/src/agentic/listing.rs
+++ b/crates/proxy/src/agentic/listing.rs
@@ -18,7 +18,7 @@
 //!
 //! So this module removes from a listing response exactly the entries that
 //! [`super::mcp`] would refuse a call to — using the same identity rule and the
-//! same [`permitted`](super::mcp::permitted) predicate, because a filter that
+//! same `permitted` predicate as [`super::mcp`], because a filter that
 //! hid a different set than the enforcer refuses would be worse than no filter
 //! at all: it would make the advertised surface a *misleading* description of
 //! the policy rather than merely an incomplete one.

--- a/crates/proxy/src/agentic/listing.rs
+++ b/crates/proxy/src/agentic/listing.rs
@@ -1,0 +1,701 @@
+//! Filtering what an MCP upstream advertises down to what the route permits.
+//!
+//! [`super::mcp`] refuses a `tools/call` naming a tool the route forbids. That
+//! is enforcement, and on its own it leaves the advertised surface and the
+//! enforced one disagreeing: `tools/list` still returns everything the upstream
+//! offers, so a client discovers tools it will only ever be refused.
+//!
+//! Three consequences, in increasing order of how much they matter:
+//!
+//! 1. A model picks a forbidden tool, calls it, and gets an error. The round
+//!    trip is wasted and the failure looks like a bug in the upstream.
+//! 2. Tool descriptions are spent from the model's context window. MCP clients
+//!    degrade well before a hundred tools, so a route that permits five of an
+//!    upstream's eighty should be advertising five.
+//! 3. The list is an inventory. Names and descriptions routinely say which
+//!    internal systems exist and what they can be made to do, and a client that
+//!    may call none of them still gets to read all of it.
+//!
+//! So this module removes from a listing response exactly the entries that
+//! [`super::mcp`] would refuse a call to — using the same identity rule and the
+//! same [`permitted`](super::mcp::permitted) predicate, because a filter that
+//! hid a different set than the enforcer refuses would be worse than no filter
+//! at all: it would make the advertised surface a *misleading* description of
+//! the policy rather than merely an incomplete one.
+
+use std::collections::HashSet;
+
+use serde_json::Value;
+use zentinel_config::agentic::McpConfig;
+
+use super::mcp::permitted;
+
+/// Largest listing response the proxy will buffer in order to rewrite it.
+///
+/// Matches [`super::jsonrpc::MAX_ENVELOPE_BYTES`]. A tool list this large is
+/// already unusable by any MCP client, so the bound is a guard against an
+/// upstream streaming something unbounded into proxy memory rather than a
+/// limit real configurations are expected to meet.
+pub const MAX_LISTING_BYTES: usize = 1024 * 1024;
+
+/// The `result` field holding entries a route's tool policy governs, if this
+/// method returns one.
+///
+/// `resources/templates/list` is deliberately absent. Its entries are keyed by
+/// `uriTemplate`, which names a *family* of URIs rather than one, and the
+/// request path never resolves a target that could be compared against it. A
+/// template can only be matched by expanding it, and a filter that guessed
+/// would hide entries the enforcer permits. Calls to the URIs a template
+/// expands to are still checked on `resources/read`.
+pub fn listed_field(method: &str) -> Option<&'static str> {
+    match method {
+        "tools/list" => Some("tools"),
+        "resources/list" => Some("resources"),
+        "prompts/list" => Some("prompts"),
+        _ => None,
+    }
+}
+
+/// How the upstream framed the listing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Framing {
+    /// `application/json` — one JSON-RPC response.
+    Json,
+    /// `text/event-stream` — Streamable HTTP, the response inside `data:`.
+    Sse,
+}
+
+/// A rewrite the response path has committed to.
+///
+/// Built once the response headers are in hand and carried until the body has
+/// arrived, so the body path does not have to look the route up again.
+#[derive(Debug, Clone)]
+pub struct Plan {
+    /// The `result` field holding the entries.
+    pub field: &'static str,
+    /// How the upstream framed the response.
+    pub framing: Framing,
+    /// Tools and resources permitted. Empty means all.
+    pub allowed: HashSet<String>,
+    /// Tools and resources refused, applied after `allowed`.
+    pub denied: HashSet<String>,
+}
+
+impl Plan {
+    /// The rewrite a route's MCP policy calls for on a response to `method`,
+    /// or `None` when it calls for none.
+    ///
+    /// This is the whole config-to-behaviour decision, kept here rather than in
+    /// the response path so it can be tested against a parsed route. The gap
+    /// between what an operator wrote and what the proxy enforced is what made
+    /// the module next door dead code for a release.
+    pub fn for_method(cfg: &McpConfig, method: &str, framing: Framing) -> Option<Self> {
+        if !cfg.filter_tool_list {
+            return None;
+        }
+        // A route that permits everything hides nothing, and must not pay to
+        // buffer a response in order to discover that.
+        if cfg.allowed_tools.is_empty() && cfg.denied_tools.is_empty() {
+            return None;
+        }
+        Some(Self {
+            field: listed_field(method)?,
+            framing,
+            allowed: cfg.allowed_tools.iter().cloned().collect(),
+            denied: cfg.denied_tools.iter().cloned().collect(),
+        })
+    }
+}
+
+/// What happened to a listing body.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Filtered {
+    /// Entries were removed; carries the replacement body.
+    Rewritten {
+        /// The new body.
+        body: Vec<u8>,
+        /// How many entries were removed, for logging and metrics.
+        hidden: usize,
+    },
+    /// Every entry is permitted, or the body carries no listing to filter.
+    Unchanged,
+    /// The body could not be rewritten. Written to be read by an operator.
+    ///
+    /// The caller refuses the response rather than forwarding it: this module
+    /// exists because forwarding an unfiltered listing advertises tools the
+    /// route forbids, and that is no less true when the reason is that the
+    /// proxy could not parse it.
+    Unfilterable(&'static str),
+}
+
+/// Remove the entries a route's tool policy would refuse a call to.
+pub fn filter(
+    body: &[u8],
+    framing: Framing,
+    field: &str,
+    allowed: &HashSet<String>,
+    denied: &HashSet<String>,
+) -> Filtered {
+    match framing {
+        Framing::Json => filter_json(body, field, allowed, denied),
+        Framing::Sse => filter_sse(body, field, allowed, denied),
+    }
+}
+
+fn filter_json(
+    body: &[u8],
+    field: &str,
+    allowed: &HashSet<String>,
+    denied: &HashSet<String>,
+) -> Filtered {
+    let Ok(mut doc) = serde_json::from_slice::<Value>(body) else {
+        return Filtered::Unfilterable("listing response is not valid JSON");
+    };
+
+    match filter_document(&mut doc, field, allowed, denied) {
+        Removed::None => Filtered::Unchanged,
+        Removed::Some(hidden) => match serde_json::to_vec(&doc) {
+            Ok(body) => Filtered::Rewritten { body, hidden },
+            Err(_) => Filtered::Unfilterable("filtered listing could not be re-serialised"),
+        },
+    }
+}
+
+/// Rewrite the `data:` payload of every event, leaving the framing alone.
+///
+/// A JSON-RPC response may be split across several `data:` lines, which the SSE
+/// grammar joins with a newline. They are re-emitted as one line, which is the
+/// same event to any conforming client.
+fn filter_sse(
+    body: &[u8],
+    field: &str,
+    allowed: &HashSet<String>,
+    denied: &HashSet<String>,
+) -> Filtered {
+    let Ok(text) = std::str::from_utf8(body) else {
+        return Filtered::Unfilterable("event stream is not valid UTF-8");
+    };
+
+    let mut out = String::with_capacity(text.len());
+    let mut hidden = 0usize;
+    // Whether the terminating blank line was present on the last event, so a
+    // stream that ends mid-event is reproduced as it arrived.
+    let ends_with_separator = text.ends_with("\n\n") || text.ends_with("\r\n\r\n");
+
+    let events: Vec<&str> = split_events(text);
+    let last = events.len().saturating_sub(1);
+
+    for (i, event) in events.iter().enumerate() {
+        let mut data = String::new();
+        let mut prefix = String::new();
+        let mut saw_data = false;
+
+        for line in event.split('\n') {
+            let line = line.strip_suffix('\r').unwrap_or(line);
+            if let Some(rest) = line.strip_prefix("data:") {
+                saw_data = true;
+                if !data.is_empty() {
+                    data.push('\n');
+                }
+                data.push_str(rest.strip_prefix(' ').unwrap_or(rest));
+            } else {
+                prefix.push_str(line);
+                prefix.push('\n');
+            }
+        }
+
+        out.push_str(&prefix);
+
+        if saw_data {
+            // A data payload that is not the listing -- a notification, a
+            // keep-alive, a different response multiplexed onto the same
+            // stream -- passes through untouched.
+            match serde_json::from_str::<Value>(&data) {
+                Ok(mut doc) => {
+                    if let Removed::Some(n) = filter_document(&mut doc, field, allowed, denied) {
+                        hidden += n;
+                        match serde_json::to_string(&doc) {
+                            Ok(s) => data = s,
+                            Err(_) => {
+                                return Filtered::Unfilterable(
+                                    "filtered listing could not be re-serialised",
+                                )
+                            }
+                        }
+                    }
+                }
+                Err(_) => {
+                    return Filtered::Unfilterable(
+                        "event stream carries a data payload \
+                                                   that is not valid JSON",
+                    )
+                }
+            }
+            out.push_str("data: ");
+            out.push_str(&data);
+            out.push('\n');
+        }
+
+        if i < last || ends_with_separator {
+            out.push('\n');
+        }
+    }
+
+    if hidden == 0 {
+        Filtered::Unchanged
+    } else {
+        Filtered::Rewritten {
+            body: out.into_bytes(),
+            hidden,
+        }
+    }
+}
+
+/// The length of the longest prefix of `buf` that ends on an event boundary.
+///
+/// An SSE response to a POST is not required to close once it has carried the
+/// response, so the caller cannot wait for end of stream before rewriting: a
+/// server that holds the stream open for later notifications would have its
+/// listing held with it. Filtering whole events as they complete costs at most
+/// one event of latency and never withholds a stream that has more to say.
+pub fn complete_events_len(buf: &[u8]) -> usize {
+    let mut end = 0usize;
+    let mut i = 0usize;
+    while i < buf.len() {
+        if buf[i..].starts_with(b"\r\n\r\n") {
+            i += 4;
+            end = i;
+        } else if buf[i..].starts_with(b"\n\n") {
+            i += 2;
+            end = i;
+        } else {
+            i += 1;
+        }
+    }
+    end
+}
+
+/// Split an event stream on blank lines, dropping the empty trailing chunk.
+fn split_events(text: &str) -> Vec<&str> {
+    let mut events = Vec::new();
+    let mut start = 0usize;
+    let bytes = text.as_bytes();
+    let mut i = 0usize;
+
+    while i < bytes.len() {
+        let sep = if bytes[i..].starts_with(b"\r\n\r\n") {
+            4
+        } else if bytes[i..].starts_with(b"\n\n") {
+            2
+        } else {
+            i += 1;
+            continue;
+        };
+        events.push(&text[start..i]);
+        i += sep;
+        start = i;
+    }
+
+    if start < text.len() {
+        events.push(&text[start..]);
+    }
+
+    events
+}
+
+enum Removed {
+    None,
+    Some(usize),
+}
+
+/// Filter `result.<field>` in place, if this document has one.
+fn filter_document(
+    doc: &mut Value,
+    field: &str,
+    allowed: &HashSet<String>,
+    denied: &HashSet<String>,
+) -> Removed {
+    let Some(entries) = doc
+        .get_mut("result")
+        .and_then(|r| r.get_mut(field))
+        .and_then(Value::as_array_mut)
+    else {
+        return Removed::None;
+    };
+
+    let before = entries.len();
+    // An entry whose identity cannot be read is kept. Hiding it would be a
+    // guess, and the enforcer would not refuse a call it cannot name either.
+    entries.retain(|e| match identity(e) {
+        Some(name) => permitted(name, allowed, denied),
+        None => true,
+    });
+    let hidden = before - entries.len();
+
+    if hidden == 0 {
+        Removed::None
+    } else {
+        Removed::Some(hidden)
+    }
+}
+
+/// An entry's identity, by the rule the request path uses: `name`, then `uri`.
+///
+/// [`super::jsonrpc::Envelope`] resolves a call's target as `params.name`
+/// falling back to `params.uri`, so a tool is identified by its name, a
+/// resource by its URI, and a prompt by its name -- on both sides.
+fn identity(entry: &Value) -> Option<&str> {
+    entry
+        .get("name")
+        .and_then(Value::as_str)
+        .or_else(|| entry.get("uri").and_then(Value::as_str))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set(items: &[&str]) -> HashSet<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn tools_list(names: &[&str]) -> Vec<u8> {
+        let entries: Vec<String> = names
+            .iter()
+            .map(|n| format!(r#"{{"name":"{n}","description":"d"}}"#))
+            .collect();
+        format!(
+            r#"{{"jsonrpc":"2.0","id":1,"result":{{"tools":[{}]}}}}"#,
+            entries.join(",")
+        )
+        .into_bytes()
+    }
+
+    fn names_in(body: &[u8]) -> Vec<String> {
+        let doc: Value = serde_json::from_slice(body).expect("valid json");
+        doc["result"]["tools"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .map(|e| e["name"].as_str().expect("name").to_string())
+            .collect()
+    }
+
+    #[test]
+    fn only_listing_methods_carry_a_field() {
+        assert_eq!(listed_field("tools/list"), Some("tools"));
+        assert_eq!(listed_field("resources/list"), Some("resources"));
+        assert_eq!(listed_field("prompts/list"), Some("prompts"));
+        assert_eq!(listed_field("tools/call"), None);
+        assert_eq!(listed_field("initialize"), None);
+    }
+
+    /// Templates are keyed by `uriTemplate`, which names a family of URIs the
+    /// request path never resolves. Filtering them by exact match would hide
+    /// entries the enforcer permits.
+    #[test]
+    fn resource_templates_are_left_alone() {
+        assert_eq!(listed_field("resources/templates/list"), None);
+    }
+
+    #[test]
+    fn an_allowlist_hides_everything_not_on_it() {
+        let body = tools_list(&["get_weather", "execute_sql", "search_docs"]);
+        let Filtered::Rewritten { body, hidden } = filter(
+            &body,
+            Framing::Json,
+            "tools",
+            &set(&["get_weather", "search_docs"]),
+            &HashSet::new(),
+        ) else {
+            panic!("expected a rewrite");
+        };
+        assert_eq!(hidden, 1);
+        assert_eq!(names_in(&body), ["get_weather", "search_docs"]);
+    }
+
+    #[test]
+    fn a_denylist_hides_what_is_on_it() {
+        let body = tools_list(&["get_weather", "execute_sql"]);
+        let Filtered::Rewritten { body, hidden } = filter(
+            &body,
+            Framing::Json,
+            "tools",
+            &HashSet::new(),
+            &set(&["execute_sql"]),
+        ) else {
+            panic!("expected a rewrite");
+        };
+        assert_eq!(hidden, 1);
+        assert_eq!(names_in(&body), ["get_weather"]);
+    }
+
+    /// The whole point of the module: what it hides is what `mcp::evaluate`
+    /// refuses. Deny wins over allow there, so it must win here.
+    #[test]
+    fn deny_beats_allow_exactly_as_the_enforcer_does() {
+        let body = tools_list(&["both"]);
+        let Filtered::Rewritten { hidden, .. } = filter(
+            &body,
+            Framing::Json,
+            "tools",
+            &set(&["both"]),
+            &set(&["both"]),
+        ) else {
+            panic!("expected a rewrite");
+        };
+        assert_eq!(hidden, 1);
+        assert!(!permitted("both", &set(&["both"]), &set(&["both"])));
+    }
+
+    #[test]
+    fn a_listing_with_nothing_to_hide_is_left_byte_for_byte_alone() {
+        let body = tools_list(&["a", "b"]);
+        assert_eq!(
+            filter(
+                &body,
+                Framing::Json,
+                "tools",
+                &set(&["a", "b"]),
+                &HashSet::new()
+            ),
+            Filtered::Unchanged
+        );
+    }
+
+    /// Everything outside the entry array survives, `nextCursor` above all:
+    /// dropping it would silently truncate a paginated listing.
+    #[test]
+    fn pagination_and_envelope_fields_survive_the_rewrite() {
+        let body = br#"{"jsonrpc":"2.0","id":"abc","result":{
+            "tools":[{"name":"keep"},{"name":"drop"}],"nextCursor":"page2"}}"#;
+        let Filtered::Rewritten { body, .. } = filter(
+            body,
+            Framing::Json,
+            "tools",
+            &set(&["keep"]),
+            &HashSet::new(),
+        ) else {
+            panic!("expected a rewrite");
+        };
+        let doc: Value = serde_json::from_slice(&body).expect("valid json");
+        assert_eq!(doc["id"], "abc");
+        assert_eq!(doc["jsonrpc"], "2.0");
+        assert_eq!(doc["result"]["nextCursor"], "page2");
+        assert_eq!(names_in(&body), ["keep"]);
+    }
+
+    /// Resources are identified by `uri`, matching the fallback the request
+    /// path uses when `params.name` is absent.
+    #[test]
+    fn resources_are_matched_on_their_uri() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"result":{"resources":[
+            {"uri":"file:///public/a.txt"},{"uri":"file:///secret/b.txt"}]}}"#;
+        let Filtered::Rewritten { body, hidden } = filter(
+            body,
+            Framing::Json,
+            "resources",
+            &HashSet::new(),
+            &set(&["file:///secret/b.txt"]),
+        ) else {
+            panic!("expected a rewrite");
+        };
+        assert_eq!(hidden, 1);
+        let doc: Value = serde_json::from_slice(&body).expect("valid json");
+        assert_eq!(
+            doc["result"]["resources"].as_array().expect("array").len(),
+            1
+        );
+    }
+
+    /// An entry the proxy cannot name is kept, because the enforcer would not
+    /// refuse a call it cannot name either. Hiding it would be a guess.
+    #[test]
+    fn an_unidentifiable_entry_is_kept() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"result":{"tools":[{"description":"no name"}]}}"#;
+        assert_eq!(
+            filter(
+                body,
+                Framing::Json,
+                "tools",
+                &set(&["only_this"]),
+                &HashSet::new()
+            ),
+            Filtered::Unchanged
+        );
+    }
+
+    #[test]
+    fn a_body_that_is_not_json_is_refused_rather_than_forwarded() {
+        assert!(matches!(
+            filter(
+                b"<html>nope</html>",
+                Framing::Json,
+                "tools",
+                &set(&["a"]),
+                &HashSet::new()
+            ),
+            Filtered::Unfilterable(_)
+        ));
+    }
+
+    /// An error response carries no `result`, so there is nothing to filter and
+    /// nothing to refuse.
+    #[test]
+    fn an_error_response_passes_through() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"nope"}}"#;
+        assert_eq!(
+            filter(body, Framing::Json, "tools", &set(&["a"]), &HashSet::new()),
+            Filtered::Unchanged
+        );
+    }
+
+    // === Streamable HTTP ===
+
+    #[test]
+    fn an_sse_listing_is_filtered_inside_its_data_field() {
+        let body = b"event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"name\":\"keep\"},{\"name\":\"drop\"}]}}\n\n";
+        let Filtered::Rewritten { body, hidden } = filter(
+            body,
+            Framing::Sse,
+            "tools",
+            &set(&["keep"]),
+            &HashSet::new(),
+        ) else {
+            panic!("expected a rewrite");
+        };
+        assert_eq!(hidden, 1);
+        let text = String::from_utf8(body).expect("utf-8");
+        assert!(
+            text.starts_with("event: message\n"),
+            "framing kept: {text:?}"
+        );
+        assert!(text.ends_with("\n\n"), "event terminator kept: {text:?}");
+        assert!(text.contains("keep"));
+        assert!(!text.contains("drop"));
+    }
+
+    /// The grammar joins consecutive `data:` lines with a newline. They are
+    /// re-emitted as one line, which is the same event to any client.
+    #[test]
+    fn a_data_payload_split_across_lines_is_reassembled() {
+        let body = b"data: {\"jsonrpc\":\"2.0\",\"id\":1,\ndata: \"result\":{\"tools\":[{\"name\":\"drop\"}]}}\n\n";
+        let Filtered::Rewritten { body, hidden } = filter(
+            body,
+            Framing::Sse,
+            "tools",
+            &set(&["keep"]),
+            &HashSet::new(),
+        ) else {
+            panic!("expected a rewrite");
+        };
+        assert_eq!(hidden, 1);
+        let text = String::from_utf8(body).expect("utf-8");
+        assert_eq!(text.matches("data:").count(), 1);
+        assert!(!text.contains("drop"));
+    }
+
+    /// Keep-alive comments and unrelated events share the stream and must
+    /// survive untouched.
+    #[test]
+    fn unrelated_events_and_comments_survive() {
+        let body = b": keep-alive\n\nevent: message\ndata: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\"}\n\nevent: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"name\":\"drop\"}]}}\n\n";
+        let Filtered::Rewritten { body, hidden } = filter(
+            body,
+            Framing::Sse,
+            "tools",
+            &set(&["keep"]),
+            &HashSet::new(),
+        ) else {
+            panic!("expected a rewrite");
+        };
+        assert_eq!(hidden, 1);
+        let text = String::from_utf8(body).expect("utf-8");
+        assert!(text.contains(": keep-alive"));
+        assert!(text.contains("notifications/progress"));
+        assert!(!text.contains("drop"));
+    }
+
+    #[test]
+    fn crlf_framing_is_understood() {
+        let body = b"event: message\r\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"name\":\"drop\"}]}}\r\n\r\n";
+        let Filtered::Rewritten { hidden, .. } = filter(
+            body,
+            Framing::Sse,
+            "tools",
+            &set(&["keep"]),
+            &HashSet::new(),
+        ) else {
+            panic!("expected a rewrite");
+        };
+        assert_eq!(hidden, 1);
+    }
+
+    // === From configuration to a filtered response ===
+
+    fn cfg(allow: &[&str], deny: &[&str]) -> McpConfig {
+        McpConfig {
+            allowed_tools: allow.iter().map(|s| s.to_string()).collect(),
+            denied_tools: deny.iter().map(|s| s.to_string()).collect(),
+            ..McpConfig::default()
+        }
+    }
+
+    /// The route names tools, so the listing is cut down to them. This is the
+    /// path a real request takes, from the config an operator wrote to the
+    /// bytes the client receives.
+    #[test]
+    fn a_route_that_names_tools_gets_a_plan_that_hides_the_rest() {
+        let c = cfg(&["get_weather"], &[]);
+        let plan = Plan::for_method(&c, "tools/list", Framing::Json).expect("a plan");
+        let body = tools_list(&["get_weather", "execute_sql"]);
+        let Filtered::Rewritten { body, hidden } =
+            filter(&body, plan.framing, plan.field, &plan.allowed, &plan.denied)
+        else {
+            panic!("expected a rewrite");
+        };
+        assert_eq!(hidden, 1);
+        assert_eq!(names_in(&body), ["get_weather"]);
+    }
+
+    /// The common case, and the one that must stay free: no tool policy means
+    /// no plan, so no response is ever buffered.
+    #[test]
+    fn a_route_naming_no_tools_is_never_buffered() {
+        assert!(Plan::for_method(&McpConfig::default(), "tools/list", Framing::Json).is_none());
+    }
+
+    #[test]
+    fn turning_the_setting_off_produces_no_plan() {
+        let c = McpConfig {
+            filter_tool_list: false,
+            ..cfg(&["get_weather"], &[])
+        };
+        assert!(Plan::for_method(&c, "tools/list", Framing::Json).is_none());
+    }
+
+    /// A route may forbid a tool without listing what it allows.
+    #[test]
+    fn a_denylist_alone_is_enough_to_get_a_plan() {
+        assert!(
+            Plan::for_method(&cfg(&[], &["execute_sql"]), "tools/list", Framing::Json).is_some()
+        );
+    }
+
+    /// Only listing methods produce a plan; a `tools/call` response is not a
+    /// listing and must not be touched.
+    #[test]
+    fn a_non_listing_method_produces_no_plan() {
+        let c = cfg(&["get_weather"], &[]);
+        assert!(Plan::for_method(&c, "tools/call", Framing::Json).is_none());
+        assert!(Plan::for_method(&c, "initialize", Framing::Json).is_none());
+    }
+
+    #[test]
+    fn event_boundaries_are_found_for_incremental_filtering() {
+        assert_eq!(complete_events_len(b"data: 1\n\ndata: 2"), 9);
+        assert_eq!(complete_events_len(b"data: 1\r\n\r\ndata: 2"), 11);
+        assert_eq!(complete_events_len(b"data: partial"), 0);
+        assert_eq!(complete_events_len(b"a\n\nb\n\n"), 6);
+    }
+}

--- a/crates/proxy/src/agentic/mcp.rs
+++ b/crates/proxy/src/agentic/mcp.rs
@@ -520,7 +520,10 @@ fn check_header_agreement(
 ///
 /// An empty allowlist means "no allowlist configured", not "allow nothing" —
 /// otherwise adding a denylist alone would silently refuse everything.
-fn permitted(value: &str, allowed: &HashSet<String>, denied: &HashSet<String>) -> bool {
+/// Whether a method or target passes an allow/deny pair.
+///
+/// `pub(super)` so [`super::listing`] can hide exactly what this refuses.
+pub(super) fn permitted(value: &str, allowed: &HashSet<String>, denied: &HashSet<String>) -> bool {
     if !allowed.is_empty() && !allowed.contains(value) {
         return false;
     }

--- a/crates/proxy/src/agentic/mod.rs
+++ b/crates/proxy/src/agentic/mod.rs
@@ -26,6 +26,7 @@
 
 pub mod a2a;
 pub mod jsonrpc;
+pub mod listing;
 pub mod mcp;
 
 use zentinel_config::agentic::{
@@ -169,6 +170,11 @@ mod conversion_tests {
             require_validated_version: false,
             validate_param_headers: false,
             on_uninspectable_body: ConfigUninspectable::Allow,
+            // Not part of `Policy`: listing filtering happens on the response
+            // path, which reads the route's config directly. Set to a
+            // non-default here so that if it ever *is* added to `Policy`, this
+            // test is already exercising the interesting value.
+            filter_tool_list: false,
         };
         let p = mcp::Policy::from(&cfg);
 

--- a/crates/proxy/src/proxy/context.rs
+++ b/crates/proxy/src/proxy/context.rs
@@ -189,6 +189,14 @@ pub struct RequestContext {
     pub(crate) mcp_target: Option<String>,
     /// A2A method resolved from the body.
     pub(crate) a2a_method: Option<String>,
+    /// Set when the response to this request is an MCP listing whose entries
+    /// the route's tool policy governs, and must be rewritten before it
+    /// reaches the client. See [`crate::agentic::listing`].
+    pub(crate) mcp_listing: Option<crate::agentic::listing::Plan>,
+    /// Response bytes held back for that rewrite. For a JSON response this is
+    /// the whole body; for an event stream it holds only the event currently
+    /// being assembled, so a stream that stays open is not withheld with it.
+    pub(crate) mcp_listing_body: Vec<u8>,
 
     // === Body Decompression ===
     /// Whether decompression is enabled for body inspection
@@ -393,6 +401,8 @@ impl RequestContext {
             agentic_body_oversize: false,
             mcp_method: None,
             mcp_target: None,
+            mcp_listing: None,
+            mcp_listing_body: Vec::new(),
             a2a_method: None,
             body_inspection_agents: Vec::new(),
             decompression_enabled: false,

--- a/crates/proxy/src/proxy/http_trait.rs
+++ b/crates/proxy/src/proxy/http_trait.rs
@@ -1974,6 +1974,10 @@ impl ProxyHttp for ZentinelProxy {
             }
         }
 
+        // Decide, before any of the body arrives, whether this response is an
+        // MCP listing that has to be cut down to what the route permits.
+        self.prepare_mcp_listing_rewrite(upstream_response, ctx)?;
+
         // Add GeoIP country header if geo lookup was performed
         if let Some(ref country_code) = ctx.geo_country_code {
             upstream_response.insert_header("X-GeoIP-Country", country_code)?;
@@ -2590,6 +2594,13 @@ impl ProxyHttp for ZentinelProxy {
             }
             // Skip normal body processing for WebSocket
             return Ok(None);
+        }
+
+        // Cut an MCP listing down to what the route permits before anything
+        // else sees it, so an agent inspects the same bytes the client will
+        // receive rather than a surface the client is not allowed to know.
+        if ctx.mcp_listing.is_some() {
+            self.rewrite_mcp_listing(body, end_of_stream, ctx)?;
         }
 
         // Process response body through agents (for agents that subscribe to ResponseBody events)
@@ -3863,7 +3874,204 @@ impl ProxyHttp for ZentinelProxy {
 // Helper methods for body streaming (not part of ProxyHttp trait)
 // =============================================================================
 
+/// The response's media type: lowercased, without parameters.
+///
+/// Compared exactly rather than by prefix, because `application/jsonl` and
+/// `application/json-rpc` both start with `application/json` and are not it.
+fn response_mime(resp: &ResponseHeader) -> Option<String> {
+    resp.headers
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .map(|v| {
+            v.split(';')
+                .next()
+                .unwrap_or_default()
+                .trim()
+                .to_ascii_lowercase()
+        })
+}
+
 impl ZentinelProxy {
+    /// Decide whether this response is an MCP listing that must be cut down to
+    /// what the route permits, and prepare its headers if so.
+    ///
+    /// Runs on headers, before any body has arrived, because the decision needs
+    /// the upstream's framing and because a rewritten body is a different
+    /// length than the one `Content-Length` announces.
+    ///
+    /// Costs nothing on a route that names no tools, which is every route that
+    /// has not asked for this.
+    fn prepare_mcp_listing_rewrite(
+        &self,
+        upstream_response: &mut ResponseHeader,
+        ctx: &mut RequestContext,
+    ) -> Result<(), Box<Error>> {
+        use crate::agentic::listing;
+
+        // The method comes from the request body, never from `Mcp-Method`: a
+        // client able to nominate the method here would name one that returns
+        // no plan and be handed the unfiltered listing.
+        let Some(method) = ctx.mcp_method.clone() else {
+            return Ok(());
+        };
+        let Some(mcp) = ctx.route_config.as_ref().and_then(|r| r.mcp.as_ref()) else {
+            return Ok(());
+        };
+        if !upstream_response.status.is_success() {
+            return Ok(());
+        }
+
+        let framing = match response_mime(upstream_response).as_deref() {
+            Some("application/json") => listing::Framing::Json,
+            Some("text/event-stream") => listing::Framing::Sse,
+            // Not a framing an MCP client reads a JSON-RPC response out of, so
+            // there is no listing here to disclose.
+            _ => return Ok(()),
+        };
+
+        let Some(plan) = listing::Plan::for_method(mcp, &method, framing) else {
+            return Ok(());
+        };
+
+        // A compressed listing cannot be rewritten, and forwarding it would
+        // advertise what the route forbids -- the one thing this exists to
+        // prevent. Refuse it, and say what to change.
+        let encoding = upstream_response
+            .headers
+            .get("content-encoding")
+            .and_then(|v| v.to_str().ok())
+            .map(str::trim)
+            .unwrap_or("");
+        if !encoding.is_empty() && !encoding.eq_ignore_ascii_case("identity") {
+            warn!(
+                correlation_id = %ctx.trace_id,
+                route_id = ?ctx.route_id,
+                content_encoding = encoding,
+                "MCP listing arrived compressed and cannot be filtered"
+            );
+            return Err(Error::explain(
+                ErrorType::HTTPStatus(502),
+                format!(
+                    "MCP listing response is {encoding}-encoded and cannot be filtered to the \
+                     route's tool policy. Serve listings uncompressed, or set \
+                     `filter-tool-list #false` on this route to forward them unfiltered."
+                ),
+            ));
+        }
+
+        // The rewritten body is shorter than the one the upstream announced,
+        // and its length is not known until the listing has been read.
+        upstream_response.remove_header("content-length");
+        ctx.mcp_listing = Some(plan);
+
+        Ok(())
+    }
+
+    /// Remove from a listing response the entries a call would be refused.
+    ///
+    /// JSON is held whole, because a rewrite needs the whole document. An event
+    /// stream is filtered a complete event at a time: a Streamable HTTP server
+    /// may keep the stream open after answering, and waiting for end of stream
+    /// would hold the listing for as long as the server holds the connection.
+    fn rewrite_mcp_listing(
+        &self,
+        body: &mut Option<Bytes>,
+        end_of_stream: bool,
+        ctx: &mut RequestContext,
+    ) -> Result<(), Box<Error>> {
+        use crate::agentic::listing::{self, Filtered};
+
+        let framing = match ctx.mcp_listing.as_ref() {
+            Some(plan) => plan.framing,
+            None => return Ok(()),
+        };
+
+        // Withhold the chunk; what goes out is decided below.
+        if let Some(chunk) = body.take() {
+            if ctx.mcp_listing_body.len() + chunk.len() > listing::MAX_LISTING_BYTES {
+                ctx.mcp_listing = None;
+                ctx.mcp_listing_body = Vec::new();
+                warn!(
+                    correlation_id = %ctx.trace_id,
+                    route_id = ?ctx.route_id,
+                    limit = listing::MAX_LISTING_BYTES,
+                    "MCP listing exceeded the size the proxy will rewrite"
+                );
+                return Err(Error::explain(
+                    ErrorType::HTTPStatus(502),
+                    "MCP listing response is larger than the proxy will buffer to filter it, \
+                     and forwarding it would advertise tools this route forbids.",
+                ));
+            }
+            ctx.mcp_listing_body.extend_from_slice(&chunk);
+        }
+
+        // How much of what is buffered can be rewritten and released now.
+        let ready = match framing {
+            listing::Framing::Json if end_of_stream => ctx.mcp_listing_body.len(),
+            listing::Framing::Json => return Ok(()),
+            listing::Framing::Sse if end_of_stream => ctx.mcp_listing_body.len(),
+            listing::Framing::Sse => listing::complete_events_len(&ctx.mcp_listing_body),
+        };
+        if ready == 0 {
+            return Ok(());
+        }
+
+        let ready: Vec<u8> = ctx.mcp_listing_body.drain(..ready).collect();
+        // Safe: the plan is present, checked at the top.
+        let plan = ctx.mcp_listing.as_ref().expect("plan present").clone();
+
+        match listing::filter(
+            &ready,
+            plan.framing,
+            plan.field,
+            &plan.allowed,
+            &plan.denied,
+        ) {
+            Filtered::Unchanged => *body = Some(Bytes::from(ready)),
+            Filtered::Rewritten {
+                body: filtered,
+                hidden,
+            } => {
+                debug!(
+                    correlation_id = %ctx.trace_id,
+                    route_id = ?ctx.route_id,
+                    method = ?ctx.mcp_method,
+                    hidden = hidden,
+                    "Hid MCP listing entries this route would refuse a call to"
+                );
+                self.metrics.record_mcp_listing_filtered(
+                    ctx.route_id.as_deref().unwrap_or("unknown"),
+                    ctx.mcp_method.as_deref().unwrap_or("unknown"),
+                    hidden as u64,
+                );
+                *body = Some(Bytes::from(filtered));
+            }
+            Filtered::Unfilterable(why) => {
+                ctx.mcp_listing = None;
+                warn!(
+                    correlation_id = %ctx.trace_id,
+                    route_id = ?ctx.route_id,
+                    reason = why,
+                    "MCP listing could not be filtered"
+                );
+                return Err(Error::explain(
+                    ErrorType::HTTPStatus(502),
+                    format!(
+                        "MCP listing response could not be filtered to the route's tool policy \
+                         ({why}), and forwarding it would advertise tools this route forbids."
+                    ),
+                ));
+            }
+        }
+
+        if end_of_stream {
+            ctx.mcp_listing = None;
+        }
+
+        Ok(())
+    }
+
     /// Enforce a route's MCP or A2A policy against the request body.
     ///
     /// Policy is resolved from the JSON-RPC envelope, never from the mirrored

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,24 @@ services:
       retries: 3
     restart: unless-stopped
 
+  # Minimal MCP server, so the suite can assert what the proxy does to a real
+  # JSON-RPC listing. httpbin cannot stand in for this: it echoes requests, and
+  # the MCP policy acts on a response the upstream has to produce.
+  mcp-backend:
+    image: python:3.12-alpine
+    container_name: zentinel-mcp-backend
+    command: ["python3", "/fixtures/mcp_server.py", "8090"]
+    volumes:
+      - ./tests/fixtures:/fixtures:ro
+    networks:
+      - zentinel
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8090/')"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
   # Prometheus for metrics collection
   prometheus:
     image: prom/prometheus:latest

--- a/tests/fixtures/mcp_server.py
+++ b/tests/fixtures/mcp_server.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""A minimal MCP server, enough to exercise the proxy's MCP policy end to end.
+
+httpbin cannot stand in for this. The proxy's MCP handling reads a JSON-RPC
+envelope out of the request and, since #457, rewrites the listing that comes
+back -- neither of which an echo backend produces. Everything here is
+deliberately fixed: the point is to assert what the proxy did to a known
+response, not to be a real server.
+
+Stdlib only, so it runs on a stock `python:*-alpine` with nothing installed.
+
+A path containing `sse` gets a `text/event-stream` reply and anything else gets
+`application/json`, so both framings the proxy has to filter are reachable --
+matched anywhere in the path so it survives a route prefix in front of it.
+"""
+
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+PROTOCOL_VERSION = "2026-07-28"
+
+# One tool a route is expected to permit, one it is expected to hide, and one
+# that only shows up when nothing is filtered.
+TOOLS = [
+    {
+        "name": "search_docs",
+        "description": "Search the documentation",
+        "inputSchema": {"type": "object", "properties": {"q": {"type": "string"}}},
+    },
+    {
+        "name": "get_weather",
+        "description": "Current conditions for a city",
+        "inputSchema": {"type": "object", "properties": {"city": {"type": "string"}}},
+    },
+    {
+        "name": "execute_sql",
+        "description": "Run a query against the production database",
+        "inputSchema": {"type": "object", "properties": {"sql": {"type": "string"}}},
+    },
+]
+
+RESOURCES = [
+    {"uri": "file:///public/readme.txt", "name": "readme"},
+    {"uri": "file:///secret/credentials.txt", "name": "credentials"},
+]
+
+
+def result_for(method, params):
+    """The result payload for a method, or an error tuple."""
+    if method == "initialize":
+        return {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {"tools": {}, "resources": {}},
+            "serverInfo": {"name": "zentinel-test-mcp", "version": "1.0.0"},
+        }
+    if method == "tools/list":
+        return {"tools": TOOLS}
+    if method == "resources/list":
+        return {"resources": RESOURCES}
+    if method == "tools/call":
+        name = params.get("name", "")
+        return {"content": [{"type": "text", "text": f"called {name}"}]}
+    return None
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):  # noqa: A003 - stdlib hook
+        sys.stderr.write("mcp-server: " + fmt % args + "\n")
+
+    def do_GET(self):
+        # A liveness probe for compose, not part of MCP.
+        self._send(200, b'{"status":"ok"}', "application/json")
+
+    def do_POST(self):
+        length = int(self.headers.get("content-length") or 0)
+        raw = self.rfile.read(length) if length else b""
+
+        try:
+            envelope = json.loads(raw)
+        except ValueError:
+            self._send(400, b'{"error":"not json"}', "application/json")
+            return
+
+        method = envelope.get("method", "")
+        result = result_for(method, envelope.get("params") or {})
+
+        if result is None:
+            body = {
+                "jsonrpc": "2.0",
+                "id": envelope.get("id"),
+                "error": {"code": -32601, "message": f"unknown method {method}"},
+            }
+        else:
+            body = {"jsonrpc": "2.0", "id": envelope.get("id"), "result": result}
+
+        payload = json.dumps(body).encode()
+
+        if "sse" in self.path:
+            # Streamable HTTP: the response arrives inside an SSE event. The
+            # stream is closed straight after, which is what a server that has
+            # nothing further to say should do.
+            framed = b"event: message\ndata: " + payload + b"\n\n"
+            self._send(200, framed, "text/event-stream")
+        else:
+            self._send(200, payload, "application/json")
+
+    def _send(self, status, body, content_type):
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("MCP-Protocol-Version", PROTOCOL_VERSION)
+        self.end_headers()
+        self.wfile.write(body)
+
+
+if __name__ == "__main__":
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8090
+    print(f"mcp-server listening on {port}", file=sys.stderr, flush=True)
+    HTTPServer(("0.0.0.0", port), Handler).serve_forever()

--- a/tests/integration_test.sh
+++ b/tests/integration_test.sh
@@ -381,6 +381,84 @@ test_echo_agent() {
     assert_status "$response" "200" "Echo route request succeeds"
 }
 
+# MCP policy: what the proxy refuses, and what it lets the upstream advertise.
+#
+# The fixture upstream (tests/fixtures/mcp_server.py) offers search_docs,
+# get_weather and execute_sql. The /mcp route allows the first two. /mcp-raw is
+# the same upstream with no policy, so the difference between the two is the
+# assertion rather than a filtered list taken on faith.
+test_mcp_policy() {
+    log_section "MCP Policy Tests"
+
+    local mcp_headers=(
+        -H "content-type: application/json"
+        -H "mcp-protocol-version: 2026-07-28"
+    )
+    local list_body='{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+
+    log_test "Unfiltered route advertises every tool"
+    local raw
+    raw=$(curl -s -X POST "http://${PROXY_HOST}:${PROXY_PORT}/mcp-raw" \
+        "${mcp_headers[@]}" -d "$list_body" 2>/dev/null)
+    if echo "$raw" | grep -q "execute_sql"; then
+        log_success "Upstream offers execute_sql without a policy in front"
+    else
+        log_failure "Fixture did not return the expected tool list: $raw"
+    fi
+
+    log_test "Forbidden tool is hidden from tools/list"
+    local filtered
+    filtered=$(curl -s -X POST "http://${PROXY_HOST}:${PROXY_PORT}/mcp" \
+        "${mcp_headers[@]}" -d "$list_body" 2>/dev/null)
+    if echo "$filtered" | grep -q "execute_sql"; then
+        log_failure "execute_sql was advertised on a route that forbids it"
+    elif echo "$filtered" | grep -q "search_docs"; then
+        log_success "execute_sql hidden, permitted tools still listed"
+    else
+        log_failure "Listing lost its permitted tools too: $filtered"
+    fi
+
+    log_test "Forbidden tool is hidden from an event-stream listing"
+    local sse
+    sse=$(curl -s -X POST "http://${PROXY_HOST}:${PROXY_PORT}/mcp/sse" \
+        "${mcp_headers[@]}" -d "$list_body" 2>/dev/null)
+    if echo "$sse" | grep -q "event: message" && ! echo "$sse" | grep -q "execute_sql"; then
+        log_success "SSE listing filtered with its framing intact"
+    else
+        log_failure "SSE listing not filtered as expected: $sse"
+    fi
+
+    log_test "Calling a forbidden tool is refused"
+    local status
+    status=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        "http://${PROXY_HOST}:${PROXY_PORT}/mcp" "${mcp_headers[@]}" \
+        -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"execute_sql"}}' 2>/dev/null)
+    if [[ "$status" == "403" ]]; then
+        log_success "execute_sql refused with 403"
+    else
+        log_failure "Expected 403 for execute_sql, got $status"
+    fi
+
+    log_test "Calling a permitted tool succeeds"
+    status=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        "http://${PROXY_HOST}:${PROXY_PORT}/mcp" "${mcp_headers[@]}" \
+        -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search_docs"}}' 2>/dev/null)
+    if [[ "$status" == "200" ]]; then
+        log_success "search_docs permitted"
+    else
+        log_failure "Expected 200 for search_docs, got $status"
+    fi
+
+    log_test "Hidden entries are counted"
+    local metrics
+    metrics=$(curl -sf "http://${PROXY_HOST}:${METRICS_PORT}/metrics" 2>/dev/null)
+    if echo "$metrics" | grep -q "zentinel_mcp_listing_entries_hidden_total"; then
+        log_success "zentinel_mcp_listing_entries_hidden_total is reported"
+    else
+        log_failure "Listing filter metric missing from /metrics"
+    fi
+}
+
 # Test rate limit agent
 test_ratelimit_agent() {
     log_section "Rate Limit Agent Tests"
@@ -705,6 +783,10 @@ main() {
     # Wait for backend first (other services depend on it)
     wait_for_service "http://${PROXY_HOST}:8081/status/200" "Backend" 60 || exit 1
 
+    # The MCP fixture has no published port, so it is probed through the proxy
+    # route that reaches it rather than directly.
+    wait_for_service "http://${PROXY_HOST}:${PROXY_PORT}/mcp-raw" "MCP backend" 60 || true
+
     # Wait for proxy
     # /health is a route on the proxy's own HTTP listener, served by the
     # `health` builtin-handler in config/docker/proxy.kdl. It is deliberately
@@ -730,6 +812,7 @@ main() {
     test_health_endpoints
     test_configuration
     test_echo_agent
+    test_mcp_policy
     test_ratelimit_agent
     test_waf_agent
     test_multi_agent


### PR DESCRIPTION
Part of #443 — the "per-client / per-route tool visibility" bullet of the MCP
gateway work. Follows #447/#448 (per-tool metrics) and #456 (per-tool rate
limiting).

## The gap

`agentic/mcp.rs` refuses a `tools/call` naming a tool the route forbids. That
is enforcement, and on its own it leaves the **advertised** surface and the
**enforced** one disagreeing — everything before this PR is request-path only,
so `tools/list` passes through untouched. A route can allow three of an
upstream's eighty tools and the client is still shown all eighty.

Three consequences, in increasing order of how much they matter:

1. A model picks a forbidden tool, calls it, gets an error. The round trip is
   wasted and the failure reads as a bug in the upstream.
2. Tool descriptions are spent from the model's context window. MCP clients
   degrade well before a hundred tools — #443's own design-risk #1.
3. **A tool list is an inventory.** Names and descriptions routinely disclose
   which internal systems exist and what they can be made to do. A client
   permitted to call none of them still got to read all of it.

## What this does

Removes from `tools/list`, `resources/list` and `prompts/list` responses
exactly the entries a call would be refused — using the same identity rule
(`name`, falling back to `uri`, matching `jsonrpc::Envelope`) and literally the
same `permitted()` predicate as the enforcer.

That symmetry is the point. A filter that hid a *different* set than the
enforcer refuses would be worse than no filter: it would make the advertised
surface a misleading description of the policy rather than merely an incomplete
one. `permitted()` is now `pub(super)` so there is one implementation, not two.

## Decisions worth reviewing

**Default on.** It does nothing unless the route sets a tool `allow`/`deny`
list, and for a route that has, matching the advertised surface to the enforced
one is what writing the list obviously meant. #443's "no implicit behaviour"
concern was about *generating* tools from an OpenAPI spec, not about honouring
a list the operator wrote. `filter-tool-list #false` is the escape hatch.

**Unfilterable listings are refused (502), not forwarded.** Compressed, over
1 MiB, or unparseable. Forwarding would advertise what the route forbids, which
is the one thing this exists to prevent. The error names which of the three it
was and what to change. The realistic case is gzip, so that message says to
serve listings uncompressed or turn the setting off.

**Event streams filter per complete event, not at end of stream.** A Streamable
HTTP server may hold the stream open after answering; waiting for the end would
hold the listing for as long as it holds the connection. Costs one event of
latency.

**`resources/templates/list` is left alone.** Its entries are keyed by
`uriTemplate`, which names a *family* of URIs the request path never resolves.
An exact-match filter would hide entries the enforcer permits. Calls to the
URIs a template expands to are still checked on `resources/read`.

**Free when unused.** No plan is built for a route naming no tools, so no
response is buffered — that is every route that has not asked for this.

## Also

- The whole config-to-behaviour decision lives in `listing::Plan::for_method`
  rather than in `http_trait`, so it is testable against a parsed route. The
  gap between what an operator wrote and what the proxy enforced is what made
  `agentic/` dead code for a release; this keeps that boundary covered.
- `zentinel_mcp_listing_entries_hidden_total{route,method}`. Counts entries,
  not responses — the useful question is how much of an upstream's surface a
  route hides. Both labels bounded by config, not traffic.
- `Content-Length` is dropped when a rewrite is planned, since the new body is
  shorter and its length is not known until the listing has been read.

## Checks

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- 94 + 394 + 736 tests pass, 0 failures
- `cargo fmt --all` touched only the files in this PR

21 new tests, including allow/deny precedence matching the enforcer, `nextCursor`
survival, SSE framing (multi-line `data:`, CRLF, keep-alive comments, unrelated
events), and the config→behaviour path from a parsed route to filtered bytes.

Docs follow in a companion PR on `zentinelproxy.io-docs`.

https://claude.ai/code/session_01VkHAQ33U78fmpk6r161DKc
