### PR TITLE
chore: bump version to 0.6.40 for release 26.09_3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8183,7 +8183,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.39"
+version = "0.6.40"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8224,7 +8224,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.39"
+version = "0.6.40"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8246,7 +8246,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.39"
+version = "0.6.40"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8325,7 +8325,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.39"
+version = "0.6.40"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8506,7 +8506,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.39"
+version = "0.6.40"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8598,7 +8598,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.39"
+version = "0.6.40"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8615,7 +8615,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.39"
+version = "0.6.40"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.39"
+version = "0.6.40"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/config-inspect/Cargo.toml
+++ b/crates/config-inspect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-config-inspect"
-version = "0.6.39"
+version = "0.6.40"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/playground-wasm/Cargo.toml
+++ b/crates/playground-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-playground-wasm"
-version = "0.6.39"
+version = "0.6.40"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/sim/Cargo.toml
+++ b/crates/sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-sim"
-version = "0.6.39"
+version = "0.6.40"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Post-release bump for 26.09_3. The Release workflow force-pushes this branch and
then fails to open the PR for it — eighth consecutive release — so it is opened
by hand as usual.

## Safety check, done not assumed

The orphan branch is dangerous only when `main` has moved past the release
commit, since it is created *from* that commit and merging it would revert
everything since:

```
$ git log --oneline origin/chore/bump-0.6.40..origin/main
(empty)

parent of branch: 83e1d32
main:             83e1d32
```

Identical, so this reverts nothing.

## The Cargo.lock sync held

zentinelproxy/zentinel#445 fixed the auto-bump to sync `Cargo.lock`, and 26.09_2
was the first release to prove it. It has now held for a second:

```
 Cargo.lock                        | 14 +++++++-------
 Cargo.toml                        |  2 +-
 crates/config-inspect/Cargo.toml  |  2 +-
 crates/playground-wasm/Cargo.toml |  2 +-
 crates/sim/Cargo.toml             |  2 +-
```

All seven workspace crates go 0.6.39 → 0.6.40 in the lockfile, no external
dependency moves. **No hand-added `cargo update --workspace` commit needed** —
which was required on every release before 26.09_2. Still worth checking the
diff each time rather than assuming; two releases is not a guarantee.

## Release verification

Against the crates.io API rather than the workflow's own status:

| Crate | Published |
|---|---|
| `zentinel-common` | 0.6.40 |
| `zentinel-config` | 0.6.40 |
| `zentinel-agent-protocol` | 0.6.40 |
| `zentinel-proxy` | 0.6.40 |

GitHub Release `26.09_3` reads `0.6.40` with 15 assets, agreeing with the
CHANGELOG and crates.io.

Note this release took two attempts: the first failed at the Docker build on a
regression of mine (#468) and published nothing, which is the build-before-publish
ordering working as intended. The tag was moved to include the fix rather than a
`26.09_4` being cut, since nothing had shipped under it.

https://claude.ai/code/session_01VkHAQ33U78fmpk6r161DKc
