### PR TITLE
fix(agentic): do not serve resources on a multiplexing route

### DIFF
--- a/crates/proxy/src/agentic/multiplex.rs
+++ b/crates/proxy/src/agentic/multiplex.rs
@@ -157,6 +157,25 @@ pub fn merge_listing(into: &mut Vec<Value>, mut entries: Vec<Value>, prefix: &st
     into.append(&mut entries);
 }
 
+/// Whether this method's entries can be merged across upstreams.
+///
+/// Tools and prompts carry bare names, which [`super::namespace`] prefixes so a
+/// call can be routed back to the upstream it came from. **Resources cannot**:
+/// they are identified by URI, and a URI is not namespaced — prefixing one
+/// produces something that is not a URI at all.
+///
+/// Merging them anyway produces a listing that is actively wrong rather than
+/// merely incomplete: two upstreams serving `file:///a.txt` appear as two
+/// entries with the same URI and no way to tell them apart, and reading either
+/// is refused, because the URI carries no prefix to route on. That is the
+/// advertised-surface-disagrees-with-enforced-surface defect this proxy fixed
+/// for tools, arriving by a different door.
+///
+/// So a multiplexing route does not serve resources at all, and says so.
+pub fn can_merge(method: &str) -> bool {
+    !method.starts_with("resources/")
+}
+
 /// Remove from a merged listing the entries a call would be refused.
 ///
 /// The route's allow/deny lists name tools as the client sees them —
@@ -414,6 +433,19 @@ mod tests {
             0
         );
         assert_eq!(merged.len(), 1);
+    }
+
+    /// Tools and prompts namespace cleanly; resources do not, so they are not
+    /// merged rather than being merged into something unusable.
+    #[test]
+    fn resources_are_not_mergeable() {
+        assert!(can_merge("tools/list"));
+        assert!(can_merge("tools/call"));
+        assert!(can_merge("prompts/list"));
+        assert!(can_merge("prompts/get"));
+        assert!(!can_merge("resources/list"));
+        assert!(!can_merge("resources/read"));
+        assert!(!can_merge("resources/templates/list"));
     }
 
     #[test]

--- a/crates/proxy/src/proxy/http_trait.rs
+++ b/crates/proxy/src/proxy/http_trait.rs
@@ -4030,7 +4030,20 @@ impl ZentinelProxy {
 
         let mut sessions = mux.sessions(client_session(session).as_deref());
 
-        let reply = if let Some(field) = listing::listed_field(&method) {
+        // Resources are not served here at all. They are identified by URI,
+        // which carries no upstream prefix, so a merged listing would advertise
+        // duplicate indistinguishable URIs that no subsequent read could be
+        // routed to -- worse than not offering them.
+        let reply = if !crate::agentic::multiplex::can_merge(&method) {
+            crate::agentic::gateway::error_response(
+                &id,
+                -32601,
+                &format!(
+                    "{method} is not available on a route that fronts several MCP servers: \
+                     resources are identified by URI and cannot be attributed to an upstream"
+                ),
+            )
+        } else if let Some(field) = listing::listed_field(&method) {
             let allowed: std::collections::HashSet<String> =
                 mcp.allowed_tools.iter().cloned().collect();
             let denied: std::collections::HashSet<String> =


### PR DESCRIPTION
A bug in #463, found before it ships. Multiplexing is on `main` but not in any
release.

## What it did

A route fronting two MCP servers answered `resources/list` with:

```json
{"name":"docs.readme",      "uri":"file:///public/readme.txt"},
{"name":"warehouse.readme", "uri":"file:///public/readme.txt"}
```

**The same URI twice, from two different servers, with nothing to tell them
apart.** And reading either was refused — with a message about *tools*, because
a URI carries no prefix to route on:

```json
{"error":{"code":-32602,
  "message":"\"file:///public/readme.txt\" does not name a tool on this endpoint"}}
```

So the route advertised resources that could not be read, and duplicated them.

## Why it happened

Tools and prompts carry bare names, which `namespace::qualify_listing` prefixes
so a call routes back to the upstream it came from. Resources are identified by
**URI**, and a URI cannot be namespaced — `docs.file:///a.txt` is not a URI.

The namespacer knew that and deliberately skipped `uri`. The *listing* step did
not, and merged resources anyway. The two halves of one decision disagreed.

This is the same defect as advertising tools a route would refuse a call to,
which #457 fixed — arriving through a different door, in code merged an hour
earlier.

## The fix

`resources/*` is refused on a multiplexing route, with the reason:

```
resources/list is not available on a route that fronts several MCP servers:
resources are identified by URI and cannot be attributed to an upstream
```

**Refused rather than answered with an empty list.** Empty says there are none,
which is false; the error says it is not supported here, which is true. A client
can act on the second.

Single-upstream routes are untouched and serve resources normally.

## How it was found

By exercising a path in my own recent work that the unit tests covered and the
behaviour did not. Every unit test passed; the endpoint was still wrong. The
only thing that caught it was driving real requests at two real upstreams and
reading the output.

## Checks

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- 124 agentic tests pass, including a new one asserting tools and prompts merge
  and resources do not
- Verified end to end: `resources/list` and `resources/read` refused with the
  reason; `tools/list` and `tools/call` unaffected

https://claude.ai/code/session_01VkHAQ33U78fmpk6r161DKc
