### PR TITLE
chore: bump version to 0.6.39 for release 26.09_2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8183,7 +8183,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.38"
+version = "0.6.39"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8224,7 +8224,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.38"
+version = "0.6.39"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8246,7 +8246,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.38"
+version = "0.6.39"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8325,7 +8325,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.38"
+version = "0.6.39"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8506,7 +8506,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.38"
+version = "0.6.39"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8597,7 +8597,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.38"
+version = "0.6.39"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8614,7 +8614,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.38"
+version = "0.6.39"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.38"
+version = "0.6.39"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/config-inspect/Cargo.toml
+++ b/crates/config-inspect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-config-inspect"
-version = "0.6.38"
+version = "0.6.39"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/playground-wasm/Cargo.toml
+++ b/crates/playground-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-playground-wasm"
-version = "0.6.38"
+version = "0.6.39"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/sim/Cargo.toml
+++ b/crates/sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-sim"
-version = "0.6.38"
+version = "0.6.39"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Post-release bump for 26.09_2. The Release workflow force-pushes this branch and
then fails to open the PR for it — this is the **seventh consecutive** release
where `gh pr create` produced nothing, so the branch is opened by hand as usual.

## Safety check done before opening

The orphan branch is only dangerous when `main` has moved past the release
commit, because it is created *from* that commit and merging it would revert
everything since. Checked rather than assumed:

```
$ git log --oneline origin/chore/bump-0.6.39..origin/main
(empty)

parent of branch: 50fb355
main:             50fb355
```

Identical, so this merges cleanly and reverts nothing.

## #445 worked — no manual Cargo.lock commit needed

Every previous release left this branch **`Cargo.toml`-only**, with `Cargo.lock`
a version behind, and needed a hand-added `cargo update --workspace` commit.
zentinelproxy/zentinel#445 fixed that, and this is the first release to prove it:

```
$ git diff origin/main origin/chore/bump-0.6.39 --stat
 Cargo.lock                        | 14 +++++++-------
 Cargo.toml                        |  2 +-
 crates/config-inspect/Cargo.toml  |  2 +-
 crates/playground-wasm/Cargo.toml |  2 +-
 crates/sim/Cargo.toml             |  2 +-
```

All seven workspace crates go 0.6.38 → 0.6.39 in `Cargo.lock`, and no external
dependency moves. Nothing to add by hand.

The `gh pr create` step is still broken, so that half of #445 remains
outstanding.

## Release verification

Verified against the crates.io API rather than the workflow's own status:

| Crate | Published |
|---|---|
| `zentinel-common` | 0.6.39 |
| `zentinel-config` | 0.6.39 |
| `zentinel-agent-protocol` | 0.6.39 |
| `zentinel-proxy` | 0.6.39 |

GitHub Release `26.09_2` reads `0.6.39`, matching the CHANGELOG and crates.io.
All four platform builds passed first time, including linux-arm64 where the
zigbuild toolchain flake usually appears.

https://claude.ai/code/session_01VkHAQ33U78fmpk6r161DKc
