### PR TITLE
chore: bump version to 0.6.41 for release 26.09_4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8183,7 +8183,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.40"
+version = "0.6.41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8224,7 +8224,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.40"
+version = "0.6.41"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8246,7 +8246,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.40"
+version = "0.6.41"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8325,7 +8325,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.40"
+version = "0.6.41"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8506,7 +8506,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.40"
+version = "0.6.41"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8598,7 +8598,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.40"
+version = "0.6.41"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8615,7 +8615,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.40"
+version = "0.6.41"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.40"
+version = "0.6.41"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/config-inspect/Cargo.toml
+++ b/crates/config-inspect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-config-inspect"
-version = "0.6.40"
+version = "0.6.41"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/playground-wasm/Cargo.toml
+++ b/crates/playground-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-playground-wasm"
-version = "0.6.40"
+version = "0.6.41"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/sim/Cargo.toml
+++ b/crates/sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-sim"
-version = "0.6.40"
+version = "0.6.41"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Post-release bump for 26.09_4. The Release workflow force-pushes this branch and
fails to open the PR for it — **ninth** consecutive release — so it is opened by
hand as usual.

## Safety check, done not assumed

```
$ git log --oneline origin/chore/bump-0.6.41..origin/main
(empty)

parent of branch: 5791d12
main:             5791d12
```

Identical, so merging reverts nothing.

## Cargo.lock synced for a third release

```
 Cargo.lock                        | 14 +++++++-------
 Cargo.toml                        |  2 +-
 crates/config-inspect/Cargo.toml  |  2 +-
 crates/playground-wasm/Cargo.toml |  2 +-
 crates/sim/Cargo.toml             |  2 +-
```

All seven workspace crates 0.6.40 → 0.6.41 in the lockfile, no external
dependency moves. No hand-added `cargo update --workspace` commit needed — that
was required on every release before 26.09_2, and #445's fix has now held three
times running.

## Release verification

Against the crates.io API rather than the workflow's own status:

| Crate | Published |
|---|---|
| `zentinel-common` | 0.6.41 |
| `zentinel-config` | 0.6.41 |
| `zentinel-agent-protocol` | 0.6.41 |
| `zentinel-proxy` | 0.6.41 |

GitHub Release `26.09_4` reads `0.6.41` with 15 assets, agreeing with the
CHANGELOG and crates.io. All four platform builds and the Docker build passed
first time — the latter worth noting, since it is where 26.09_3's first attempt
failed and the `runtime-dirs` fix (#468) has now been exercised in a real
release run.

https://claude.ai/code/session_01VkHAQ33U78fmpk6r161DKc
