### PR TITLE
fix(upstream): health checks never probed anything

### DIFF
--- a/crates/proxy/src/upstream/health.rs
+++ b/crates/proxy/src/upstream/health.rs
@@ -221,6 +221,26 @@ impl ActiveHealthChecker {
             "Running health check cycle"
         );
 
+        // Populate the backend set from discovery before probing it.
+        //
+        // `Backends::run_health_check` iterates the set that `update()` fills,
+        // and nothing else fills it -- so without this the runner ticks on
+        // schedule, logs that it is running, and probes nothing at all. It
+        // fails silently in both directions: no probe is sent, and no backend
+        // is ever marked unhealthy, so an upstream that is down stays in
+        // rotation while the configuration says it is being checked.
+        //
+        // Cheap to repeat: discovery here is `Static`, and `update` only
+        // invokes its callback when the resolved set actually differs.
+        if let Err(e) = self.backends.update(|_| {}).await {
+            warn!(
+                upstream_id = %self.upstream_id,
+                error = %e,
+                "Failed to refresh backends before health check"
+            );
+            return;
+        }
+
         self.backends.run_health_check(self.parallel).await;
     }
 
@@ -419,6 +439,48 @@ mod tests {
             http_version: HttpVersionConfig::default(),
             discovery: None,
         }
+    }
+
+    /// The runner ticked on schedule, logged that it was running, and probed
+    /// nothing: `Backends::run_health_check` iterates the set that `update()`
+    /// fills, and nothing called `update()`. Every health check in every
+    /// configuration was inert, in both directions -- no probe sent, and no
+    /// backend ever marked unhealthy.
+    ///
+    /// Asserts against a real socket, because the defect was invisible to any
+    /// test that only inspected configuration.
+    #[tokio::test]
+    async fn a_health_check_cycle_actually_probes_the_backend() {
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr").to_string();
+
+        let probed = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let seen = probed.clone();
+        tokio::spawn(async move {
+            while listener.accept().await.is_ok() {
+                seen.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
+        });
+
+        let mut config = create_test_config();
+        config.targets[0].address = addr;
+        config.health_check = Some(HealthCheckConfig {
+            check_type: HealthCheckType::Tcp,
+            interval_secs: 1,
+            timeout_secs: 1,
+            healthy_threshold: 1,
+            unhealthy_threshold: 1,
+        });
+
+        let checker = ActiveHealthChecker::new(&config).expect("checker built");
+        checker.run_health_check().await;
+
+        assert!(
+            probed.load(std::sync::atomic::Ordering::SeqCst) > 0,
+            "a health check cycle connected to nothing"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Found while trying to prove a new health-check type end to end. It is not
specific to that type — **active health checking has never worked, for any
check type.**

## The defect

`ActiveHealthChecker::new` builds a `Backends` from the configured targets and
attaches a health check to it, but never calls `update()`.
`Backends::run_health_check` iterates the set that `update()` populates, and
nothing else populates it. The set is empty, so every cycle probes nothing.

The runner reports itself working the whole time — it spawns, logs
`Starting health check runner checker_count=N`, and ticks on schedule.

## Measured, not inferred

Against a real backend with `interval-secs 2`:

| | probes in 12s |
|---|---|
| `type "http"` before | **0** |
| `type "mcp"` before | **0** |
| after this change | **29** |

I checked `http` specifically to rule out my own new code as the cause. Both
were zero, and pingora's source confirms why: `run_health_check` iterates
`self.backends.load()`, filled only by `update()`.

## Why it matters

It fails silently in both directions:

- No probe is sent, so a backend that is down is never detected.
- No backend is ever marked unhealthy, so nothing is taken out of rotation —
  there is no failover, only the appearance of it.

Meanwhile the config says health checking is on, and `zentinel lint` actively
recommends adding it to upstreams that lack it. Both have been describing
something inert. Anyone relying on health-checked failover in production has
not had it.

## The test

Asserts against a real `TcpListener` that a cycle actually connects. The defect
was invisible to any test that only inspected configuration, which is how it
survived — so the test had to reach the socket.

I verified it catches the bug rather than assuming: reverting the fix makes it
fail, restoring it makes it pass.

## Checks

- `cargo clippy -p zentinel-proxy --all-targets -- -D warnings` — clean
- `cargo fmt --all` — touched only this file
- `upstream::health` tests pass (4)

Diff is one file, +62 lines, of which the fix is 8 and the rest is the test and
its explanation. An MCP-specific health check type builds on this in a
follow-up; this stands alone and is worth landing on its own.

https://claude.ai/code/session_01VkHAQ33U78fmpk6r161DKc
