### PR TITLE
fix(docker): take the socket directory from runtime-dirs, not the build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,11 @@ RUN cargo build --release --package zentinel-proxy --package zentinel-echo-agent
 # zentinelproxy/zentinel#255.
 ################################################################################
 FROM busybox:1.38 AS runtime-dirs
-RUN mkdir -p /var/log/zentinel /var/lib/zentinel
+# `/var/run/zentinel` is the shared agent-socket directory. 1777 because the
+# proxy and the agents may run as different users, sticky like /tmp so one agent
+# cannot remove another's socket.
+RUN mkdir -p /var/log/zentinel /var/lib/zentinel /var/run/zentinel \
+    && chmod 1777 /var/run/zentinel
 
 ################################################################################
 # Production image: Distroless (smallest, most secure)
@@ -247,7 +251,7 @@ CMD ["-c", "/etc/zentinel/zentinel.kdl"]
 FROM gcr.io/distroless/cc-debian12:nonroot AS echo-agent
 
 COPY --from=builder /app/target/release/zentinel-echo-agent /zentinel-echo-agent
-COPY --chmod=1777 docker/socket-dir /var/run/zentinel
+COPY --from=runtime-dirs --chmod=1777 /var/run/zentinel /var/run/zentinel
 
 # ECHO_AGENT_SOCKET, not SOCKET_PATH: the agent's argument parser reads the
 # former, so the latter was inert and the agent fell back to its hardcoded
@@ -266,7 +270,7 @@ CMD ["/zentinel-echo-agent"]
 FROM gcr.io/distroless/cc-debian12:nonroot AS echo-agent-prebuilt
 
 COPY zentinel-echo-agent /zentinel-echo-agent
-COPY --chmod=1777 docker/socket-dir /var/run/zentinel
+COPY --from=runtime-dirs --chmod=1777 /var/run/zentinel /var/run/zentinel
 
 LABEL org.opencontainers.image.title="Zentinel Echo Agent" \
       org.opencontainers.image.description="Echo agent for Zentinel proxy testing"

--- a/docker/socket-dir/.gitkeep
+++ b/docker/socket-dir/.gitkeep
@@ -1,8 +1,0 @@
-This directory is copied into the agent images as /var/run/zentinel, the
-shared agent-socket directory.
-
-It exists because a Docker named volume mounted at a path the image does not
-contain is created root-owned, and the agents run as `nonroot` — so they could
-not create their socket in it. It is copied from the build context rather than
-produced by a builder stage so that the `*-prebuilt` image targets, which exist
-precisely to avoid compiling, do not gain a dependency on the Rust builder.


### PR DESCRIPTION
**The 26.09_3 release failed at the Docker build. This is my regression from
#464.** Nothing was published — all builds run before any publish step, so
crates.io and the GitHub Release were skipped, and `main` is still consistent
with the published 0.6.39.

## What broke

```
#9 [echo-agent-prebuilt 3/3] COPY --chmod=1777 docker/socket-dir /var/run/zentinel
#9 ERROR: "/docker/socket-dir": not found
```

The `*-prebuilt` targets build with `artifacts/<platform>` as their context —
the downloaded binary plus the config the workflow copies in beside it — not the
repository.

## The mistake, plainly

In #464 I first wrote `COPY --from=builder`, spotted that it would pull a full
Rust compile into every release image, and changed it to copy from the build
context instead. That fixed the symptom I had noticed and reintroduced the same
class of problem: the prebuilt stages have neither the builder **nor** the
repository available.

The workflow passes that context explicitly (`artifacts/linux-amd64`), so it was
visible without running anything. I checked the builder dependency and stopped
looking.

## The fix

The Dockerfile already had the right mechanism, and I did not look for it:
`runtime-dirs`, a busybox stage that exists precisely so the distroless stages
can copy directories in. The prebuilt targets already use it for
`/var/log/zentinel` and `/var/lib/zentinel`.

`/var/run/zentinel` now comes from there too — 1777, sticky, created once and
copied into every image that needs it. Not the builder, not the context, so it
works for built and prebuilt alike.

`docker/socket-dir/` is removed, since nothing references it now.

## Re-release

`26.09_3` is tagged at a commit whose Docker build fails. Once this lands the
tag needs to be moved to include it, or the release cut as `26.09_4`. Since
nothing was published under `26.09_3`, moving the tag is clean — but that is a
judgement call about whether a tag that produced no artifacts should be reused,
and I would rather it were made deliberately than by me assuming.

https://claude.ai/code/session_01VkHAQ33U78fmpk6r161DKc
