### PR TITLE
chore: bump version to 0.6.42 for release 26.09_5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8183,7 +8183,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-agent-protocol"
-version = "0.6.41"
+version = "0.6.42"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8224,7 +8224,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-common"
-version = "0.6.41"
+version = "0.6.42"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8246,7 +8246,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-config"
-version = "0.6.41"
+version = "0.6.42"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8325,7 +8325,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-gateway"
-version = "0.6.41"
+version = "0.6.42"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8506,7 +8506,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-proxy"
-version = "0.6.41"
+version = "0.6.42"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8598,7 +8598,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-stack"
-version = "0.6.41"
+version = "0.6.42"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8615,7 +8615,7 @@ dependencies = [
 
 [[package]]
 name = "zentinel-wasm-runtime"
-version = "0.6.41"
+version = "0.6.42"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.41"
+version = "0.6.42"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/config-inspect/Cargo.toml
+++ b/crates/config-inspect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-config-inspect"
-version = "0.6.41"
+version = "0.6.42"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/playground-wasm/Cargo.toml
+++ b/crates/playground-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-playground-wasm"
-version = "0.6.41"
+version = "0.6.42"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/sim/Cargo.toml
+++ b/crates/sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zentinel-sim"
-version = "0.6.41"
+version = "0.6.42"
 edition = "2021"
 authors = ["Zentinel Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Post-release bump for 26.09_5. The Release workflow force-pushes this branch and
fails to open the PR for it — **tenth** consecutive release — so it is opened by
hand.

## Safety check, done not assumed

```
$ git log --oneline origin/chore/bump-0.6.42..origin/main
(empty)

parent of branch: 8a01a5e
main:             8a01a5e
```

Identical, so merging reverts nothing.

## Cargo.lock synced for a fourth release

All seven workspace crates 0.6.41 → 0.6.42 in the lockfile, no external
dependency moves. No hand-added `cargo update --workspace` commit needed —
#445's fix has now held four times running, where every release before 26.09_2
required one.

## Release verification

Against the crates.io API rather than the workflow's own status:

| Crate | Published |
|---|---|
| `zentinel-common` | 0.6.42 |
| `zentinel-config` | 0.6.42 |
| `zentinel-agent-protocol` | 0.6.42 |
| `zentinel-proxy` | 0.6.42 |

GitHub Release `26.09_5` reads `0.6.42` with 15 assets, agreeing with the
CHANGELOG and crates.io. All four platform builds and the Docker build passed
first time.

With this merged, `zentinel bundle install` works for a non-root user for the
first time, and
[registry.zentinelproxy.io#3](https://github.com/zentinelproxy/registry.zentinelproxy.io/issues/3)
can be closed against a version its reporter can actually install.

https://claude.ai/code/session_01VkHAQ33U78fmpk6r161DKc
