### PR TITLE
feat(agentic): present several MCP servers as one endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8512,6 +8512,7 @@ dependencies = [
  "arc-swap",
  "async-memcached",
  "async-trait",
+ "aws-lc-rs",
  "base64 0.23.1",
  "brotli 8.0.4",
  "bytes",

--- a/crates/config/src/agentic.rs
+++ b/crates/config/src/agentic.rs
@@ -73,6 +73,46 @@ pub struct McpConfig {
     /// on a route where that trade is the wrong way round.
     #[serde(default = "default_true")]
     pub filter_tool_list: bool,
+    /// Upstream MCP servers presented to the client as one endpoint.
+    ///
+    /// Empty is the ordinary case: the route forwards to its own `upstream` and
+    /// nothing here applies. With entries, the route becomes a multiplexer —
+    /// `tools/list` is merged across them and a call is routed by the prefix on
+    /// its tool name.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub upstreams: Vec<McpUpstream>,
+    /// Key for the session token, hex-encoded, 32 bytes.
+    ///
+    /// Required once `upstreams` has more than one entry, because a client
+    /// session then spans several upstream sessions and the mapping between
+    /// them travels in the token rather than in the proxy.
+    ///
+    /// It must be configured rather than generated: a per-process key would
+    /// rotate on every reload and drop every live session, and two gateway
+    /// instances could not read each other's tokens — which is what would force
+    /// session affinity back onto the load balancer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_key: Option<String>,
+}
+
+/// One upstream MCP server behind a multiplexing route.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct McpUpstream {
+    /// The `upstreams` entry to forward to.
+    pub upstream: String,
+    /// Prefix applied to every tool this upstream offers.
+    ///
+    /// Declared rather than derived. A tool's name is what a model reasons
+    /// about, so it must not change because an unrelated upstream was added, or
+    /// because this one was renamed.
+    pub prefix: String,
+    /// Path to send MCP requests to on this upstream.
+    #[serde(default = "default_mcp_path")]
+    pub path: String,
+}
+
+fn default_mcp_path() -> String {
+    "/".to_string()
 }
 
 impl Default for McpConfig {
@@ -86,6 +126,8 @@ impl Default for McpConfig {
             validate_param_headers: true,
             on_uninspectable_body: UninspectableBody::Deny,
             filter_tool_list: true,
+            upstreams: Vec::new(),
+            session_key: None,
         }
     }
 }

--- a/crates/config/src/kdl/routes.rs
+++ b/crates/config/src/kdl/routes.rs
@@ -9,7 +9,7 @@ use zentinel_common::budget::{
     BudgetPeriod, CostAttributionConfig, ModelPricing, TokenBudgetConfig,
 };
 
-use crate::agentic::{A2aConfig, McpConfig, UninspectableBody, UnknownMethods};
+use crate::agentic::{A2aConfig, McpConfig, McpUpstream, UninspectableBody, UnknownMethods};
 use crate::filters::RateLimitKey;
 use crate::{kdl::retrypolicy_helper::parse_retry_policy, routes::*};
 use zentinel_common::types::ByteSize;
@@ -462,6 +462,83 @@ fn parse_optional_block<T>(
         .transpose()
 }
 
+/// A node's `name=value` property, as a string.
+///
+/// The shared helpers read *child nodes*; this reads a property on the node
+/// itself, which is the shape `upstream "docs" prefix="docs"` uses.
+fn get_string_prop(node: &kdl::KdlNode, name: &str) -> Option<String> {
+    node.entries()
+        .iter()
+        .find(|e| e.name().map(|n| n.value()) == Some(name))
+        .and_then(|e| e.value().as_string())
+        .map(|s| s.to_string())
+}
+
+/// Parse the `upstreams` block inside `mcp`.
+///
+/// ```kdl
+/// upstreams {
+///     upstream "docs" prefix="docs"
+///     upstream "warehouse" prefix="warehouse" path="/mcp"
+/// }
+/// ```
+fn parse_mcp_upstreams(node: &kdl::KdlNode) -> Result<Vec<McpUpstream>> {
+    let mut out: Vec<McpUpstream> = Vec::new();
+
+    let Some(children) = node.children() else {
+        return Ok(out);
+    };
+
+    for child in children.nodes() {
+        if child.name().value() != "upstream" {
+            return Err(anyhow::anyhow!(
+                "Unknown node '{}' in mcp upstreams block. Expected 'upstream'",
+                child.name().value()
+            ));
+        }
+
+        let upstream = get_first_arg_string(child).ok_or_else(|| {
+            anyhow::anyhow!("mcp upstream needs a name: upstream \"docs\" prefix=\"docs\"")
+        })?;
+
+        // Required, never derived from the upstream name. A tool's name is what
+        // a model reasons about; deriving it would rename every tool when an
+        // upstream is renamed.
+        let prefix = get_string_prop(child, "prefix").ok_or_else(|| {
+            anyhow::anyhow!(
+                "mcp upstream '{upstream}' needs a prefix: upstream \"{upstream}\" prefix=\"...\""
+            )
+        })?;
+
+        if prefix.contains('.') {
+            return Err(anyhow::anyhow!(
+                "mcp upstream '{upstream}' prefix '{prefix}' contains '.', which separates a \
+                 prefix from a tool name and would make routing ambiguous"
+            ));
+        }
+        if prefix.is_empty() {
+            return Err(anyhow::anyhow!(
+                "mcp upstream '{upstream}' has an empty prefix"
+            ));
+        }
+        if let Some(clash) = out.iter().find(|u| u.prefix == prefix) {
+            return Err(anyhow::anyhow!(
+                "mcp upstreams '{}' and '{upstream}' share the prefix '{prefix}'; every tool \
+                 from one would be indistinguishable from the other's",
+                clash.upstream
+            ));
+        }
+
+        out.push(McpUpstream {
+            path: get_string_prop(child, "path").unwrap_or_else(|| "/".to_string()),
+            upstream,
+            prefix,
+        });
+    }
+
+    Ok(out)
+}
+
 /// Parse a route's `mcp` block.
 ///
 /// ```kdl
@@ -494,6 +571,8 @@ fn parse_mcp_config(node: &kdl::KdlNode) -> Result<McpConfig> {
         config.filter_tool_list = value;
     }
 
+    config.session_key = get_string_entry(node, "session-key");
+
     config.on_uninspectable_body = match get_string_entry(node, "on-uninspectable-body").as_deref()
     {
         None => UninspectableBody::default(),
@@ -519,18 +598,22 @@ fn parse_mcp_config(node: &kdl::KdlNode) -> Result<McpConfig> {
                     config.allowed_tools = allow;
                     config.denied_tools = deny;
                 }
+                "upstreams" => {
+                    config.upstreams = parse_mcp_upstreams(child)?;
+                }
                 // Scalars already read above; anything else is a mistake worth
                 // naming, since a silently ignored key in a security policy is
                 // how a policy stops applying without anyone noticing.
                 "require-validated-version"
                 | "validate-param-headers"
                 | "filter-tool-list"
+                | "session-key"
                 | "on-uninspectable-body" => {}
                 other => {
                     return Err(anyhow::anyhow!(
                         "Unknown setting '{other}' in mcp block. Valid settings: \
                          require-validated-version, validate-param-headers, filter-tool-list, \
-                         on-uninspectable-body, methods, tools"
+                         session-key, on-uninspectable-body, methods, tools, upstreams"
                     ))
                 }
             }
@@ -2137,6 +2220,17 @@ mod tests {
                 .remove(0)
         }
 
+        /// Like `route_with`, but hands back the error instead of unwrapping —
+        /// for the cases where refusing the config *is* the behaviour.
+        fn route_result(body: &str) -> Result<Vec<crate::RouteConfig>> {
+            let kdl = format!(
+                "routes {{\n  route \"agentic\" {{\n    matches {{\n      path-prefix \"/mcp\"\n    }}\n\
+                 \x20   upstream \"backend\"\n{body}\n  }}\n}}\n"
+            );
+            let doc: kdl::KdlDocument = kdl.parse().expect("kdl should parse");
+            parse_routes(doc.nodes().first().expect("routes node"))
+        }
+
         #[test]
         fn a_route_without_an_mcp_block_has_no_mcp_policy() {
             assert!(route_with("").mcp.is_none());
@@ -2167,6 +2261,89 @@ mod tests {
         fn filter_tool_list_defaults_on() {
             let route = route_with("    mcp {\n      tools {\n        deny \"x\"\n      }\n    }");
             assert!(route.mcp.expect("parsed").filter_tool_list);
+        }
+
+        mod multiplexing {
+            use super::*;
+
+            #[test]
+            fn upstreams_and_prefixes_are_read() {
+                let route = route_with(
+                    "    mcp {\n      upstreams {\n        upstream \"docs\" prefix=\"docs\"\n        upstream \"wh\" prefix=\"warehouse\" path=\"/mcp\"\n      }\n    }",
+                );
+                let ups = route.mcp.expect("parsed").upstreams;
+                assert_eq!(ups.len(), 2);
+                assert_eq!(ups[0].upstream, "docs");
+                assert_eq!(ups[0].prefix, "docs");
+                assert_eq!(ups[0].path, "/", "path defaults to root");
+                assert_eq!(ups[1].upstream, "wh");
+                assert_eq!(ups[1].prefix, "warehouse");
+                assert_eq!(ups[1].path, "/mcp");
+            }
+
+            #[test]
+            fn the_session_key_is_read() {
+                let route = route_with("    mcp {\n      session-key \"abc123\"\n    }");
+                assert_eq!(
+                    route.mcp.expect("parsed").session_key.as_deref(),
+                    Some("abc123")
+                );
+            }
+
+            /// The ordinary route is untouched: no upstreams, no key, and none
+            /// of the multiplexing machinery applies.
+            #[test]
+            fn a_route_without_the_block_multiplexes_nothing() {
+                let route =
+                    route_with("    mcp {\n      tools {\n        deny \"x\"\n      }\n    }");
+                let mcp = route.mcp.expect("parsed");
+                assert!(mcp.upstreams.is_empty());
+                assert!(mcp.session_key.is_none());
+            }
+
+            /// Deriving the prefix from the upstream name was rejected, so a
+            /// missing one is an error rather than a default.
+            #[test]
+            fn a_missing_prefix_is_refused() {
+                let err = route_result(
+                    "    mcp {\n      upstreams {\n        upstream \"docs\"\n      }\n    }",
+                )
+                .expect_err("should refuse");
+                assert!(err.to_string().contains("needs a prefix"), "{err}");
+            }
+
+            /// Two upstreams sharing a prefix would make every tool from one
+            /// indistinguishable from the other's.
+            #[test]
+            fn duplicate_prefixes_are_refused() {
+                let err = route_result(
+                    "    mcp {\n      upstreams {\n        upstream \"a\" prefix=\"p\"\n        upstream \"b\" prefix=\"p\"\n      }\n    }",
+                )
+                .expect_err("should refuse");
+                assert!(err.to_string().contains("share the prefix"), "{err}");
+            }
+
+            /// The separator in a prefix would make routing ambiguous.
+            #[test]
+            fn a_prefix_containing_the_separator_is_refused() {
+                let err = route_result(
+                    "    mcp {\n      upstreams {\n        upstream \"a\" prefix=\"a.b\"\n      }\n    }",
+                )
+                .expect_err("should refuse");
+                assert!(
+                    err.to_string().contains("would make routing ambiguous"),
+                    "{err}"
+                );
+            }
+
+            #[test]
+            fn an_unknown_node_in_the_block_is_refused() {
+                let err = route_result(
+                    "    mcp {\n      upstreams {\n        server \"a\" prefix=\"p\"\n      }\n    }",
+                )
+                .expect_err("should refuse");
+                assert!(err.to_string().contains("Expected 'upstream'"), "{err}");
+            }
         }
 
         #[test]

--- a/crates/proxy/Cargo.toml
+++ b/crates/proxy/Cargo.toml
@@ -70,6 +70,8 @@ url = "2.5"
 
 # HMAC for cookie signing (sticky sessions)
 hmac = "0.13"
+# Already in the tree via rustls; used directly for the MCP session token's AEAD.
+aws-lc-rs = "1.16"
 
 # Utilities
 uuid = { workspace = true }

--- a/crates/proxy/src/agentic/gateway.rs
+++ b/crates/proxy/src/agentic/gateway.rs
@@ -1,0 +1,222 @@
+//! Talking MCP to an upstream on the gateway's own behalf.
+//!
+//! A multiplexing route cannot be served by forwarding. `tools/list` has to ask
+//! every upstream and merge what comes back, which is N requests where proxying
+//! makes one; and the merged answer is something the gateway composes rather
+//! than relays. So for these routes Zentinel stops forwarding and originates —
+//! the same inversion [#443] identifies for serving MCP generally, arriving
+//! early and in a much narrower form.
+//!
+//! **What that costs, stated plainly:** these requests do not use Pingora's
+//! connection pool, its retry policy, or its per-peer TLS settings. They *do*
+//! still go through the route's `UpstreamPool`, so load balancing, service
+//! discovery and health checking all apply — a fan-out reaches the same targets
+//! a proxied request would. Putting tool calls back on the proxy path, and
+//! keeping only the listing fan-out here, is a worthwhile follow-up; it needs
+//! body-driven peer selection, which is a larger change than this.
+//!
+//! [#443]: https://github.com/zentinelproxy/zentinel/issues/443
+
+use std::time::Duration;
+
+use serde_json::Value;
+
+/// Protocol revision the gateway announces upstream.
+pub const PROTOCOL_VERSION: &str = "2026-07-28";
+
+/// Header carrying a session, in the casing the spec uses.
+pub const SESSION_HEADER: &str = "Mcp-Session-Id";
+
+/// How long any single upstream call may take.
+const UPSTREAM_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Largest upstream response the gateway will read.
+const MAX_RESPONSE_BYTES: usize = 1024 * 1024;
+
+/// What an upstream said.
+pub struct UpstreamReply {
+    /// The JSON-RPC document.
+    pub doc: Value,
+    /// A session ID the upstream issued, if it did.
+    pub session: Option<String>,
+}
+
+/// Why a call to an upstream did not produce a usable reply.
+#[derive(Debug)]
+pub enum GatewayError {
+    /// The upstream could not be reached or did not answer in time.
+    Unreachable(String),
+    /// The upstream answered, but not with a JSON-RPC document.
+    Malformed(String),
+}
+
+impl std::fmt::Display for GatewayError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unreachable(e) => write!(f, "upstream unreachable: {e}"),
+            Self::Malformed(e) => write!(f, "upstream reply not usable: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for GatewayError {}
+
+/// The HTTP client used for gateway-originated MCP calls.
+///
+/// One client, built once: it owns a connection pool, and building one per
+/// request would open a fresh connection to every upstream on every fan-out.
+pub fn client() -> &'static reqwest::Client {
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .timeout(UPSTREAM_TIMEOUT)
+            .build()
+            .unwrap_or_default()
+    })
+}
+
+/// Send one JSON-RPC message to an upstream and read its reply.
+pub async fn call(
+    url: &str,
+    body: &Value,
+    session: Option<&str>,
+) -> Result<UpstreamReply, GatewayError> {
+    let mut req = client()
+        .post(url)
+        .header("content-type", "application/json")
+        // Both framings, because a Streamable HTTP server may answer either and
+        // a gateway that accepted only one would fail against conforming
+        // servers.
+        .header("accept", "application/json, text/event-stream")
+        .header("mcp-protocol-version", PROTOCOL_VERSION);
+
+    if let Some(s) = session {
+        req = req.header(SESSION_HEADER, s);
+    }
+
+    let resp = req
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| GatewayError::Unreachable(e.to_string()))?;
+
+    let status = resp.status();
+    let issued = resp
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| GatewayError::Unreachable(e.to_string()))?;
+
+    if !status.is_success() {
+        return Err(GatewayError::Unreachable(format!("HTTP {status}")));
+    }
+    if text.len() > MAX_RESPONSE_BYTES {
+        return Err(GatewayError::Malformed(format!(
+            "reply is {} bytes, over the {MAX_RESPONSE_BYTES} limit",
+            text.len()
+        )));
+    }
+
+    let doc = parse_reply(&text)?;
+    Ok(UpstreamReply {
+        doc,
+        session: issued,
+    })
+}
+
+/// Parse a reply that may be plain JSON or a Streamable HTTP event.
+pub fn parse_reply(text: &str) -> Result<Value, GatewayError> {
+    let payload = if text.contains("data:") {
+        text.lines()
+            .filter_map(|l| l.strip_prefix("data:"))
+            .map(|l| l.strip_prefix(' ').unwrap_or(l))
+            .collect::<Vec<_>>()
+            .join("\n")
+    } else {
+        text.to_string()
+    };
+
+    serde_json::from_str(payload.trim()).map_err(|e| {
+        let preview: String = payload.trim().chars().take(200).collect();
+        GatewayError::Malformed(format!("{e}: {preview}"))
+    })
+}
+
+/// The `initialize` message the gateway sends to open an upstream session.
+pub fn initialize_body() -> Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "zentinel-init",
+        "method": "initialize",
+        "params": {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": { "name": "zentinel-gateway", "version": "1.0" },
+        },
+    })
+}
+
+/// A JSON-RPC error response, for telling the client something the gateway
+/// itself decided.
+pub fn error_response(id: &Value, code: i64, message: &str) -> Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": { "code": code, "message": message },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_plain_json_reply_parses() {
+        let doc = parse_reply(r#"{"jsonrpc":"2.0","id":1,"result":{}}"#).expect("parsed");
+        assert_eq!(doc["id"], 1);
+    }
+
+    /// Streamable HTTP wraps the reply in an event; a gateway that only read
+    /// `application/json` would fail against a conforming server.
+    #[test]
+    fn an_event_stream_reply_parses() {
+        let doc =
+            parse_reply("event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n\n")
+                .expect("parsed");
+        assert_eq!(doc["id"], 1);
+    }
+
+    #[test]
+    fn a_multi_line_data_payload_is_reassembled() {
+        let doc = parse_reply("data: {\"jsonrpc\":\"2.0\",\ndata: \"id\":7}\n\n").expect("parsed");
+        assert_eq!(doc["id"], 7);
+    }
+
+    /// The error names what came back, truncated, because "not JSON" alone
+    /// sends an operator to the wrong place.
+    #[test]
+    fn a_non_json_reply_is_reported_with_a_preview() {
+        let err = parse_reply("<html>gateway timeout</html>").expect_err("should fail");
+        assert!(format!("{err}").contains("<html>"), "{err}");
+    }
+
+    #[test]
+    fn the_initialize_body_announces_the_protocol_version() {
+        let b = initialize_body();
+        assert_eq!(b["method"], "initialize");
+        assert_eq!(b["params"]["protocolVersion"], PROTOCOL_VERSION);
+    }
+
+    #[test]
+    fn an_error_response_carries_the_requests_id() {
+        let r = error_response(&Value::from("req-3"), -32601, "no such tool");
+        assert_eq!(r["id"], "req-3");
+        assert_eq!(r["error"]["code"], -32601);
+        assert_eq!(r["error"]["message"], "no such tool");
+    }
+}

--- a/crates/proxy/src/agentic/mod.rs
+++ b/crates/proxy/src/agentic/mod.rs
@@ -25,9 +25,13 @@
 //! contents are safe.
 
 pub mod a2a;
+pub mod gateway;
 pub mod jsonrpc;
 pub mod listing;
 pub mod mcp;
+pub mod multiplex;
+pub mod namespace;
+pub mod session;
 
 use zentinel_config::agentic::{
     A2aConfig, McpConfig, UninspectableBody as ConfigUninspectable, UnknownMethods as ConfigUnknown,
@@ -175,6 +179,8 @@ mod conversion_tests {
             // non-default here so that if it ever *is* added to `Policy`, this
             // test is already exercising the interesting value.
             filter_tool_list: false,
+            upstreams: Vec::new(),
+            session_key: None,
         };
         let p = mcp::Policy::from(&cfg);
 

--- a/crates/proxy/src/agentic/multiplex.rs
+++ b/crates/proxy/src/agentic/multiplex.rs
@@ -1,0 +1,439 @@
+//! Presenting several MCP upstreams to a client as one server.
+//!
+//! A multiplexing route answers `tools/list` by asking each upstream and
+//! merging what comes back, with every tool name carrying its upstream's
+//! prefix. A `tools/call` then arrives naming one of those prefixed tools, and
+//! is routed to the upstream that prefix belongs to with the prefix stripped.
+//!
+//! The pieces this composes are deliberately separate and separately tested:
+//! [`super::namespace`] owns the name mapping, [`super::session`] owns the
+//! per-client session state, and [`super::listing`] owns filtering a listing to
+//! what a route permits. This module is the part that knows they go together.
+//!
+//! # Order of operations, and why it is this way
+//!
+//! Merge and namespace **before** filtering. The route's `allow`/`deny` lists
+//! name tools as a client sees them — `docs.search`, not `search` — because
+//! that is the only name an operator can write down when two upstreams both
+//! offer `search`. Filtering first would apply the list to bare names, and a
+//! rule meant for one upstream would silently apply to every upstream offering
+//! the same tool.
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+use zentinel_config::agentic::{McpConfig, McpUpstream};
+
+use super::namespace;
+use super::session::{SessionCodec, SessionError};
+
+/// A route's multiplexing configuration, once validated.
+///
+/// Its [`std::fmt::Debug`] omits the codec, which holds key material.
+pub struct Multiplexer {
+    upstreams: Vec<McpUpstream>,
+    codec: SessionCodec,
+}
+
+impl std::fmt::Debug for Multiplexer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Multiplexer")
+            .field("upstreams", &self.upstreams)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Why a route's multiplexing configuration cannot be used.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ConfigError {
+    /// More than one upstream but no `session-key`.
+    MissingSessionKey,
+    /// The key was not 64 hex characters.
+    BadSessionKey(String),
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingSessionKey => write!(
+                f,
+                "an mcp block with more than one upstream needs `session-key`, because a client \
+                 session then spans several upstream sessions"
+            ),
+            Self::BadSessionKey(why) => write!(f, "mcp session-key is unusable: {why}"),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+impl Multiplexer {
+    /// Build a multiplexer from a route's `mcp` block, or `None` when the route
+    /// does not multiplex.
+    ///
+    /// A single upstream needs no session token: there is exactly one upstream
+    /// session and the client's own `Mcp-Session-Id` can be passed straight
+    /// through. The key only becomes necessary at two.
+    pub fn from_config(cfg: &McpConfig) -> Result<Option<Self>, ConfigError> {
+        if cfg.upstreams.len() < 2 {
+            return Ok(None);
+        }
+
+        let key_hex = cfg
+            .session_key
+            .as_deref()
+            .ok_or(ConfigError::MissingSessionKey)?;
+        let key = decode_key(key_hex)?;
+        let codec =
+            SessionCodec::new(&key).map_err(|e| ConfigError::BadSessionKey(e.to_string()))?;
+
+        Ok(Some(Self {
+            upstreams: cfg.upstreams.clone(),
+            codec,
+        }))
+    }
+
+    /// The upstreams this route fans out to.
+    pub fn upstreams(&self) -> &[McpUpstream] {
+        &self.upstreams
+    }
+
+    /// The configured prefixes, in declaration order.
+    pub fn prefixes(&self) -> Vec<String> {
+        self.upstreams.iter().map(|u| u.prefix.clone()).collect()
+    }
+
+    /// Which upstream a call to `qualified` belongs to, and its name there.
+    pub fn route(&self, qualified: &str) -> Option<(&McpUpstream, String)> {
+        let (prefix, bare) = namespace::split(qualified)?;
+        self.upstreams
+            .iter()
+            .find(|u| u.prefix == prefix)
+            .map(|u| (u, bare.to_string()))
+    }
+
+    /// Read the per-upstream sessions out of a client's `Mcp-Session-Id`.
+    ///
+    /// A token that does not decrypt yields an empty map rather than an error:
+    /// to a client that is the same as not having a session yet, which is a
+    /// state MCP already requires servers to handle. Returning an error would
+    /// turn a rotated key into a wall of failures rather than a wave of
+    /// re-initialisations.
+    pub fn sessions(&self, token: Option<&str>) -> BTreeMap<String, String> {
+        token
+            .and_then(|t| self.codec.decode(t).ok())
+            .unwrap_or_default()
+    }
+
+    /// Build the `Mcp-Session-Id` to hand back to the client.
+    pub fn token(&self, sessions: &BTreeMap<String, String>) -> Result<String, SessionError> {
+        self.codec.encode(sessions)
+    }
+}
+
+/// Decode a 64-character hex key into 32 bytes.
+fn decode_key(hex: &str) -> Result<Vec<u8>, ConfigError> {
+    if hex.len() != 64 {
+        return Err(ConfigError::BadSessionKey(format!(
+            "expected 64 hex characters (32 bytes), got {}",
+            hex.len()
+        )));
+    }
+    (0..64)
+        .step_by(2)
+        .map(|i| {
+            u8::from_str_radix(&hex[i..i + 2], 16)
+                .map_err(|_| ConfigError::BadSessionKey("expected hex characters only".to_string()))
+        })
+        .collect()
+}
+
+/// Merge one upstream's listing into an accumulating result.
+///
+/// Entries are namespaced on the way in, so what the client is shown is what
+/// [`Multiplexer::route`] can route back.
+pub fn merge_listing(into: &mut Vec<Value>, mut entries: Vec<Value>, prefix: &str) {
+    namespace::qualify_listing(&mut entries, prefix);
+    into.append(&mut entries);
+}
+
+/// Remove from a merged listing the entries a call would be refused.
+///
+/// The route's allow/deny lists name tools as the client sees them —
+/// `docs.search`, not `search` — so this runs **after** merging and
+/// namespacing. Filtering each upstream's listing before the prefix was applied
+/// would match rules against bare names, and a rule meant for one upstream
+/// would silently apply to every upstream offering the same tool.
+///
+/// Returns how many entries were removed.
+pub fn filter_merged(
+    entries: &mut Vec<Value>,
+    allowed: &std::collections::HashSet<String>,
+    denied: &std::collections::HashSet<String>,
+) -> usize {
+    if allowed.is_empty() && denied.is_empty() {
+        return 0;
+    }
+    let before = entries.len();
+    entries.retain(|e| match e.get("name").and_then(Value::as_str) {
+        Some(name) => super::mcp::permitted(name, allowed, denied),
+        // Kept: the enforcer would not refuse a call it cannot name either.
+        None => true,
+    });
+    before - entries.len()
+}
+
+/// Extract the entry array of a listing response, if it has one.
+pub fn entries_of(doc: &Value, field: &str) -> Option<Vec<Value>> {
+    doc.get("result")
+        .and_then(|r| r.get(field))
+        .and_then(Value::as_array)
+        .cloned()
+}
+
+/// Build a JSON-RPC response carrying a merged listing.
+pub fn listing_response(id: &Value, field: &str, entries: Vec<Value>) -> Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": { field: entries },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KEY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    fn upstream(name: &str, prefix: &str) -> McpUpstream {
+        McpUpstream {
+            upstream: name.to_string(),
+            prefix: prefix.to_string(),
+            path: "/".to_string(),
+        }
+    }
+
+    fn cfg(upstreams: Vec<McpUpstream>, key: Option<&str>) -> McpConfig {
+        McpConfig {
+            upstreams,
+            session_key: key.map(str::to_string),
+            ..McpConfig::default()
+        }
+    }
+
+    /// The ordinary route: no upstreams declared, nothing multiplexes, and no
+    /// session key is demanded of anyone who is not using the feature.
+    #[test]
+    fn a_route_with_no_upstreams_does_not_multiplex() {
+        assert!(Multiplexer::from_config(&cfg(vec![], None))
+            .expect("ok")
+            .is_none());
+    }
+
+    /// One upstream needs no token: there is a single upstream session and the
+    /// client's own header can pass straight through.
+    #[test]
+    fn a_single_upstream_needs_no_session_key() {
+        let c = cfg(vec![upstream("docs", "docs")], None);
+        assert!(Multiplexer::from_config(&c).expect("ok").is_none());
+    }
+
+    /// Two upstreams without a key is a configuration error, not a silent
+    /// fallback to something that half works.
+    #[test]
+    fn two_upstreams_without_a_key_are_refused() {
+        let c = cfg(vec![upstream("a", "a"), upstream("b", "b")], None);
+        assert_eq!(
+            Multiplexer::from_config(&c).unwrap_err(),
+            ConfigError::MissingSessionKey
+        );
+    }
+
+    #[test]
+    fn a_malformed_key_is_refused_with_the_reason() {
+        let c = cfg(vec![upstream("a", "a"), upstream("b", "b")], Some("abc"));
+        let err = Multiplexer::from_config(&c).unwrap_err();
+        assert!(format!("{err}").contains("got 3"), "{err}");
+
+        let c = cfg(
+            vec![upstream("a", "a"), upstream("b", "b")],
+            Some(&"z".repeat(64)),
+        );
+        let err = Multiplexer::from_config(&c).unwrap_err();
+        assert!(format!("{err}").contains("hex characters only"), "{err}");
+    }
+
+    #[test]
+    fn a_call_routes_by_its_prefix() {
+        let c = cfg(
+            vec![upstream("docs", "docs"), upstream("wh", "warehouse")],
+            Some(KEY),
+        );
+        let m = Multiplexer::from_config(&c)
+            .expect("ok")
+            .expect("multiplexer");
+
+        let (up, bare) = m.route("warehouse.query").expect("routed");
+        assert_eq!(up.upstream, "wh");
+        assert_eq!(bare, "query");
+
+        assert!(m.route("unknown.thing").is_none());
+        assert!(m.route("unqualified").is_none());
+    }
+
+    #[test]
+    fn sessions_round_trip_through_the_token() {
+        let c = cfg(
+            vec![upstream("docs", "docs"), upstream("wh", "warehouse")],
+            Some(KEY),
+        );
+        let m = Multiplexer::from_config(&c)
+            .expect("ok")
+            .expect("multiplexer");
+
+        let mut s = BTreeMap::new();
+        s.insert("docs".to_string(), "sess-a1".to_string());
+        let token = m.token(&s).expect("encoded");
+        assert_eq!(m.sessions(Some(&token)), s);
+    }
+
+    /// A client with no session, or one holding a token this gateway cannot
+    /// read, is treated as not having a session yet — a state MCP already
+    /// requires servers to handle. Erroring instead would turn a key rotation
+    /// into a wall of failures rather than a wave of re-initialisations.
+    #[test]
+    fn an_absent_or_unreadable_token_reads_as_no_sessions() {
+        let c = cfg(
+            vec![upstream("docs", "docs"), upstream("wh", "warehouse")],
+            Some(KEY),
+        );
+        let m = Multiplexer::from_config(&c)
+            .expect("ok")
+            .expect("multiplexer");
+
+        assert!(m.sessions(None).is_empty());
+        assert!(m.sessions(Some("nonsense")).is_empty());
+    }
+
+    #[test]
+    fn merging_namespaces_each_upstreams_entries() {
+        let mut merged = Vec::new();
+        merge_listing(
+            &mut merged,
+            serde_json::from_str(r#"[{"name":"search"}]"#).expect("json"),
+            "docs",
+        );
+        merge_listing(
+            &mut merged,
+            serde_json::from_str(r#"[{"name":"search"},{"name":"query"}]"#).expect("json"),
+            "warehouse",
+        );
+
+        let names: Vec<&str> = merged
+            .iter()
+            .map(|e| e["name"].as_str().expect("name"))
+            .collect();
+        assert_eq!(
+            names,
+            ["docs.search", "warehouse.search", "warehouse.query"]
+        );
+    }
+
+    /// The collision that motivates the whole feature: both upstreams offer
+    /// `search`, and after merging the client can still reach either.
+    #[test]
+    fn a_collision_survives_the_merge_and_still_routes() {
+        let c = cfg(
+            vec![upstream("docs", "docs"), upstream("wh", "warehouse")],
+            Some(KEY),
+        );
+        let m = Multiplexer::from_config(&c)
+            .expect("ok")
+            .expect("multiplexer");
+
+        let mut merged = Vec::new();
+        merge_listing(
+            &mut merged,
+            serde_json::from_str(r#"[{"name":"search"}]"#).expect("json"),
+            "docs",
+        );
+        merge_listing(
+            &mut merged,
+            serde_json::from_str(r#"[{"name":"search"}]"#).expect("json"),
+            "warehouse",
+        );
+
+        for entry in &merged {
+            let advertised = entry["name"].as_str().expect("name");
+            assert!(m.route(advertised).is_some(), "cannot route {advertised}");
+        }
+        assert_eq!(m.route("docs.search").expect("routed").0.upstream, "docs");
+        assert_eq!(
+            m.route("warehouse.search").expect("routed").0.upstream,
+            "wh"
+        );
+    }
+
+    /// The route's lists name tools as the client sees them, so filtering
+    /// happens after the prefix is applied.
+    #[test]
+    fn a_merged_listing_is_filtered_on_namespaced_names() {
+        let mut merged = Vec::new();
+        merge_listing(
+            &mut merged,
+            serde_json::from_str(r#"[{"name":"search"},{"name":"execute_sql"}]"#).expect("json"),
+            "docs",
+        );
+        merge_listing(
+            &mut merged,
+            serde_json::from_str(r#"[{"name":"execute_sql"}]"#).expect("json"),
+            "warehouse",
+        );
+
+        let denied: std::collections::HashSet<String> =
+            ["docs.execute_sql".to_string()].into_iter().collect();
+        let hidden = filter_merged(&mut merged, &Default::default(), &denied);
+
+        assert_eq!(hidden, 1);
+        let names: Vec<&str> = merged
+            .iter()
+            .map(|e| e["name"].as_str().expect("name"))
+            .collect();
+        // Only the one that was named: the other upstream's identically-named
+        // tool is untouched, which is the whole reason rules name the prefix.
+        assert_eq!(names, ["docs.search", "warehouse.execute_sql"]);
+    }
+
+    #[test]
+    fn a_route_naming_no_tools_filters_nothing() {
+        let mut merged: Vec<Value> =
+            serde_json::from_str(r#"[{"name":"docs.search"}]"#).expect("json");
+        assert_eq!(
+            filter_merged(&mut merged, &Default::default(), &Default::default()),
+            0
+        );
+        assert_eq!(merged.len(), 1);
+    }
+
+    #[test]
+    fn entries_are_read_out_of_a_listing_response() {
+        let doc: Value =
+            serde_json::from_str(r#"{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"a"}]}}"#)
+                .expect("json");
+        assert_eq!(entries_of(&doc, "tools").expect("entries").len(), 1);
+        assert!(entries_of(&doc, "prompts").is_none());
+
+        let err: Value =
+            serde_json::from_str(r#"{"jsonrpc":"2.0","id":1,"error":{"code":-1}}"#).expect("json");
+        assert!(entries_of(&err, "tools").is_none());
+    }
+
+    #[test]
+    fn a_merged_response_keeps_the_requests_id() {
+        let r = listing_response(&Value::from("req-7"), "tools", vec![]);
+        assert_eq!(r["id"], "req-7");
+        assert_eq!(r["jsonrpc"], "2.0");
+        assert!(r["result"]["tools"].as_array().expect("array").is_empty());
+    }
+}

--- a/crates/proxy/src/agentic/namespace.rs
+++ b/crates/proxy/src/agentic/namespace.rs
@@ -1,0 +1,190 @@
+//! Namespacing tool names across several MCP upstreams.
+//!
+//! When one endpoint fronts several upstreams, two of them will eventually both
+//! offer `search`. The client sees one merged list, so the collision has to be
+//! resolved before it gets there.
+//!
+//! Each upstream declares a prefix in configuration and every one of its tools
+//! is exposed as `prefix.tool`. The alternative — prefixing only when a
+//! collision actually occurs — was rejected deliberately: a tool's name is what
+//! the model reasons about and stores, and having it change because someone
+//! added an unrelated upstream that happened to collide is the kind of implicit
+//! behaviour this proxy is supposed to refuse. Deriving the prefix from the
+//! upstream's own name was rejected for the same reason in reverse: names
+//! chosen for infrastructure reasons read poorly to a model, and renaming an
+//! upstream would rename its tools.
+//!
+//! The mapping is total and reversible, which is what lets the request path
+//! route by prefix and the response path present the merged view:
+//!
+//! ```text
+//! upstream "docs"      prefix "docs"       search  ->  docs.search
+//! upstream "warehouse" prefix "warehouse"  query   ->  warehouse.query
+//! ```
+
+use serde_json::Value;
+
+/// Separator between a prefix and the tool's own name.
+///
+/// A dot reads naturally to a model and is accepted by MCP, which places no
+/// constraint on tool-name characters beyond them being a string.
+pub const SEPARATOR: char = '.';
+
+/// Apply a prefix to a name.
+pub fn qualify(prefix: &str, name: &str) -> String {
+    format!("{prefix}{SEPARATOR}{name}")
+}
+
+/// Split a qualified name back into its prefix and the upstream's own name.
+///
+/// Splits on the **first** separator, so a tool whose own name contains a dot
+/// survives the round trip: `docs.v2.search` belongs to `docs` and is called
+/// upstream as `v2.search`.
+pub fn split(qualified: &str) -> Option<(&str, &str)> {
+    qualified.split_once(SEPARATOR)
+}
+
+/// The upstream a call is destined for, given the configured prefixes.
+///
+/// Returns `None` when the name carries no known prefix — which is a refusal,
+/// not a fallback. Guessing an upstream for an unqualified name would route a
+/// call somewhere the operator never said it should go.
+pub fn route<'a>(qualified: &str, prefixes: &'a [String]) -> Option<(&'a str, String)> {
+    let (prefix, rest) = split(qualified)?;
+    prefixes
+        .iter()
+        .find(|p| p.as_str() == prefix)
+        .map(|p| (p.as_str(), rest.to_string()))
+}
+
+/// Rewrite the `name` of each entry in one upstream's listing so it carries the
+/// upstream's prefix.
+///
+/// **Only `name`.** [`super::listing`] identifies an entry as `name` falling
+/// back to `uri`, and the fallback is deliberately not followed here: a resource
+/// URI is already a globally-scoped identifier, and `docs.file:///a.txt` is not
+/// a URI at all. Prefixing one would hand clients a value they cannot parse,
+/// resolve or compare, in order to solve a collision that URIs mostly do not
+/// have — two upstreams serving the same `file:///a.txt` is a real ambiguity but
+/// a rare one, where two upstreams both offering `search` is close to certain.
+///
+/// So tools and prompts, which carry bare names, are namespaced; resources are
+/// left alone and multiplexing them is out of scope until there is a URI-shaped
+/// answer. An entry with no `name` is passed through untouched rather than
+/// dropped: the enforcer would not refuse a call it cannot name either.
+pub fn qualify_listing(entries: &mut [Value], prefix: &str) {
+    for entry in entries {
+        let Some(obj) = entry.as_object_mut() else {
+            continue;
+        };
+        if let Some(Value::String(s)) = obj.get("name") {
+            let qualified = qualify(prefix, s);
+            obj.insert("name".to_string(), Value::String(qualified));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn prefixes(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn a_name_round_trips_through_its_prefix() {
+        let q = qualify("docs", "search");
+        assert_eq!(q, "docs.search");
+        assert_eq!(split(&q), Some(("docs", "search")));
+    }
+
+    /// Splitting on the first separator, so an upstream whose own tool names
+    /// contain dots is not mangled on the way through.
+    #[test]
+    fn a_tool_name_containing_the_separator_survives() {
+        let q = qualify("docs", "v2.search");
+        assert_eq!(q, "docs.v2.search");
+        assert_eq!(split(&q), Some(("docs", "v2.search")));
+    }
+
+    #[test]
+    fn a_call_routes_to_the_upstream_its_prefix_names() {
+        let p = prefixes(&["docs", "warehouse"]);
+        assert_eq!(
+            route("warehouse.query", &p),
+            Some(("warehouse", "query".to_string()))
+        );
+    }
+
+    /// An unqualified or unknown-prefix name is refused rather than guessed.
+    /// Picking an upstream here would send a call somewhere no one configured.
+    #[test]
+    fn an_unknown_or_missing_prefix_does_not_route() {
+        let p = prefixes(&["docs"]);
+        assert_eq!(route("search", &p), None);
+        assert_eq!(route("other.search", &p), None);
+    }
+
+    /// Two upstreams offering the same tool are distinguishable after
+    /// namespacing, which is the collision this exists to resolve.
+    #[test]
+    fn colliding_tools_become_distinct() {
+        assert_ne!(qualify("docs", "search"), qualify("wiki", "search"));
+    }
+
+    #[test]
+    fn a_listing_is_qualified_by_name() {
+        let mut entries: Vec<Value> =
+            serde_json::from_str(r#"[{"name":"search","description":"d"},{"name":"fetch"}]"#)
+                .expect("json");
+        qualify_listing(&mut entries, "docs");
+        assert_eq!(entries[0]["name"], "docs.search");
+        assert_eq!(entries[1]["name"], "docs.fetch");
+        // Everything else survives.
+        assert_eq!(entries[0]["description"], "d");
+    }
+
+    /// A resource URI is left alone. Prefixing it would produce
+    /// `docs.file:///a.txt`, which is not a URI and which no client could
+    /// resolve or compare — a mangler rather than a namespace.
+    #[test]
+    fn a_resource_uri_is_not_prefixed() {
+        let mut entries: Vec<Value> =
+            serde_json::from_str(r#"[{"uri":"file:///a.txt"}]"#).expect("json");
+        qualify_listing(&mut entries, "docs");
+        assert_eq!(entries[0]["uri"], "file:///a.txt");
+    }
+
+    /// An entry carrying both is namespaced on `name` only, so its URI stays
+    /// resolvable.
+    #[test]
+    fn an_entry_with_both_fields_keeps_its_uri() {
+        let mut entries: Vec<Value> =
+            serde_json::from_str(r#"[{"name":"n","uri":"file:///a.txt"}]"#).expect("json");
+        qualify_listing(&mut entries, "docs");
+        assert_eq!(entries[0]["name"], "docs.n");
+        assert_eq!(entries[0]["uri"], "file:///a.txt");
+    }
+
+    #[test]
+    fn an_unidentifiable_entry_is_left_alone() {
+        let mut entries: Vec<Value> =
+            serde_json::from_str(r#"[{"description":"no name"}]"#).expect("json");
+        qualify_listing(&mut entries, "docs");
+        assert_eq!(entries[0]["description"], "no name");
+        assert!(entries[0].get("name").is_none());
+    }
+
+    /// The namespaced name is what the route's allow/deny list from #457 sees,
+    /// so hiding and enforcement stay in agreement after merging.
+    #[test]
+    fn what_is_advertised_is_what_routes() {
+        let p = prefixes(&["docs"]);
+        let mut entries: Vec<Value> = serde_json::from_str(r#"[{"name":"search"}]"#).expect("json");
+        qualify_listing(&mut entries, "docs");
+
+        let advertised = entries[0]["name"].as_str().expect("name");
+        assert_eq!(route(advertised, &p), Some(("docs", "search".to_string())));
+    }
+}

--- a/crates/proxy/src/agentic/session.rs
+++ b/crates/proxy/src/agentic/session.rs
@@ -1,0 +1,356 @@
+//! The gateway's MCP session token.
+//!
+//! When one endpoint fronts several MCP upstreams, a single client session spans
+//! several server sessions: Streamable HTTP has each upstream issue its own
+//! `Mcp-Session-Id` on `initialize`, and a client that calls tools from two
+//! upstreams is holding two of them without knowing it. Something has to
+//! remember which is which.
+//!
+//! That mapping lives in the token itself rather than in the gateway. The
+//! `Mcp-Session-Id` handed to the client *is* an encrypted envelope containing
+//! the upstream session IDs, decrypted on each request. No shared store, nothing
+//! lost on restart, and two gateway instances can serve the same client without
+//! the load balancer being told to pin it — which matters, because the
+//! alternative is exporting an affinity requirement to the operator's
+//! infrastructure and calling it a design.
+//!
+//! # Two things this must get right
+//!
+//! **Encrypted, not signed.** [`crate::upstream::sticky_session`] signs a target
+//! index with HMAC and hands it to the client, which is fine: the index is not a
+//! secret. Upstream session IDs are, so this uses AEAD. A client must not be
+//! able to read them, and must not be able to forge one.
+//!
+//! **The key comes from configuration.** `StickySessionRuntime` generates its
+//! HMAC key with `rand::rng()` at construction, so it rotates on every rebuild
+//! and silently invalidates every cookie. Repeating that here would drop live
+//! MCP sessions on every config reload, and an MCP session is work in flight
+//! rather than a warm cache. A configured key is also what lets two instances
+//! decrypt each other's tokens.
+
+use std::collections::BTreeMap;
+
+use aws_lc_rs::aead::{Aad, LessSafeKey, Nonce, UnboundKey, AES_256_GCM, NONCE_LEN};
+use aws_lc_rs::rand::{SecureRandom, SystemRandom};
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+
+/// Largest token this will produce or accept, in encoded bytes.
+///
+/// Headers have limits and MCP does not say what they are, so the bound is
+/// ours: exceeded, the session is refused with an error naming the cause rather
+/// than truncated into a token that fails to decrypt later. At roughly 60 bytes
+/// per upstream entry this is comfortably past any realistic fan-out.
+pub const MAX_TOKEN_BYTES: usize = 4096;
+
+/// Why a token could not be produced or read.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SessionError {
+    /// The configured key was not 32 bytes.
+    KeyLength(usize),
+    /// The token did not decode, decrypt, or authenticate.
+    ///
+    /// Deliberately one variant. Distinguishing "wrong key" from "tampered" from
+    /// "truncated" in a value the client supplies tells an attacker which of
+    /// those they achieved.
+    Invalid,
+    /// The token would exceed [`MAX_TOKEN_BYTES`].
+    TooLarge(usize),
+}
+
+impl std::fmt::Display for SessionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::KeyLength(n) => {
+                write!(f, "session key must be 32 bytes, got {n}")
+            }
+            Self::Invalid => write!(f, "session token is not valid"),
+            Self::TooLarge(n) => write!(
+                f,
+                "session token would be {n} bytes, over the {MAX_TOKEN_BYTES} limit"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SessionError {}
+
+/// Encrypts and decrypts the gateway's session tokens.
+///
+/// Its [`std::fmt::Debug`] deliberately shows nothing about the key. A struct
+/// holding key material is exactly the sort of thing that ends up in a log line
+/// via `{:?}` on some enclosing type, and the default derive would put it there.
+pub struct SessionCodec {
+    key: LessSafeKey,
+    rng: SystemRandom,
+}
+
+impl std::fmt::Debug for SessionCodec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("SessionCodec { key: <redacted> }")
+    }
+}
+
+impl SessionCodec {
+    /// Build a codec from a 32-byte key.
+    pub fn new(key: &[u8]) -> Result<Self, SessionError> {
+        if key.len() != 32 {
+            return Err(SessionError::KeyLength(key.len()));
+        }
+        let unbound = UnboundKey::new(&AES_256_GCM, key).map_err(|_| SessionError::Invalid)?;
+        Ok(Self {
+            key: LessSafeKey::new(unbound),
+            rng: SystemRandom::new(),
+        })
+    }
+
+    /// Encrypt a map of upstream name to that upstream's session ID.
+    ///
+    /// The map is ordered, so the same set of sessions always serialises the
+    /// same way; the nonce is fresh per call, so the same map still produces a
+    /// different token each time.
+    pub fn encode(&self, sessions: &BTreeMap<String, String>) -> Result<String, SessionError> {
+        let plaintext = serialize(sessions);
+
+        let mut nonce_bytes = [0u8; NONCE_LEN];
+        self.rng
+            .fill(&mut nonce_bytes)
+            .map_err(|_| SessionError::Invalid)?;
+
+        let mut buf = plaintext.into_bytes();
+        self.key
+            .seal_in_place_append_tag(
+                Nonce::assume_unique_for_key(nonce_bytes),
+                Aad::empty(),
+                &mut buf,
+            )
+            .map_err(|_| SessionError::Invalid)?;
+
+        let mut envelope = Vec::with_capacity(NONCE_LEN + buf.len());
+        envelope.extend_from_slice(&nonce_bytes);
+        envelope.append(&mut buf);
+
+        let token = URL_SAFE_NO_PAD.encode(&envelope);
+        if token.len() > MAX_TOKEN_BYTES {
+            return Err(SessionError::TooLarge(token.len()));
+        }
+        Ok(token)
+    }
+
+    /// Decrypt a token back into its upstream sessions.
+    pub fn decode(&self, token: &str) -> Result<BTreeMap<String, String>, SessionError> {
+        if token.len() > MAX_TOKEN_BYTES {
+            return Err(SessionError::TooLarge(token.len()));
+        }
+
+        let envelope = URL_SAFE_NO_PAD
+            .decode(token)
+            .map_err(|_| SessionError::Invalid)?;
+        if envelope.len() <= NONCE_LEN {
+            return Err(SessionError::Invalid);
+        }
+
+        let (nonce_bytes, ciphertext) = envelope.split_at(NONCE_LEN);
+        let nonce: [u8; NONCE_LEN] = nonce_bytes.try_into().map_err(|_| SessionError::Invalid)?;
+
+        let mut buf = ciphertext.to_vec();
+        let plaintext = self
+            .key
+            .open_in_place(Nonce::assume_unique_for_key(nonce), Aad::empty(), &mut buf)
+            .map_err(|_| SessionError::Invalid)?;
+
+        deserialize(std::str::from_utf8(plaintext).map_err(|_| SessionError::Invalid)?)
+    }
+}
+
+/// `name=session` pairs joined by newlines.
+///
+/// Newline and `=` cannot appear in either field -- upstream names come from
+/// configuration and are validated there, and a session ID carrying one is
+/// refused rather than encoded, since a token that round-trips into a different
+/// map than it started as is worse than a rejected request.
+fn serialize(sessions: &BTreeMap<String, String>) -> String {
+    sessions
+        .iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn deserialize(s: &str) -> Result<BTreeMap<String, String>, SessionError> {
+    if s.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    s.lines()
+        .map(|line| {
+            line.split_once('=')
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .ok_or(SessionError::Invalid)
+        })
+        .collect()
+}
+
+/// Whether a session ID can be carried in a token.
+///
+/// Checked before encoding rather than after, because the failure it prevents
+/// is silent: a value containing the separator would decode into a different
+/// map than it was built from.
+pub fn is_encodable(session_id: &str) -> bool {
+    !session_id.contains('\n') && !session_id.contains('=')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KEY: &[u8; 32] = b"0123456789abcdef0123456789abcdef";
+
+    fn codec() -> SessionCodec {
+        SessionCodec::new(KEY).expect("valid key")
+    }
+
+    fn sessions(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn a_token_round_trips() {
+        let s = sessions(&[("docs", "sess-a1"), ("warehouse", "sess-b7")]);
+        let c = codec();
+        assert_eq!(
+            c.decode(&c.encode(&s).expect("encoded")).expect("decoded"),
+            s
+        );
+    }
+
+    #[test]
+    fn an_empty_map_round_trips() {
+        let c = codec();
+        let empty = BTreeMap::new();
+        assert_eq!(
+            c.decode(&c.encode(&empty).expect("encoded"))
+                .expect("decoded"),
+            empty
+        );
+    }
+
+    /// The whole point of choosing AEAD over a signature: a client holding the
+    /// token must not learn which upstreams exist or what their session IDs are.
+    #[test]
+    fn upstream_session_ids_are_not_readable_from_the_token() {
+        let s = sessions(&[("warehouse", "super-secret-session")]);
+        let token = codec().encode(&s).expect("encoded");
+        assert!(!token.contains("warehouse"));
+        assert!(!token.contains("super-secret-session"));
+        let decoded = URL_SAFE_NO_PAD.decode(&token).expect("base64");
+        let as_text = String::from_utf8_lossy(&decoded);
+        assert!(!as_text.contains("warehouse"));
+        assert!(!as_text.contains("super-secret-session"));
+    }
+
+    #[test]
+    fn a_tampered_token_is_refused() {
+        let c = codec();
+        let token = c
+            .encode(&sessions(&[("docs", "sess-a1")]))
+            .expect("encoded");
+
+        // Flip a bit in the ciphertext, keeping it valid base64.
+        let mut raw = URL_SAFE_NO_PAD.decode(&token).expect("base64");
+        let last = raw.len() - 1;
+        raw[last] ^= 0x01;
+        let tampered = URL_SAFE_NO_PAD.encode(&raw);
+
+        assert_eq!(c.decode(&tampered), Err(SessionError::Invalid));
+    }
+
+    /// A token from another deployment must not decrypt here.
+    #[test]
+    fn a_token_from_a_different_key_is_refused() {
+        let mine = codec();
+        let theirs = SessionCodec::new(b"ffffffffffffffffffffffffffffffff").expect("valid key");
+        let token = theirs
+            .encode(&sessions(&[("docs", "sess-a1")]))
+            .expect("encoded");
+        assert_eq!(mine.decode(&token), Err(SessionError::Invalid));
+    }
+
+    /// Two instances sharing a configured key can read each other's tokens.
+    /// This is what makes horizontal scaling work without load-balancer
+    /// affinity, and is the reason the key must not be per-process.
+    #[test]
+    fn two_codecs_with_the_same_key_interoperate() {
+        let a = codec();
+        let b = codec();
+        let s = sessions(&[("docs", "sess-a1")]);
+        assert_eq!(
+            b.decode(&a.encode(&s).expect("encoded")).expect("decoded"),
+            s
+        );
+    }
+
+    /// A fresh nonce per call, so identical sessions do not produce a stable
+    /// token a client could recognise or correlate across sessions.
+    #[test]
+    fn the_same_map_encodes_differently_each_time() {
+        let c = codec();
+        let s = sessions(&[("docs", "sess-a1")]);
+        assert_ne!(
+            c.encode(&s).expect("encoded"),
+            c.encode(&s).expect("encoded")
+        );
+    }
+
+    #[test]
+    fn garbage_is_refused_rather_than_panicking() {
+        let c = codec();
+        for bad in ["", "not base64 !!!", "aaaa", &"A".repeat(100)] {
+            assert!(c.decode(bad).is_err(), "accepted {bad:?}");
+        }
+    }
+
+    /// The error names the length it got, because "invalid key" on a config
+    /// value sends an operator looking in the wrong place.
+    #[test]
+    fn a_key_of_the_wrong_length_is_rejected_with_its_length() {
+        assert!(matches!(
+            SessionCodec::new(b"short").err(),
+            Some(SessionError::KeyLength(5))
+        ));
+        assert!(matches!(
+            SessionCodec::new(&[0u8; 16]).err(),
+            Some(SessionError::KeyLength(16))
+        ));
+        assert!(SessionCodec::new(&[0u8; 32]).is_ok());
+    }
+
+    #[test]
+    fn an_oversized_token_is_refused_both_ways() {
+        let c = codec();
+        let huge: BTreeMap<String, String> = (0..200)
+            .map(|i| {
+                (
+                    format!("upstream-{i:03}"),
+                    format!("session-{i:03}-{}", "x".repeat(40)),
+                )
+            })
+            .collect();
+        assert!(matches!(c.encode(&huge), Err(SessionError::TooLarge(_))));
+        assert!(matches!(
+            c.decode(&"A".repeat(MAX_TOKEN_BYTES + 1)),
+            Err(SessionError::TooLarge(_))
+        ));
+    }
+
+    /// A session ID carrying the separator would decode into a different map
+    /// than it was built from, so it is rejected before it can.
+    #[test]
+    fn session_ids_carrying_the_separator_are_not_encodable() {
+        assert!(is_encodable("sess-a1"));
+        assert!(!is_encodable("sess\na1"));
+        assert!(!is_encodable("sess=a1"));
+    }
+}

--- a/crates/proxy/src/proxy/http_trait.rs
+++ b/crates/proxy/src/proxy/http_trait.rs
@@ -1452,6 +1452,14 @@ impl ProxyHttp for ZentinelProxy {
             return Ok(true); // Filter handled request (e.g. CORS preflight)
         }
 
+        // A route fronting several MCP upstreams is answered here rather than
+        // forwarded: the upstream a call belongs to is named in the body, and a
+        // listing has to be merged from several answers. Costs nothing on any
+        // other route.
+        if self.serve_mcp_multiplex(session, ctx).await? {
+            return Ok(true);
+        }
+
         // Check for WebSocket upgrade requests
         let is_websocket_upgrade = session
             .req_header()
@@ -3874,6 +3882,16 @@ impl ProxyHttp for ZentinelProxy {
 // Helper methods for body streaming (not part of ProxyHttp trait)
 // =============================================================================
 
+/// The `Mcp-Session-Id` the client presented, if any.
+fn client_session(session: &Session) -> Option<String> {
+    session
+        .req_header()
+        .headers
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string)
+}
+
 /// The response's media type: lowercased, without parameters.
 ///
 /// Compared exactly rather than by prefix, because `application/jsonl` and
@@ -3892,6 +3910,394 @@ fn response_mime(resp: &ResponseHeader) -> Option<String> {
 }
 
 impl ZentinelProxy {
+    /// Serve a route that fronts several MCP upstreams as one endpoint.
+    ///
+    /// Returns `Ok(true)` when the response has been written and the request
+    /// must not be forwarded. A route that does not multiplex returns
+    /// `Ok(false)` immediately and pays nothing.
+    ///
+    /// This runs in `request_filter`, before a peer is chosen, because the
+    /// upstream a call belongs to is named in the body and nowhere else. The
+    /// mirrored `Mcp-Name` header could be read earlier, and is not: a client
+    /// that could nominate its own upstream would be choosing which server
+    /// executes its call.
+    async fn serve_mcp_multiplex(
+        &self,
+        session: &mut Session,
+        ctx: &mut RequestContext,
+    ) -> Result<bool, Box<Error>> {
+        use crate::agentic::{gateway, jsonrpc, listing, multiplex::Multiplexer, namespace};
+
+        let Some(mcp) = ctx.route_config.as_ref().and_then(|r| r.mcp.as_ref()) else {
+            return Ok(false);
+        };
+        let mux = match Multiplexer::from_config(mcp) {
+            Ok(None) => return Ok(false),
+            Ok(Some(m)) => m,
+            Err(e) => {
+                // A route configured to multiplex but unable to is refused
+                // rather than quietly forwarded to its single `upstream`,
+                // which would apply none of the policy the operator wrote.
+                error!(
+                    correlation_id = %ctx.trace_id,
+                    route_id = ?ctx.route_id,
+                    error = %e,
+                    "MCP multiplexing route is misconfigured"
+                );
+                return Err(Error::explain(ErrorType::HTTPStatus(500), e.to_string()));
+            }
+        };
+
+        // Read the whole envelope before deciding anything. Nothing has been
+        // forwarded at this point, so a refusal here costs the client one
+        // response and no upstream any work.
+        let mut body = Vec::new();
+        while let Some(chunk) = session.read_request_body().await? {
+            if body.len() + chunk.len() > jsonrpc::MAX_ENVELOPE_BYTES {
+                return Err(Error::explain(
+                    ErrorType::HTTPStatus(413),
+                    "MCP request body is larger than this route will parse",
+                ));
+            }
+            body.extend_from_slice(&chunk);
+        }
+
+        let envelope = match jsonrpc::parse(&body) {
+            Ok(e) => e,
+            Err(e) => {
+                return self
+                    .write_mcp_reply(
+                        session,
+                        ctx,
+                        &gateway::error_response(
+                            &serde_json::Value::Null,
+                            -32700,
+                            &format!("request is not a JSON-RPC message: {e:?}"),
+                        ),
+                        None,
+                    )
+                    .await
+            }
+        };
+
+        // The id is taken from the raw body, not from the envelope.
+        //
+        // `Envelope` normalises it to a String because policy and audit only
+        // need something to name the call by. JSON-RPC requires the response id
+        // to equal the request id *including its type*, so answering `42` with
+        // `"42"` is a protocol violation a strict client is entitled to reject.
+        let id = serde_json::from_slice::<serde_json::Value>(&body)
+            .ok()
+            .and_then(|v| v.get("id").cloned())
+            .unwrap_or(serde_json::Value::Null);
+        let method = envelope.method.clone().unwrap_or_default();
+
+        // Enforce the route's MCP policy here, because this path never reaches
+        // `evaluate_agentic_policy` -- that runs in `request_body_filter`, and
+        // a multiplexing route answers before the body is ever forwarded.
+        //
+        // Without this the short-circuit would silently disable every policy an
+        // operator wrote on the route, which is the failure this module's
+        // neighbours exist to prevent.
+        let headers: Vec<(String, String)> = session
+            .req_header()
+            .headers
+            .iter()
+            .filter_map(|(k, v)| {
+                v.to_str()
+                    .ok()
+                    .map(|v| (k.as_str().to_ascii_lowercase(), v.to_string()))
+            })
+            .collect();
+
+        if let crate::agentic::mcp::Decision::Deny { reason } =
+            crate::agentic::mcp::evaluate(&crate::agentic::mcp::Policy::from(mcp), &headers, &body)
+        {
+            warn!(
+                correlation_id = %ctx.trace_id,
+                route_id = ?ctx.route_id,
+                reason = %reason,
+                "MCP request denied on a multiplexing route"
+            );
+            self.metrics.record_blocked_request("mcp_policy");
+            let id = serde_json::from_slice::<serde_json::Value>(&body)
+                .ok()
+                .and_then(|v| v.get("id").cloned())
+                .unwrap_or(serde_json::Value::Null);
+            let doc = crate::agentic::gateway::error_response(&id, -32600, &reason.to_string());
+            return self.write_mcp_reply(session, ctx, &doc, None).await;
+        }
+
+        let mut sessions = mux.sessions(client_session(session).as_deref());
+
+        let reply = if let Some(field) = listing::listed_field(&method) {
+            let allowed: std::collections::HashSet<String> =
+                mcp.allowed_tools.iter().cloned().collect();
+            let denied: std::collections::HashSet<String> =
+                mcp.denied_tools.iter().cloned().collect();
+            self.mcp_merged_listing(
+                &mux,
+                &method,
+                field,
+                &id,
+                &mut sessions,
+                &allowed,
+                &denied,
+                ctx,
+            )
+            .await
+        } else if method == "initialize" {
+            // Answered by the gateway itself. Fanning out here would open a
+            // session on every upstream for a client that may use one, which is
+            // what lazy initialisation exists to avoid.
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": {
+                    "protocolVersion": gateway::PROTOCOL_VERSION,
+                    "capabilities": { "tools": {} },
+                    "serverInfo": { "name": "zentinel-gateway", "version": "1.0" },
+                },
+            })
+        } else if let Some(target) = envelope.target.as_deref() {
+            self.mcp_route_call(&mux, target, &body, &id, &mut sessions, ctx)
+                .await
+        } else {
+            gateway::error_response(
+                &id,
+                -32601,
+                &format!("{method} is not supported on a multiplexing route"),
+            )
+        };
+
+        let token = mux.token(&sessions).ok();
+        self.write_mcp_reply(session, ctx, &reply, token.as_deref())
+            .await
+    }
+
+    /// Ask every upstream for its listing and merge the answers.
+    ///
+    /// An upstream that fails is logged and skipped rather than failing the
+    /// whole listing: one unreachable server should cost the client that
+    /// server's tools, not all of them.
+    async fn mcp_merged_listing(
+        &self,
+        mux: &crate::agentic::multiplex::Multiplexer,
+        method: &str,
+        field: &'static str,
+        id: &serde_json::Value,
+        sessions: &mut std::collections::BTreeMap<String, String>,
+        allowed: &std::collections::HashSet<String>,
+        denied: &std::collections::HashSet<String>,
+        ctx: &RequestContext,
+    ) -> serde_json::Value {
+        use crate::agentic::{gateway, multiplex};
+
+        let request = serde_json::json!({
+            "jsonrpc": "2.0", "id": "zentinel-list", "method": method,
+        });
+
+        let mut merged = Vec::new();
+        for up in mux.upstreams() {
+            let Some(url) = self.mcp_upstream_url(&up.upstream, &up.path, ctx).await else {
+                warn!(
+                    correlation_id = %ctx.trace_id,
+                    upstream = %up.upstream,
+                    "MCP upstream has no reachable target; its tools are omitted"
+                );
+                continue;
+            };
+
+            match gateway::call(&url, &request, sessions.get(&up.prefix).map(String::as_str)).await
+            {
+                Ok(reply) => {
+                    if let Some(s) = reply.session {
+                        sessions.insert(up.prefix.clone(), s);
+                    }
+                    if let Some(entries) = multiplex::entries_of(&reply.doc, field) {
+                        multiplex::merge_listing(&mut merged, entries, &up.prefix);
+                    }
+                }
+                Err(e) => warn!(
+                    correlation_id = %ctx.trace_id,
+                    upstream = %up.upstream,
+                    error = %e,
+                    "MCP upstream did not answer a listing; its tools are omitted"
+                ),
+            }
+        }
+
+        // The route's allow/deny lists apply to the merged, namespaced view --
+        // the names the client actually sees. Advertising a tool this route
+        // would refuse a call to is the defect #457 fixed for a single
+        // upstream; it must not come back on the multiplexed path.
+        let hidden = multiplex::filter_merged(&mut merged, allowed, denied);
+        if hidden > 0 {
+            debug!(
+                correlation_id = %ctx.trace_id,
+                route_id = ?ctx.route_id,
+                hidden = hidden,
+                "Hid merged MCP entries this route would refuse a call to"
+            );
+            self.metrics.record_mcp_listing_filtered(
+                ctx.route_id.as_deref().unwrap_or("unknown"),
+                method,
+                hidden as u64,
+            );
+        }
+
+        multiplex::listing_response(id, field, merged)
+    }
+
+    /// Route one call to the upstream its prefix names.
+    async fn mcp_route_call(
+        &self,
+        mux: &crate::agentic::multiplex::Multiplexer,
+        target: &str,
+        body: &[u8],
+        id: &serde_json::Value,
+        sessions: &mut std::collections::BTreeMap<String, String>,
+        ctx: &RequestContext,
+    ) -> serde_json::Value {
+        use crate::agentic::gateway;
+
+        let Some((up, bare)) = mux.route(target) else {
+            // Not a guess. Picking an upstream for an unqualified name would
+            // send the call somewhere nobody configured.
+            return gateway::error_response(
+                id,
+                -32602,
+                &format!("\"{target}\" does not name a tool on this endpoint"),
+            );
+        };
+
+        let Some(url) = self.mcp_upstream_url(&up.upstream, &up.path, ctx).await else {
+            return gateway::error_response(id, -32603, "upstream is not reachable");
+        };
+
+        // Rewrite the call to the name the upstream knows it by.
+        let mut outbound: serde_json::Value = match serde_json::from_slice(body) {
+            Ok(v) => v,
+            Err(e) => return gateway::error_response(id, -32700, &e.to_string()),
+        };
+        for field in ["name", "uri"] {
+            if let Some(params) = outbound.get_mut("params").and_then(|p| p.as_object_mut()) {
+                if params.get(field).and_then(|v| v.as_str()) == Some(target) {
+                    params.insert(field.to_string(), serde_json::Value::from(bare.clone()));
+                    break;
+                }
+            }
+        }
+
+        // Lazy initialisation: the session is opened the first time a call
+        // actually routes here, not when the client initialised.
+        if !sessions.contains_key(&up.prefix) {
+            match gateway::call(&url, &gateway::initialize_body(), None).await {
+                Ok(reply) => {
+                    if let Some(s) = reply.session {
+                        sessions.insert(up.prefix.clone(), s);
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        correlation_id = %ctx.trace_id,
+                        upstream = %up.upstream,
+                        error = %e,
+                        "MCP upstream could not be initialised"
+                    );
+                    return gateway::error_response(id, -32603, "upstream is not reachable");
+                }
+            }
+        }
+
+        match gateway::call(
+            &url,
+            &outbound,
+            sessions.get(&up.prefix).map(String::as_str),
+        )
+        .await
+        {
+            Ok(reply) => {
+                if let Some(s) = reply.session {
+                    sessions.insert(up.prefix.clone(), s);
+                }
+                // The upstream answered the id it was given; the client is
+                // owed its own.
+                let mut doc = reply.doc;
+                if let Some(obj) = doc.as_object_mut() {
+                    obj.insert("id".to_string(), id.clone());
+                }
+                doc
+            }
+            Err(e) => {
+                warn!(
+                    correlation_id = %ctx.trace_id,
+                    upstream = %up.upstream,
+                    error = %e,
+                    "MCP upstream did not answer a call"
+                );
+                gateway::error_response(id, -32603, "upstream did not answer")
+            }
+        }
+    }
+
+    /// Resolve a named upstream to a URL for a gateway-originated call.
+    ///
+    /// Goes through the route's `UpstreamPool`, so load balancing, discovery
+    /// and health checking all still apply — a fan-out reaches the same targets
+    /// a proxied request would.
+    async fn mcp_upstream_url(
+        &self,
+        upstream: &str,
+        path: &str,
+        ctx: &RequestContext,
+    ) -> Option<String> {
+        let pool = self.upstream_pools.get(upstream).await?;
+
+        // Selection sees the client, so algorithms that key on it — ip_hash,
+        // sticky sessions — pick the same target a proxied request would rather
+        // than a different one for every fan-out.
+        let selection_ctx = crate::upstream::RequestContext {
+            client_ip: ctx.client_ip.parse().ok(),
+            headers: std::collections::HashMap::new(),
+            path: path.to_string(),
+            method: "POST".to_string(),
+        };
+        let peer = pool.select_peer(Some(&selection_ctx)).await.ok()?;
+        let scheme = if peer.is_tls() { "https" } else { "http" };
+        Some(format!("{scheme}://{}{path}", peer._address))
+    }
+
+    /// Write a JSON-RPC document as the response to this request.
+    async fn write_mcp_reply(
+        &self,
+        session: &mut Session,
+        ctx: &RequestContext,
+        doc: &serde_json::Value,
+        token: Option<&str>,
+    ) -> Result<bool, Box<Error>> {
+        use crate::agentic::gateway::SESSION_HEADER;
+
+        let body = serde_json::to_vec(doc).unwrap_or_else(|_| b"{}".to_vec());
+
+        let mut header = pingora::http::ResponseHeader::build(200, None)?;
+        header.insert_header("Content-Type", "application/json")?;
+        header.insert_header("Content-Length", body.len().to_string())?;
+        header.insert_header("X-Correlation-Id", ctx.trace_id.as_str())?;
+        if let Some(t) = token {
+            header.insert_header(SESSION_HEADER, t)?;
+        }
+
+        session
+            .write_response_header(Box::new(header), false)
+            .await?;
+        session
+            .write_response_body(Some(Bytes::from(body)), true)
+            .await?;
+
+        Ok(true)
+    }
+
     /// Decide whether this response is an MCP listing that must be cut down to
     /// what the route permits, and prepare its headers if so.
     ///


### PR DESCRIPTION
Completes the gateway half of #443 — the last bullet, and the one that was
blocked on design rather than effort. Implements the three decisions agreed
[on the issue](https://github.com/zentinelproxy/zentinel/issues/443#issuecomment-5507823652).

```kdl
mcp {
    upstreams {
        upstream "docs" prefix="docs"
        upstream "warehouse" prefix="warehouse" path="/mcp"
    }
    session-key "…64 hex chars…"
    tools { deny "warehouse.execute_sql" }
}
```

One `tools/list`, two servers, tools namespaced apart; a call goes to the server
its prefix names, with the prefix stripped before the upstream sees it.

## A bug this introduced, and how it was caught

Worth leading with, because it is the most important thing in the diff.

Answering in `request_filter` means the request never reaches
`request_body_filter` — which is where `evaluate_agentic_policy` runs. The first
working version of this therefore **silently disabled every MCP policy on a
multiplexing route**. A tool on the route's deny list returned HTTP 200 and
executed.

I had even written "merge and namespace before filtering" in a module doc as
though it were implemented. It wasn't wired at all. It surfaced only because I
tested the interaction against a real pair of upstreams rather than trusting my
own note.

Both halves are fixed: policy is enforced explicitly on this path, with a
comment saying why it must be, and merged listings are filtered on namespaced
names. **What is advertised is what is enforced** — the property #457
established for one upstream, which must not regress because a second was added.

This is the third instance of the same shape today, after the MCP policy that
was parsed and never called and the health checks that never probed. The lesson
that keeps applying: count what arrives at the other end.

## The three decisions, as built

**Session state travels in the token.** One client session spans several server
sessions, since each upstream issues its own `Mcp-Session-Id`. The gateway's
session ID is an AEAD envelope carrying that mapping — no shared store, nothing
lost on restart, no affinity requirement pushed onto the operator's load
balancer.

- **Encrypted, not signed.** `sticky_session.rs` HMACs a target index because
  leaking one is harmless. Upstream session IDs are not.
- **Key from configuration.** `StickySessionRuntime` generates its key with
  `rand::rng()` at construction, so it rotates on every rebuild. Here that would
  drop live sessions on every config reload. Both `SessionCodec` and
  `Multiplexer` also have hand-written `Debug` impls that redact it — a derive
  would have put key material into any `{:?}` on an enclosing type.

**Lazy initialize.** An upstream session opens the first time a call routes
there. List twenty tools, call one, hold one session.

**Declared prefixes.** Deriving from upstream names was rejected: infrastructure
names read poorly to a model, and renaming an upstream would rename its tools.
Duplicate prefixes and prefixes containing `.` are refused at load.

## Also fixed: JSON-RPC id fidelity

`Envelope` normalises ids to `String` for policy and audit, so a request with
`"id":42` was answered `"id":"42"`. JSON-RPC requires the response id to equal
the request id including its type; strict clients may reject that. The id now
comes from the raw body. Verified across number, string and null.

## Scoped out, deliberately

- **Resources are not namespaced.** Prefixing a URI gives `docs.file:///a.txt`,
  which is not a URI — a mangler, not a namespace. It solves a collision URIs
  rarely have by breaking one they always have.
- **No failover.** A call to a downed upstream fails. But an upstream that
  cannot be reached during `tools/list` has its tools omitted rather than
  failing the whole listing, so one bad server costs its own tools and no
  others. Graceful degradation via `notifications/tools/list_changed` is the
  follow-up, and composes with the health checks from #460.

## The architectural trade, stated plainly

These routes **originate rather than forward**. Merging a listing is composition,
not proxying, so the gateway makes the upstream calls itself — meaning no
Pingora connection pool and no route retry policy for them.

They *do* go through the upstream's `UpstreamPool`, so load balancing, service
discovery and health checking all still apply, and selection sees the client so
`ip_hash` and sticky algorithms pick the same target a proxied request would.

Putting tool calls back on the proxy path, keeping only the listing fan-out
here, needs body-driven peer selection — a larger change, and a good follow-up.

## Verified end to end

Against two real MCP fixtures on separate ports:

| Check | Result |
|---|---|
| `tools/list` merged | 6 tools, incl. `execute_sql` from **both**, distinguishable |
| `tools/call` routed | `warehouse.query` → upstream sees `query` |
| Unknown prefix | refused, not guessed |
| Denied tool listed | hidden (4 advertised, not 6) |
| Denied tool called | refused with a JSON-RPC error naming it |
| Session token | issued and round-tripped |
| `id` fidelity | number, string, null all preserved |

## Checks

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc` — clean
- 94 + 406 + 790 tests pass
- `cargo fmt --all` — touched only this PR's files

40 new unit tests across four modules kept deliberately separable: `session`
(the token), `namespace` (the name mapping), `multiplex` (composition and config
validation), `gateway` (talking MCP upstream). Docs in a companion PR.

https://claude.ai/code/session_01VkHAQ33U78fmpk6r161DKc
